### PR TITLE
feat: list_boards MCP tool

### DIFF
--- a/src/kanbantool_mcp/models.py
+++ b/src/kanbantool_mcp/models.py
@@ -2,9 +2,16 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 
 class Board(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
     id: int
     name: str
+    description: str | None = None
+    slug: str | None = None
+    use_swimlanes: bool | None = None
+    is_archived: bool | None = None
+    user_role: str | None = None

--- a/src/kanbantool_mcp/server.py
+++ b/src/kanbantool_mcp/server.py
@@ -4,13 +4,37 @@ from __future__ import annotations
 
 from fastmcp import FastMCP
 
+from .client import KanbanToolClient
+from .config import Config
+from .models import Board
+
 mcp: FastMCP = FastMCP("kanbantool-mcp")
+
+# Module-level singleton. The stdio MCP runs in a single asyncio loop on a
+# single thread, so no lock is needed around lazy init.
+_client: KanbanToolClient | None = None
+
+
+def _get_client() -> KanbanToolClient:
+    global _client
+    if _client is None:
+        _client = KanbanToolClient(Config.from_env())
+    return _client
 
 
 @mcp.tool
 def ping() -> str:
     """Return ``pong``. Useful as a smoke test for the MCP transport."""
     return "pong"
+
+
+@mcp.tool
+async def list_boards() -> list[Board]:
+    """List boards visible to the authenticated user."""
+    data = await _get_client().request("GET", "users/current")
+    raw = data.get("boards", []) if isinstance(data, dict) else []
+    # M3: consider wrapping ValidationError as KanbanToolHTTPError("malformed boards payload").
+    return [Board.model_validate(b) for b in raw]
 
 
 def run() -> None:

--- a/tests/test_list_boards.py
+++ b/tests/test_list_boards.py
@@ -1,0 +1,110 @@
+"""Tests for the list_boards MCP tool."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import httpx
+import pytest
+import respx
+
+from kanbantool_mcp import server
+from kanbantool_mcp.client import KanbanToolClient
+from kanbantool_mcp.config import Config
+from kanbantool_mcp.exceptions import KanbanToolHTTPError, KanbanToolPermissionError
+from kanbantool_mcp.server import list_boards
+
+BASE_URL = "https://testacct.kanbantool.com/api/v3/"
+USERS_CURRENT_URL = f"{BASE_URL}users/current.json"
+
+
+@pytest.fixture
+def config() -> Config:
+    return Config.from_env()
+
+
+@pytest.fixture
+async def client(config: Config) -> AsyncIterator[KanbanToolClient]:
+    c = KanbanToolClient(config)
+    try:
+        yield c
+    finally:
+        await c.aclose()
+
+
+@pytest.fixture
+def _inject_client(monkeypatch: pytest.MonkeyPatch, client: KanbanToolClient) -> KanbanToolClient:
+    monkeypatch.setattr(server, "_client", client)
+    return client
+
+
+async def test_list_boards_happy_path(_inject_client: KanbanToolClient) -> None:
+    payload = {
+        "boards": [
+            {
+                "id": 1,
+                "name": "Engineering",
+                "description": "Eng work",
+                "slug": "engineering",
+                "use_swimlanes": True,
+                "is_archived": False,
+                "user_role": "admin",
+                "extra_unknown_field": "ignored",
+            },
+            {"id": 2, "name": "Marketing"},
+        ]
+    }
+    with respx.mock(assert_all_called=True) as router:
+        router.get(USERS_CURRENT_URL).mock(return_value=httpx.Response(200, json=payload))
+        result = await list_boards()
+
+    assert len(result) == 2
+    first, second = result
+    assert first.id == 1
+    assert first.name == "Engineering"
+    assert first.description == "Eng work"
+    assert first.slug == "engineering"
+    assert first.use_swimlanes is True
+    assert first.is_archived is False
+    assert first.user_role == "admin"
+
+    assert second.id == 2
+    assert second.name == "Marketing"
+    assert second.description is None
+    assert second.slug is None
+    assert second.use_swimlanes is None
+    assert second.is_archived is None
+    assert second.user_role is None
+
+
+async def test_list_boards_empty(_inject_client: KanbanToolClient) -> None:
+    with respx.mock(assert_all_called=True) as router:
+        router.get(USERS_CURRENT_URL).mock(return_value=httpx.Response(200, json={"boards": []}))
+        result = await list_boards()
+
+    assert result == []
+
+
+async def test_list_boards_missing_key(_inject_client: KanbanToolClient) -> None:
+    with respx.mock(assert_all_called=True) as router:
+        router.get(USERS_CURRENT_URL).mock(
+            return_value=httpx.Response(200, json={"id": 7, "email": "a@b.c"})
+        )
+        result = await list_boards()
+
+    assert result == []
+
+
+async def test_list_boards_propagates_permission_error(_inject_client: KanbanToolClient) -> None:
+    with respx.mock() as router:
+        router.get(USERS_CURRENT_URL).mock(return_value=httpx.Response(401, text="unauthorized"))
+        with pytest.raises(KanbanToolPermissionError):
+            await list_boards()
+
+
+async def test_list_boards_propagates_http_error(_inject_client: KanbanToolClient) -> None:
+    with respx.mock() as router:
+        router.get(USERS_CURRENT_URL).mock(return_value=httpx.Response(500, text="boom"))
+        with pytest.raises(KanbanToolHTTPError) as exc_info:
+            await list_boards()
+        assert exc_info.value.status_code == 500


### PR DESCRIPTION
## Summary

- Add `list_boards` MCP tool that calls `GET /users/current.json` and returns the embedded `boards[]` (Kanban Tool API has no global boards endpoint).
- Extend `Board` model with `description`, `slug`, `use_swimlanes`, `is_archived`, `user_role`; `ConfigDict(extra="ignore")` keeps unknown API fields from breaking validation.
- Lazy `_get_client()` module singleton in `server.py`; stdio MCP runs on a single event loop, so no lock is needed.

## Test plan

- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run ty check`
- [x] `uv run pytest` (22 passed; 5 new respx cases for `list_boards`)
- [x] Happy path returns two `Board`s, full + minimal
- [x] Empty `boards: []` returns `[]`
- [x] Missing `boards` key returns `[]` (defensive)
- [x] 401 propagates `KanbanToolPermissionError`
- [x] 500 propagates `KanbanToolHTTPError`

Closes #3

Generated with [Claude Code](https://claude.com/claude-code)