### PR TITLE
chore: strengthen .gitignore against accidental secret commits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,18 @@ uv.lock
 .vscode/
 .idea/
 .DS_Store
+
+# secrets
+# Defense-in-depth: never commit credentials. Project rule is to keep
+# secrets out of the tree entirely; these patterns just stop the obvious
+# mistakes (stray .env, copied SSH key, exported credentials.json, ...).
+.env
+.env.*
+*.pem
+*.key
+id_rsa
+id_ed25519
+id_ecdsa
+*.kdbx
+credentials.json
+secrets.json


### PR DESCRIPTION
## Summary

- Adds a `# secrets` group to `.gitignore` covering common offenders: dotenv files, TLS / generic private keys, SSH private keys by conventional name, KeePass DBs, and common credential dumps.
- Defense-in-depth for the project's never-commit-secrets rule. Developer discipline + review remain the primary lines; this just stops the obvious mistakes from being staged in the first place.
- `*.pub` is deliberately **not** ignored — public keys are safe to commit.

Closes #31

## Test plan

- [x] Diff is `.gitignore`-only (`git diff --cached` verified pre-push)
- [ ] CI green (lint, format, type-check, tests) — gitignore-only change, expected to pass
- [ ] Spot-check: `touch .env foo.pem id_rsa credentials.json && git status` shows them as untracked-and-ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)