### PR TITLE
feat: implement get_board MCP tool

### DIFF
--- a/src/kanbantool_mcp/models.py
+++ b/src/kanbantool_mcp/models.py
@@ -2,11 +2,47 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class Column(BaseModel):
+    """A workflow stage on a board (the API calls these ``workflow_stages``)."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    id: int
+    name: str
+    position: int | None = None
+    parent_id: int | None = None
+    wip_limit: int | None = None
+    # ``type`` shadows a Python builtin; accept the raw API key via alias.
+    type_: str | None = Field(default=None, alias="type")
+
+
+class Swimlane(BaseModel):
+    """A horizontal lane on a board."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    id: int
+    name: str
+    position: int | None = None
+
+
+class CustomField(BaseModel):
+    """A custom field definition from the board's card template."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    label: str | None = None
+    position: int | None = None
+    options: str | None = None
+    # ``type`` shadows a Python builtin; accept the raw API key via alias.
+    type_: str | None = Field(default=None, alias="type")
 
 
 class Board(BaseModel):
-    model_config = ConfigDict(extra="ignore")
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
 
     id: int
     name: str
@@ -15,3 +51,7 @@ class Board(BaseModel):
     use_swimlanes: bool | None = None
     is_archived: bool | None = None
     user_role: str | None = None
+    # Detail-only collections; absent from list_boards' compact payload, hence defaults.
+    columns: list[Column] = Field(default_factory=list, alias="workflow_stages")
+    swimlanes: list[Swimlane] = Field(default_factory=list)
+    custom_fields: list[CustomField] = Field(default_factory=list, alias="card_template")

--- a/src/kanbantool_mcp/server.py
+++ b/src/kanbantool_mcp/server.py
@@ -37,5 +37,13 @@ async def list_boards() -> list[Board]:
     return [Board.model_validate(b) for b in raw]
 
 
+@mcp.tool
+async def get_board(board_id: int) -> Board:
+    """Fetch a board with its columns, swimlanes, and custom-field definitions."""
+    data = await _get_client().request("GET", f"boards/{board_id}")
+    # M3: consider wrapping ValidationError as KanbanToolHTTPError("malformed board payload").
+    return Board.model_validate(data)
+
+
 def run() -> None:
     mcp.run()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,10 +2,38 @@
 
 from __future__ import annotations
 
+from collections.abc import AsyncIterator
+
 import pytest
+
+from kanbantool_mcp import server
+from kanbantool_mcp.client import KanbanToolClient
+from kanbantool_mcp.config import Config
+
+BASE_URL = "https://testacct.kanbantool.com/api/v3/"
 
 
 @pytest.fixture(autouse=True)
 def _kanbantool_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("KANBANTOOL_DOMAIN", "testacct")
     monkeypatch.setenv("KANBANTOOL_API_TOKEN", "test-token")
+
+
+@pytest.fixture
+def config() -> Config:
+    return Config.from_env()
+
+
+@pytest.fixture
+async def client(config: Config) -> AsyncIterator[KanbanToolClient]:
+    c = KanbanToolClient(config)
+    try:
+        yield c
+    finally:
+        await c.aclose()
+
+
+@pytest.fixture
+def _inject_client(monkeypatch: pytest.MonkeyPatch, client: KanbanToolClient) -> KanbanToolClient:
+    monkeypatch.setattr(server, "_client", client)
+    return client

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator
-
 import httpx
 import pytest
 import respx
@@ -16,21 +14,7 @@ from kanbantool_mcp.exceptions import (
     KanbanToolTransportError,
 )
 
-BASE_URL = "https://testacct.kanbantool.com/api/v3/"
-
-
-@pytest.fixture
-def config() -> Config:
-    return Config.from_env()
-
-
-@pytest.fixture
-async def client(config: Config) -> AsyncIterator[KanbanToolClient]:
-    c = KanbanToolClient(config)
-    try:
-        yield c
-    finally:
-        await c.aclose()
+from .conftest import BASE_URL
 
 
 async def test_get_returns_parsed_dict(client: KanbanToolClient) -> None:

--- a/tests/test_get_board.py
+++ b/tests/test_get_board.py
@@ -1,0 +1,127 @@
+"""Tests for the get_board MCP tool."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+
+from kanbantool_mcp.client import KanbanToolClient
+from kanbantool_mcp.exceptions import KanbanToolHTTPError
+from kanbantool_mcp.server import get_board
+
+from .conftest import BASE_URL
+
+
+def _board_url(board_id: int) -> str:
+    return f"{BASE_URL}boards/{board_id}.json"
+
+
+async def test_get_board_happy_path(_inject_client: KanbanToolClient) -> None:
+    payload = {
+        "id": 42,
+        "name": "Engineering",
+        "description": "Eng board",
+        "slug": "engineering",
+        "use_swimlanes": True,
+        "is_archived": False,
+        "user_role": "admin",
+        "extra_unknown_field": "ignored",
+        "workflow_stages": [
+            {
+                "id": 100,
+                "name": "Backlog",
+                "position": 1,
+                "parent_id": None,
+                "wip_limit": None,
+                "type": "queue",
+                "extra_stage_field": "ignored",
+            },
+            {
+                "id": 101,
+                "name": "In Progress",
+                "position": 2,
+                "wip_limit": 5,
+                "type": "in-progress",
+            },
+        ],
+        "swimlanes": [
+            {"id": 200, "name": "Default", "position": 1, "extra_lane_field": "ignored"},
+            {"id": 201, "name": "Expedite", "position": 2},
+        ],
+        "card_template": [
+            {
+                "label": "Story Points",
+                "type": "number",
+                "position": 1,
+                "extra_field_meta": "ignored",
+            },
+            {
+                "label": "Owner",
+                "type": "user",
+                "position": 2,
+            },
+        ],
+    }
+    with respx.mock(assert_all_called=True) as router:
+        router.get(_board_url(42)).mock(return_value=httpx.Response(200, json=payload))
+        board = await get_board(42)
+
+    assert board.id == 42
+    assert board.name == "Engineering"
+    assert board.description == "Eng board"
+    assert board.slug == "engineering"
+    assert board.use_swimlanes is True
+    assert board.is_archived is False
+    assert board.user_role == "admin"
+
+    assert len(board.columns) == 2
+    backlog, in_progress = board.columns
+    assert backlog.id == 100
+    assert backlog.name == "Backlog"
+    assert backlog.position == 1
+    assert backlog.parent_id is None
+    assert backlog.wip_limit is None
+    assert backlog.type_ == "queue"
+    assert in_progress.wip_limit == 5
+    assert in_progress.type_ == "in-progress"
+
+    assert len(board.swimlanes) == 2
+    default_lane, expedite_lane = board.swimlanes
+    assert default_lane.id == 200
+    assert default_lane.name == "Default"
+    assert default_lane.position == 1
+    assert expedite_lane.name == "Expedite"
+
+    assert len(board.custom_fields) == 2
+    story_points, owner = board.custom_fields
+    assert story_points.label == "Story Points"
+    assert story_points.type_ == "number"
+    assert story_points.position == 1
+    assert owner.label == "Owner"
+    assert owner.type_ == "user"
+
+
+async def test_get_board_minimal_payload_defaults_collections(
+    _inject_client: KanbanToolClient,
+) -> None:
+    with respx.mock(assert_all_called=True) as router:
+        router.get(_board_url(7)).mock(
+            return_value=httpx.Response(200, json={"id": 7, "name": "Tiny"})
+        )
+        board = await get_board(7)
+
+    assert board.id == 7
+    assert board.name == "Tiny"
+    assert board.columns == []
+    assert board.swimlanes == []
+    assert board.custom_fields == []
+
+
+async def test_get_board_404_raises_http_error(_inject_client: KanbanToolClient) -> None:
+    with respx.mock() as router:
+        router.get(_board_url(999)).mock(return_value=httpx.Response(404, text="not found"))
+        with pytest.raises(KanbanToolHTTPError) as exc_info:
+            await get_board(999)
+        assert exc_info.value.status_code == 404
+        assert "not found" in exc_info.value.body_excerpt

--- a/tests/test_list_boards.py
+++ b/tests/test_list_boards.py
@@ -2,40 +2,17 @@
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator
-
 import httpx
 import pytest
 import respx
 
-from kanbantool_mcp import server
 from kanbantool_mcp.client import KanbanToolClient
-from kanbantool_mcp.config import Config
 from kanbantool_mcp.exceptions import KanbanToolHTTPError, KanbanToolPermissionError
 from kanbantool_mcp.server import list_boards
 
-BASE_URL = "https://testacct.kanbantool.com/api/v3/"
+from .conftest import BASE_URL
+
 USERS_CURRENT_URL = f"{BASE_URL}users/current.json"
-
-
-@pytest.fixture
-def config() -> Config:
-    return Config.from_env()
-
-
-@pytest.fixture
-async def client(config: Config) -> AsyncIterator[KanbanToolClient]:
-    c = KanbanToolClient(config)
-    try:
-        yield c
-    finally:
-        await c.aclose()
-
-
-@pytest.fixture
-def _inject_client(monkeypatch: pytest.MonkeyPatch, client: KanbanToolClient) -> KanbanToolClient:
-    monkeypatch.setattr(server, "_client", client)
-    return client
 
 
 async def test_list_boards_happy_path(_inject_client: KanbanToolClient) -> None:
@@ -75,6 +52,11 @@ async def test_list_boards_happy_path(_inject_client: KanbanToolClient) -> None:
     assert second.use_swimlanes is None
     assert second.is_archived is None
     assert second.user_role is None
+
+    # The compact /users/current payload omits detail-only collections.
+    assert first.columns == []
+    assert first.swimlanes == []
+    assert first.custom_fields == []
 
 
 async def test_list_boards_empty(_inject_client: KanbanToolClient) -> None:


### PR DESCRIPTION
## Summary

- Adds the `get_board` MCP tool (GET `/boards/{id}.json`), Closes #4.
- Extends the existing `Board` model with optional `columns`, `swimlanes`, and `custom_fields` collections so the same model serves both `list_boards` (compact `/users/current` payload) and `get_board` (detail payload). New `Column`, `Swimlane`, and `CustomField` models use `extra="ignore"`; `type` is exposed as `type_` via `Field(alias="type")` to avoid shadowing the builtin. Detail collections are aliased to their on-the-wire keys (`workflow_stages`, `card_template`).
- Promotes `BASE_URL`, `config`, `client`, and `_inject_client` to `tests/conftest.py` and removes the duplicates from `test_client.py` / `test_list_boards.py`.

## Test plan

- [x] `uv run ruff format --check .`
- [x] `uv run ruff check .`
- [x] `uv run ty check`
- [x] `uv run pytest` (25 passed)
- [x] Happy path with nested unknown fields (verifies `extra="ignore"` cascades through `Column`, `Swimlane`, `CustomField`)
- [x] Minimal payload (id + name only) defaults all three collections to `[]`
- [x] 404 response raises `KanbanToolHTTPError` with status code and body excerpt

🤖 Generated with [Claude Code](https://claude.com/claude-code)