### PR TITLE
feat: implement recent_changes MCP tool (changelog poller)

### DIFF
--- a/src/kanbantool_mcp/models.py
+++ b/src/kanbantool_mcp/models.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from datetime import datetime
+from typing import Any
+
 from pydantic import BaseModel, ConfigDict, Field
 
 
@@ -55,3 +58,22 @@ class Board(BaseModel):
     columns: list[Column] = Field(default_factory=list, alias="workflow_stages")
     swimlanes: list[Swimlane] = Field(default_factory=list)
     custom_fields: list[CustomField] = Field(default_factory=list, alias="card_template")
+
+
+class ChangelogEntry(BaseModel):
+    """A single entry from a board's changelog feed.
+
+    Fields beyond ``id`` and ``created_at`` are optional — the API's exact
+    shape varies by event type, and we keep this model permissive so the
+    poller never blows up on an unfamiliar action."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    id: int
+    created_at: datetime
+    action: str | None = None
+    actor_id: int | None = None
+    actor_name: str | None = None
+    target_type: str | None = None
+    target_id: int | None = None
+    details: dict[str, Any] | None = None

--- a/src/kanbantool_mcp/server.py
+++ b/src/kanbantool_mcp/server.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+from datetime import datetime
+
 from fastmcp import FastMCP
 
 from .client import KanbanToolClient
 from .config import Config
-from .models import Board
+from .models import Board, ChangelogEntry
 
 mcp: FastMCP = FastMCP("kanbantool-mcp")
 
@@ -43,6 +45,22 @@ async def get_board(board_id: int) -> Board:
     data = await _get_client().request("GET", f"boards/{board_id}")
     # M3: consider wrapping ValidationError as KanbanToolHTTPError("malformed board payload").
     return Board.model_validate(data)
+
+
+@mcp.tool
+async def recent_changes(board_id: int, since: datetime | None = None) -> list[ChangelogEntry]:
+    """Fetch the changelog feed for a board — the change-tracking primitive
+    that stands in for webhooks (Kanban Tool ships none).
+
+    Poll sparingly — typical cadence 30-120s, not per-keystroke. Always pass
+    ``since`` (timestamp of the last entry seen) on subsequent calls; omitting
+    it returns the full history, which can be very large. Returns entries
+    newest-first per the API."""
+    params = {"since": since.isoformat()} if since is not None else None
+    data = await _get_client().request("GET", f"boards/{board_id}/changelog", params=params)
+    raw = data.get("changelog", []) if isinstance(data, dict) else []
+    # M3: consider wrapping ValidationError as KanbanToolHTTPError("malformed changelog payload").
+    return [ChangelogEntry.model_validate(entry) for entry in raw]
 
 
 def run() -> None:

--- a/tests/test_recent_changes.py
+++ b/tests/test_recent_changes.py
@@ -1,0 +1,138 @@
+"""Tests for the recent_changes MCP tool."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import httpx
+import pytest
+import respx
+
+from kanbantool_mcp.client import KanbanToolClient
+from kanbantool_mcp.exceptions import KanbanToolHTTPError, KanbanToolPermissionError
+from kanbantool_mcp.server import mcp, recent_changes
+
+from .conftest import BASE_URL
+
+
+def _changelog_url(board_id: int) -> str:
+    return f"{BASE_URL}boards/{board_id}/changelog.json"
+
+
+async def test_recent_changes_happy_path(_inject_client: KanbanToolClient) -> None:
+    payload = {
+        "changelog": [
+            {
+                "id": 1001,
+                "created_at": "2026-04-30T10:15:00Z",
+                "action": "task_created",
+                "actor_id": 7,
+                "actor_name": "Ada Lovelace",
+                "target_type": "Task",
+                "target_id": 555,
+                "details": {"title": "Write spec"},
+                "extra_unknown_field": "ignored",
+            },
+            {
+                "id": 1000,
+                "created_at": "2026-04-30T09:00:00Z",
+                "action": "task_moved",
+                "target_type": "Task",
+                "target_id": 555,
+            },
+        ]
+    }
+    with respx.mock(assert_all_called=True) as router:
+        router.get(_changelog_url(42)).mock(return_value=httpx.Response(200, json=payload))
+        result = await recent_changes(42)
+
+    assert len(result) == 2
+    newest, older = result
+    assert newest.id == 1001
+    assert newest.created_at == datetime(2026, 4, 30, 10, 15, 0, tzinfo=UTC)
+    assert newest.action == "task_created"
+    assert newest.actor_id == 7
+    assert newest.actor_name == "Ada Lovelace"
+    assert newest.target_type == "Task"
+    assert newest.target_id == 555
+    assert newest.details == {"title": "Write spec"}
+
+    assert older.id == 1000
+    assert older.action == "task_moved"
+    assert older.actor_id is None
+    assert older.actor_name is None
+    assert older.details is None
+
+
+async def test_recent_changes_passes_since_as_query_param(
+    _inject_client: KanbanToolClient,
+) -> None:
+    since = datetime(2026, 4, 30, 8, 0, 0, tzinfo=UTC)
+    with respx.mock(assert_all_called=True) as router:
+        route = router.get(_changelog_url(42)).mock(
+            return_value=httpx.Response(200, json={"changelog": []})
+        )
+        await recent_changes(42, since=since)
+
+    request = route.calls.last.request
+    assert request.url.params["since"] == since.isoformat()
+
+
+async def test_recent_changes_omits_since_when_none(
+    _inject_client: KanbanToolClient,
+) -> None:
+    with respx.mock(assert_all_called=True) as router:
+        route = router.get(_changelog_url(42)).mock(
+            return_value=httpx.Response(200, json={"changelog": []})
+        )
+        await recent_changes(42)
+
+    request = route.calls.last.request
+    assert "since" not in request.url.params
+    # No query string at all when since is omitted.
+    assert request.url.query == b""
+
+
+async def test_recent_changes_empty(_inject_client: KanbanToolClient) -> None:
+    with respx.mock(assert_all_called=True) as router:
+        router.get(_changelog_url(42)).mock(
+            return_value=httpx.Response(200, json={"changelog": []})
+        )
+        result = await recent_changes(42)
+
+    assert result == []
+
+
+async def test_recent_changes_404_raises_http_error(_inject_client: KanbanToolClient) -> None:
+    with respx.mock() as router:
+        router.get(_changelog_url(999)).mock(return_value=httpx.Response(404, text="not found"))
+        with pytest.raises(KanbanToolHTTPError) as exc_info:
+            await recent_changes(999)
+        assert exc_info.value.status_code == 404
+
+
+async def test_recent_changes_401_raises_permission_error(
+    _inject_client: KanbanToolClient,
+) -> None:
+    with respx.mock() as router:
+        router.get(_changelog_url(42)).mock(return_value=httpx.Response(401, text="unauthorized"))
+        with pytest.raises(KanbanToolPermissionError):
+            await recent_changes(42)
+
+
+async def test_recent_changes_via_fastmcp_entrypoint_accepts_iso_string(
+    _inject_client: KanbanToolClient,
+) -> None:
+    """The FastMCP runtime coerces a JSON-Schema ``date-time`` string into
+    a ``datetime`` for us — this guards that boundary so MCP clients can
+    pass ``since`` as plain ISO text."""
+    iso = "2026-04-30T08:00:00+00:00"
+    with respx.mock(assert_all_called=True) as router:
+        route = router.get(_changelog_url(42)).mock(
+            return_value=httpx.Response(200, json={"changelog": []})
+        )
+        tool = await mcp.get_tool("recent_changes")
+        assert tool is not None
+        await tool.run({"board_id": 42, "since": iso})
+
+    assert route.calls.last.request.url.params["since"] == iso


### PR DESCRIPTION
## Summary

- Adds `recent_changes(board_id, since=None)` MCP tool hitting `GET /boards/{id}/changelog.json` — the change-tracking primitive that stands in for webhooks (Kanban Tool ships none).
- Adds permissive `ChangelogEntry` model (`extra="ignore"`); `id` and `created_at` are required so callers can dedup and advance the `since` cursor; remaining fields optional because event shapes vary by action type.
- Tool docstring is explicit about polling cadence (30-120s) and the `since`-on-every-call discipline so an LLM agent doesn't hammer the API or pull unbounded history.
- `since.isoformat()` is inlined and only sent when non-`None` — matches the KISS plan-review note (no params dict when omitted).

Closes #7

## Implementation notes

- Mirrors `list_boards`'s `data.get("changelog", [])` pattern — single response root, fail loudly on API surprises.
- Actor fields kept flat (`actor_id`, `actor_name`); will switch to a `model_validator(mode="before")` if/when we observe nested `actor: {...}` in the wild.
- Renamed `payload` -> `details` for clarity.
- FastMCP cleanly converts JSON-Schema `date-time` strings to `datetime` at the tool boundary, so MCP clients can pass `since` as plain ISO text — covered by `test_recent_changes_via_fastmcp_entrypoint_accepts_iso_string`.

## Test plan

- [x] Happy path with two entries (verifies `extra="ignore"` and field mapping)
- [x] `since` is forwarded as `?since=...` query param
- [x] `since=None` produces no query string at all
- [x] Empty changelog list
- [x] 404 -> `KanbanToolHTTPError`
- [x] 401 -> `KanbanToolPermissionError`
- [x] FastMCP entrypoint accepts ISO string for `since`
- [x] `uv run ruff check .`, `uv run ruff format --check .`, `uv run ty check`, `uv run pytest` all green locally (32 passed)

Generated with [Claude Code](https://claude.com/claude-code)