### PR TITLE
feat: HTTP client with auth and error handling

### DIFF
--- a/src/kanbantool_mcp/client.py
+++ b/src/kanbantool_mcp/client.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+import json
+import re
 from typing import Any
 
 import httpx
@@ -16,6 +18,16 @@ from .exceptions import (
 
 _BODY_EXCERPT_LIMIT = 200
 _RETRY_BACKOFF_SECONDS = 0.5
+
+_BEARER_PATTERN = re.compile(r"(?i)\bbearer\s+\S+")
+
+
+def _scrub_secrets(text: str) -> str:
+    """Replace any 'Bearer <token>' sequence with 'Bearer ***' before storing
+    or surfacing user-visible response excerpts. Single-pattern scrub —
+    Kanban Tool API uses bearer auth exclusively, so this covers the realistic
+    leak path (upstream proxy/WAF echoing the Authorization header)."""
+    return _BEARER_PATTERN.sub("Bearer ***", text)
 
 
 class KanbanToolClient:
@@ -39,13 +51,18 @@ class KanbanToolClient:
         await self._http.aclose()
 
     async def request(self, method: str, path: str, **kwargs: Any) -> dict[str, Any]:
+        """Send an HTTP request to the Kanban Tool API and return the parsed JSON response.
+
+        Pass query parameters via the `params=` keyword, not embedded in `path` —
+        the `.json` suffix logic doesn't account for query strings. Authorization
+        is set client-wide; do not override it via `headers=`."""
         normalized = path.lstrip("/")
         if not normalized.endswith(".json"):
             normalized = f"{normalized}.json"
 
         try:
             response = await self._http.request(method, normalized, **kwargs)
-        except httpx.TransportError as first_error:
+        except httpx.TransportError:
             await asyncio.sleep(_RETRY_BACKOFF_SECONDS)
             try:
                 response = await self._http.request(method, normalized, **kwargs)
@@ -53,7 +70,6 @@ class KanbanToolClient:
                 raise KanbanToolTransportError(
                     f"Transport error contacting Kanban Tool API: {second_error}"
                 ) from second_error
-            del first_error
 
         status = response.status_code
         if status == 401:
@@ -67,11 +83,18 @@ class KanbanToolClient:
                 "The token does not have permission for this resource."
             )
         if status >= 400:
-            body_excerpt = response.text[:_BODY_EXCERPT_LIMIT]
+            body_excerpt = _scrub_secrets(response.text)[:_BODY_EXCERPT_LIMIT]
             raise KanbanToolHTTPError(
                 f"Kanban Tool API returned HTTP {status} for {method} {normalized}",
                 status_code=status,
                 body_excerpt=body_excerpt,
             )
 
-        return response.json()
+        try:
+            return response.json()
+        except json.JSONDecodeError:
+            raise KanbanToolHTTPError(
+                f"Kanban Tool API returned non-JSON body for {method} {normalized}",
+                status_code=status,
+                body_excerpt=_scrub_secrets(response.text)[:_BODY_EXCERPT_LIMIT],
+            ) from None

--- a/src/kanbantool_mcp/client.py
+++ b/src/kanbantool_mcp/client.py
@@ -1,10 +1,21 @@
-"""HTTP client skeleton for the Kanban Tool API v3."""
+"""HTTP client for the Kanban Tool API v3."""
 
 from __future__ import annotations
+
+import asyncio
+from typing import Any
 
 import httpx
 
 from .config import Config
+from .exceptions import (
+    KanbanToolHTTPError,
+    KanbanToolPermissionError,
+    KanbanToolTransportError,
+)
+
+_BODY_EXCERPT_LIMIT = 200
+_RETRY_BACKOFF_SECONDS = 0.5
 
 
 class KanbanToolClient:
@@ -26,3 +37,41 @@ class KanbanToolClient:
 
     async def aclose(self) -> None:
         await self._http.aclose()
+
+    async def request(self, method: str, path: str, **kwargs: Any) -> dict[str, Any]:
+        normalized = path.lstrip("/")
+        if not normalized.endswith(".json"):
+            normalized = f"{normalized}.json"
+
+        try:
+            response = await self._http.request(method, normalized, **kwargs)
+        except httpx.TransportError as first_error:
+            await asyncio.sleep(_RETRY_BACKOFF_SECONDS)
+            try:
+                response = await self._http.request(method, normalized, **kwargs)
+            except httpx.TransportError as second_error:
+                raise KanbanToolTransportError(
+                    f"Transport error contacting Kanban Tool API: {second_error}"
+                ) from second_error
+            del first_error
+
+        status = response.status_code
+        if status == 401:
+            raise KanbanToolPermissionError(
+                "Kanban Tool API rejected the request as unauthorized (401). "
+                "Check that the KANBANTOOL_API_TOKEN env var is set to a valid token."
+            )
+        if status == 403:
+            raise KanbanToolPermissionError(
+                "Kanban Tool API denied the request as forbidden (403). "
+                "The token does not have permission for this resource."
+            )
+        if status >= 400:
+            body_excerpt = response.text[:_BODY_EXCERPT_LIMIT]
+            raise KanbanToolHTTPError(
+                f"Kanban Tool API returned HTTP {status} for {method} {normalized}",
+                status_code=status,
+                body_excerpt=body_excerpt,
+            )
+
+        return response.json()

--- a/src/kanbantool_mcp/config.py
+++ b/src/kanbantool_mcp/config.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 
 @dataclass(frozen=True)
 class Config:
     domain: str
-    api_token: str
+    api_token: str = field(repr=False)
 
     @property
     def base_url(self) -> str:

--- a/src/kanbantool_mcp/exceptions.py
+++ b/src/kanbantool_mcp/exceptions.py
@@ -1,0 +1,24 @@
+"""Exception hierarchy for the Kanban Tool client."""
+
+from __future__ import annotations
+
+
+class KanbanToolError(Exception):
+    """Base class for all Kanban Tool client errors."""
+
+
+class KanbanToolPermissionError(KanbanToolError):
+    """Raised on 401/403 responses from the Kanban Tool API."""
+
+
+class KanbanToolHTTPError(KanbanToolError):
+    """Raised on non-2xx responses other than 401/403."""
+
+    def __init__(self, message: str, *, status_code: int, body_excerpt: str) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.body_excerpt = body_excerpt
+
+
+class KanbanToolTransportError(KanbanToolError):
+    """Raised when the underlying httpx transport fails after a retry."""

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -125,3 +125,34 @@ async def test_json_suffix_not_double_appended(client: KanbanToolClient) -> None
 def test_config_repr_does_not_leak_token() -> None:
     cfg = Config.from_env()
     assert "test-token" not in repr(cfg)
+
+
+async def test_non_json_2xx_raises_http_error(client: KanbanToolClient) -> None:
+    with respx.mock() as router:
+        router.get(f"{BASE_URL}users/current.json").mock(
+            return_value=httpx.Response(200, text="<html>oops</html>")
+        )
+        with pytest.raises(KanbanToolHTTPError) as exc_info:
+            await client.request("GET", "users/current")
+        assert exc_info.value.status_code == 200
+        assert "<html>" in exc_info.value.body_excerpt
+
+
+async def test_500_body_scrubs_bearer_token(client: KanbanToolClient) -> None:
+    with respx.mock() as router:
+        router.get(f"{BASE_URL}boards/1.json").mock(
+            return_value=httpx.Response(500, text="Authorization: Bearer leaked-token-secret-xyz")
+        )
+        with pytest.raises(KanbanToolHTTPError) as exc_info:
+            await client.request("GET", "boards/1")
+        assert "leaked-token-secret-xyz" not in exc_info.value.body_excerpt
+        assert "Bearer ***" in exc_info.value.body_excerpt
+
+
+async def test_404_with_empty_body(client: KanbanToolClient) -> None:
+    with respx.mock() as router:
+        router.get(f"{BASE_URL}boards/999.json").mock(return_value=httpx.Response(404, text=""))
+        with pytest.raises(KanbanToolHTTPError) as exc_info:
+            await client.request("GET", "boards/999")
+        assert exc_info.value.status_code == 404
+        assert exc_info.value.body_excerpt == ""

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,127 @@
+"""Tests for the Kanban Tool HTTP client."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import httpx
+import pytest
+import respx
+
+from kanbantool_mcp.client import KanbanToolClient
+from kanbantool_mcp.config import Config
+from kanbantool_mcp.exceptions import (
+    KanbanToolHTTPError,
+    KanbanToolPermissionError,
+    KanbanToolTransportError,
+)
+
+BASE_URL = "https://testacct.kanbantool.com/api/v3/"
+
+
+@pytest.fixture
+def config() -> Config:
+    return Config.from_env()
+
+
+@pytest.fixture
+async def client(config: Config) -> AsyncIterator[KanbanToolClient]:
+    c = KanbanToolClient(config)
+    try:
+        yield c
+    finally:
+        await c.aclose()
+
+
+async def test_get_returns_parsed_dict(client: KanbanToolClient) -> None:
+    with respx.mock(assert_all_called=True) as router:
+        router.get(f"{BASE_URL}users/current.json").mock(
+            return_value=httpx.Response(200, json={"id": 1, "email": "a@b.c"})
+        )
+        result = await client.request("GET", "users/current")
+        assert result == {"id": 1, "email": "a@b.c"}
+
+
+async def test_401_raises_permission_error_mentions_env_var(client: KanbanToolClient) -> None:
+    with respx.mock() as router:
+        router.get(f"{BASE_URL}users/current.json").mock(
+            return_value=httpx.Response(401, text="unauthorized")
+        )
+        with pytest.raises(KanbanToolPermissionError) as exc_info:
+            await client.request("GET", "users/current")
+        assert "KANBANTOOL_API_TOKEN" in str(exc_info.value)
+        assert "test-token" not in str(exc_info.value)
+
+
+async def test_403_raises_permission_error(client: KanbanToolClient) -> None:
+    with respx.mock() as router:
+        router.get(f"{BASE_URL}boards/1.json").mock(
+            return_value=httpx.Response(403, text="forbidden")
+        )
+        with pytest.raises(KanbanToolPermissionError):
+            await client.request("GET", "boards/1")
+
+
+async def test_404_raises_http_error_with_body(client: KanbanToolClient) -> None:
+    with respx.mock() as router:
+        router.get(f"{BASE_URL}boards/999.json").mock(
+            return_value=httpx.Response(404, text="not found body")
+        )
+        with pytest.raises(KanbanToolHTTPError) as exc_info:
+            await client.request("GET", "boards/999")
+        assert exc_info.value.status_code == 404
+        assert exc_info.value.body_excerpt
+        assert "not found" in exc_info.value.body_excerpt
+
+
+async def test_500_raises_http_error(client: KanbanToolClient) -> None:
+    with respx.mock() as router:
+        router.get(f"{BASE_URL}boards/1.json").mock(return_value=httpx.Response(500, text="boom"))
+        with pytest.raises(KanbanToolHTTPError) as exc_info:
+            await client.request("GET", "boards/1")
+        assert exc_info.value.status_code == 500
+
+
+async def test_transport_error_then_success_retries(client: KanbanToolClient) -> None:
+    with respx.mock() as router:
+        router.get(f"{BASE_URL}users/current.json").mock(
+            side_effect=[
+                httpx.ConnectError("boom"),
+                httpx.Response(200, json={"ok": True}),
+            ]
+        )
+        result = await client.request("GET", "users/current")
+        assert result == {"ok": True}
+
+
+async def test_transport_error_twice_raises(client: KanbanToolClient) -> None:
+    with respx.mock() as router:
+        router.get(f"{BASE_URL}users/current.json").mock(
+            side_effect=[httpx.ConnectError("boom1"), httpx.ConnectError("boom2")]
+        )
+        with pytest.raises(KanbanToolTransportError) as exc_info:
+            await client.request("GET", "users/current")
+        assert isinstance(exc_info.value.__cause__, httpx.TransportError)
+
+
+async def test_json_suffix_auto_appended(client: KanbanToolClient) -> None:
+    with respx.mock(assert_all_called=True) as router:
+        route = router.get(f"{BASE_URL}users/current.json").mock(
+            return_value=httpx.Response(200, json={"ok": True})
+        )
+        await client.request("GET", "users/current")
+        assert route.called
+
+
+async def test_json_suffix_not_double_appended(client: KanbanToolClient) -> None:
+    with respx.mock(assert_all_called=True) as router:
+        route = router.get(f"{BASE_URL}users/current.json").mock(
+            return_value=httpx.Response(200, json={"ok": True})
+        )
+        await client.request("GET", "users/current.json")
+        assert route.called
+
+
+def test_config_repr_does_not_leak_token() -> None:
+    cfg = Config.from_env()
+    assert "test-token" not in repr(cfg)


### PR DESCRIPTION
## Summary
- Adds a typed exception hierarchy (`KanbanToolError`, `KanbanToolPermissionError`, `KanbanToolHTTPError`, `KanbanToolTransportError`) under `src/kanbantool_mcp/exceptions.py`.
- Extends `KanbanToolClient` with an async `request(method, path, **kwargs) -> dict` helper: auto-appends `.json`, maps 401/403 to a permission error (mentioning `KANBANTOOL_API_TOKEN`), maps other 4xx/5xx to an HTTP error with `status_code` + truncated `body_excerpt` (no headers, no token leak), and retries `httpx.TransportError` once with a 0.5s backoff before wrapping in `KanbanToolTransportError`.
- Hides `api_token` from `Config` `repr()` via `dataclasses.field(repr=False)` so logs/tracebacks won't leak the bearer token.

## Test plan
- [x] `uv run pytest` (14 tests, 10 new in `tests/test_client.py`)
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run ty check`
- [x] Verified `repr(Config.from_env())` does not contain the token

Closes #2
Closes #23

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>