### PR TITLE
chore: add SECURITY.md and refresh README for public launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ An MCP server that bridges Claude Code with the [Kanban Tool API v3](https://kan
 
 ## Install
 
-> The `uvx`-based install below will work once the package is published to PyPI ([#19](https://github.com/VeryLongNicknameSuchWow/kanbantool-mcp/issues/19)). Until then, run from a local checkout — see [Development](#development).
+> The `uvx`-based install below will work once the package is published to PyPI ([#19](https://github.com/VeryLongOrgNameSuchWow/kanbantool-mcp/issues/19)). Until then, run from a local checkout — see [Development](#development).
 
 Add to your `mcp.json`:
 
@@ -34,7 +34,7 @@ Implemented today:
 - `list_boards` — list boards visible to the authenticated user.
 - `get_board` — fetch a single board (workflow stages, swimlanes, metadata) by ID.
 
-More read tools (`search_tasks`, `get_task`, `recent_changes`, `list_subtasks`) and the M2 write tools are tracked on the issue board. README polish is tracked in [#16](https://github.com/VeryLongNicknameSuchWow/kanbantool-mcp/issues/16).
+More read tools (`search_tasks`, `get_task`, `recent_changes`, `list_subtasks`) and the M2 write tools are tracked on the issue board. README polish is tracked in [#16](https://github.com/VeryLongOrgNameSuchWow/kanbantool-mcp/issues/16).
 
 ## Security
 
@@ -43,7 +43,7 @@ See [SECURITY.md](SECURITY.md) for how to report vulnerabilities.
 ## Development
 
 ```sh
-git clone https://github.com/VeryLongNicknameSuchWow/kanbantool-mcp.git
+git clone https://github.com/VeryLongOrgNameSuchWow/kanbantool-mcp.git
 cd kanbantool-mcp
 uv sync
 uv run pytest

--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 An MCP server that bridges Claude Code with the [Kanban Tool API v3](https://kanbantool.com/developer/api-v3).
 
-> **Status:** Pre-alpha. Read tools land in M1, write tools in M2.
+> **Status:** Pre-alpha, under active development. The tool surface and API are unstable. M1 (read tools) is in progress; M2 (write tools) and PyPI publishing are still ahead.
 
 ## Install
+
+> The `uvx`-based install below will work once the package is published to PyPI ([#19](https://github.com/VeryLongNicknameSuchWow/kanbantool-mcp/issues/19)). Until then, run from a local checkout — see [Development](#development).
 
 Add to your `mcp.json`:
 
@@ -27,7 +29,16 @@ Add to your `mcp.json`:
 
 ## Tools
 
-(Filled in as M1/M2 land.)
+Implemented today:
+
+- `list_boards` — list boards visible to the authenticated user.
+- `get_board` — fetch a single board (workflow stages, swimlanes, metadata) by ID.
+
+More read tools (`search_tasks`, `get_task`, `recent_changes`, `list_subtasks`) and the M2 write tools are tracked on the issue board. README polish is tracked in [#16](https://github.com/VeryLongNicknameSuchWow/kanbantool-mcp/issues/16).
+
+## Security
+
+See [SECURITY.md](SECURITY.md) for how to report vulnerabilities.
 
 ## Development
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,27 @@
+# Security Policy
+
+## Supported versions
+
+`kanbantool-mcp` is pre-1.0 and under active development. Security fixes are
+applied to the latest release only; older pre-releases do not receive
+backports.
+
+| Version        | Supported |
+| -------------- | --------- |
+| Latest pre-1.0 | Yes       |
+| Older versions | No        |
+
+## Reporting a vulnerability
+
+Please report security issues privately — **do not** open a public GitHub
+issue or pull request.
+
+Preferred: GitHub private security advisories at
+<https://github.com/VeryLongNicknameSuchWow/kanbantool-mcp/security/advisories/new>.
+
+Email fallback: <riohno@tutamail.com>.
+
+Please include a description, reproduction steps or a minimal PoC, and the
+affected version or commit. You can expect an initial acknowledgement within
+a few days, and updates as we triage and fix. Thanks for helping keep the
+project and its users safe.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,7 +17,7 @@ Please report security issues privately — **do not** open a public GitHub
 issue or pull request.
 
 Preferred: GitHub private security advisories at
-<https://github.com/VeryLongNicknameSuchWow/kanbantool-mcp/security/advisories/new>.
+<https://github.com/VeryLongOrgNameSuchWow/kanbantool-mcp/security/advisories/new>.
 
 Email fallback: <riohno@tutamail.com>.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,8 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/VeryLongNicknameSuchWow/kanbantool-mcp"
-Issues = "https://github.com/VeryLongNicknameSuchWow/kanbantool-mcp/issues"
+Homepage = "https://github.com/VeryLongOrgNameSuchWow/kanbantool-mcp"
+Issues = "https://github.com/VeryLongOrgNameSuchWow/kanbantool-mcp/issues"
 
 [project.scripts]
 kanbantool-mcp = "kanbantool_mcp.__main__:main"


### PR DESCRIPTION
## Summary

Front-door polish ahead of flipping the repo public.

- **README**: replace the `Tools: (Filled in as M1/M2 land.)` placeholder with the two tools actually implemented today (`list_boards`, `get_board`), tighten the pre-alpha status line, and add a note that the `uvx` install path is gated on PyPI publishing (#19). Full README polish still tracked in #16.
- **SECURITY.md**: short vulnerability reporting policy — GitHub private security advisories as the primary channel, `riohno@tutamail.com` as fallback, supported-versions table for the pre-1.0 era.

Out of scope (handled separately by the owner):

- Repo description / topics (need admin permissions).
- `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md` — deferred; not blocking the flip.

## Test plan

- [x] `uv run pytest` — 25 passed locally
- [ ] CI green on this PR
- [ ] Spot-check rendered README and SECURITY.md on GitHub