### PR TITLE
feat: implement get_task MCP tool

### DIFF
--- a/src/kanbantool_mcp/models.py
+++ b/src/kanbantool_mcp/models.py
@@ -55,3 +55,47 @@ class Board(BaseModel):
     columns: list[Column] = Field(default_factory=list, alias="workflow_stages")
     swimlanes: list[Swimlane] = Field(default_factory=list)
     custom_fields: list[CustomField] = Field(default_factory=list, alias="card_template")
+
+
+class Task(BaseModel):
+    """A task (card) on a board.
+
+    Mirrors the GET ``/tasks/{id}.json`` response. Heavier nested resources
+    (full subtasks, comments, time-tracker entries) are intentionally elided
+    here — only their counts/totals are surfaced. Dedicated tools fetch the
+    deep objects when an agent actually needs them.
+    """
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    id: int
+    name: str
+    description: str | None = None
+    board_id: int | None = None
+    # ``workflow_stage_id`` is the on-the-wire name; expose the column id under
+    # the terser ``lane_id`` alias that matches how callers reason about a
+    # card's location (column/lane).
+    lane_id: int | None = Field(default=None, alias="workflow_stage_id")
+    swimlane_id: int | None = None
+    position: int | None = None
+    # ``priority`` is a small enum on most accounts but some installs return
+    # raw integers; accept either rather than guessing.
+    priority: int | str | None = None
+    color: str | None = None
+    # ISO 8601 strings as returned by the API; no native datetime parsing here.
+    due_date: str | None = None
+    start_date: str | None = None
+    tags: str | None = None
+    # User ids only. The full Assignee submodel can land alongside a tool that
+    # actually needs it.
+    assignees: list[int] | None = None
+    is_archived: bool | None = None
+    is_blocked: bool | None = None
+    block_reason: str | None = None
+    subtasks_count: int | None = None
+    comment_count: int | None = None
+    # Flat seconds. The wrapped ``{ "total": ..., "by_user": ... }`` shape is a
+    # separate concern — exposed via a dedicated time-tracker tool later.
+    time_tracker_total: int | None = None
+    created_at: str | None = None
+    updated_at: str | None = None

--- a/src/kanbantool_mcp/server.py
+++ b/src/kanbantool_mcp/server.py
@@ -6,7 +6,7 @@ from fastmcp import FastMCP
 
 from .client import KanbanToolClient
 from .config import Config
-from .models import Board
+from .models import Board, Task
 
 mcp: FastMCP = FastMCP("kanbantool-mcp")
 
@@ -43,6 +43,19 @@ async def get_board(board_id: int) -> Board:
     data = await _get_client().request("GET", f"boards/{board_id}")
     # M3: consider wrapping ValidationError as KanbanToolHTTPError("malformed board payload").
     return Board.model_validate(data)
+
+
+@mcp.tool
+async def get_task(task_id: int) -> Task:
+    """Fetch a task by id.
+
+    Surfaces the task's headline metadata along with subtask count, comment
+    count, and total tracked time. Use the dedicated subtask/comment/time
+    tools to drill into the nested collections.
+    """
+    data = await _get_client().request("GET", f"tasks/{task_id}")
+    # M3: consider wrapping ValidationError as KanbanToolHTTPError("malformed task payload").
+    return Task.model_validate(data)
 
 
 def run() -> None:

--- a/tests/test_get_task.py
+++ b/tests/test_get_task.py
@@ -1,0 +1,130 @@
+"""Tests for the get_task MCP tool."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+
+from kanbantool_mcp.client import KanbanToolClient
+from kanbantool_mcp.exceptions import KanbanToolHTTPError, KanbanToolPermissionError
+from kanbantool_mcp.server import get_task
+
+from .conftest import BASE_URL
+
+
+def _task_url(task_id: int) -> str:
+    return f"{BASE_URL}tasks/{task_id}.json"
+
+
+async def test_get_task_happy_path(_inject_client: KanbanToolClient) -> None:
+    payload = {
+        "id": 4242,
+        "name": "Ship the thing",
+        "description": "Cut a release once CI is green.",
+        "board_id": 7,
+        "workflow_stage_id": 100,
+        "swimlane_id": 200,
+        "position": 3,
+        "priority": "high",
+        "color": "#ff0000",
+        "due_date": "2026-05-15T00:00:00Z",
+        "start_date": "2026-04-30T00:00:00Z",
+        "tags": "release,urgent",
+        "assignees": [11, 22],
+        "is_archived": False,
+        "is_blocked": True,
+        "block_reason": "Waiting on review",
+        "subtasks_count": 4,
+        "comment_count": 12,
+        "time_tracker_total": 3600,
+        "created_at": "2026-04-01T09:30:00Z",
+        "updated_at": "2026-04-29T17:45:00Z",
+        "extra_unknown_field": "ignored",
+    }
+    with respx.mock(assert_all_called=True) as router:
+        router.get(_task_url(4242)).mock(return_value=httpx.Response(200, json=payload))
+        task = await get_task(4242)
+
+    assert task.id == 4242
+    assert task.name == "Ship the thing"
+    assert task.description == "Cut a release once CI is green."
+    assert task.board_id == 7
+    assert task.lane_id == 100
+    assert task.swimlane_id == 200
+    assert task.position == 3
+    assert task.priority == "high"
+    assert task.color == "#ff0000"
+    assert task.due_date == "2026-05-15T00:00:00Z"
+    assert task.start_date == "2026-04-30T00:00:00Z"
+    assert task.tags == "release,urgent"
+    assert task.assignees == [11, 22]
+    assert task.is_archived is False
+    assert task.is_blocked is True
+    assert task.block_reason == "Waiting on review"
+    assert task.subtasks_count == 4
+    assert task.comment_count == 12
+    assert task.time_tracker_total == 3600
+    assert task.created_at == "2026-04-01T09:30:00Z"
+    assert task.updated_at == "2026-04-29T17:45:00Z"
+
+
+async def test_get_task_accepts_integer_priority(_inject_client: KanbanToolClient) -> None:
+    """Some accounts return ``priority`` as an int rather than an enum string."""
+    with respx.mock(assert_all_called=True) as router:
+        router.get(_task_url(7)).mock(
+            return_value=httpx.Response(200, json={"id": 7, "name": "x", "priority": 2})
+        )
+        task = await get_task(7)
+
+    assert task.priority == 2
+
+
+async def test_get_task_minimal_payload(_inject_client: KanbanToolClient) -> None:
+    with respx.mock(assert_all_called=True) as router:
+        router.get(_task_url(1)).mock(
+            return_value=httpx.Response(200, json={"id": 1, "name": "Tiny"})
+        )
+        task = await get_task(1)
+
+    assert task.id == 1
+    assert task.name == "Tiny"
+    assert task.description is None
+    assert task.board_id is None
+    assert task.lane_id is None
+    assert task.swimlane_id is None
+    assert task.assignees is None
+    assert task.subtasks_count is None
+    assert task.comment_count is None
+    assert task.time_tracker_total is None
+
+
+async def test_get_task_404_raises_http_error(_inject_client: KanbanToolClient) -> None:
+    with respx.mock() as router:
+        router.get(_task_url(999)).mock(return_value=httpx.Response(404, text="not found"))
+        with pytest.raises(KanbanToolHTTPError) as exc_info:
+            await get_task(999)
+        assert exc_info.value.status_code == 404
+        assert "not found" in exc_info.value.body_excerpt
+
+
+async def test_get_task_401_raises_permission_error(_inject_client: KanbanToolClient) -> None:
+    with respx.mock() as router:
+        router.get(_task_url(1)).mock(return_value=httpx.Response(401, text="unauthorized"))
+        with pytest.raises(KanbanToolPermissionError):
+            await get_task(1)
+
+
+async def test_get_task_url_shape(_inject_client: KanbanToolClient) -> None:
+    """Verify the tool hits exactly ``GET tasks/{id}.json`` (no query string,
+    no double-suffix, correct base URL)."""
+    with respx.mock(assert_all_called=True) as router:
+        route = router.get(_task_url(123)).mock(
+            return_value=httpx.Response(200, json={"id": 123, "name": "Probe"})
+        )
+        await get_task(123)
+
+    assert route.call_count == 1
+    request = route.calls.last.request
+    assert request.method == "GET"
+    assert str(request.url) == _task_url(123)


### PR DESCRIPTION
## Summary

- Adds the `get_task` MCP tool (GET `/tasks/{id}.json`), Closes #6.
- Introduces a `Task` pydantic model with `id`/`name` required and everything else optional under `extra="ignore"`, mirroring the permissive shape `Board` already uses. Surfaces the lightweight roll-ups the issue calls out — `subtasks_count`, `comment_count`, and a flat `time_tracker_total` (seconds) — and intentionally leaves the deep collections (full subtasks/comments/trackers) for dedicated tools.
- The on-the-wire `workflow_stage_id` is exposed under the terser `lane_id` alias to match how callers reason about a card's location; `priority` accepts both `int` and `str` since the API's shape varies by account.

## Test plan

- [x] `uv run ruff format --check .`
- [x] `uv run ruff check .`
- [x] `uv run ty check`
- [x] `uv run pytest` (31 passed)
- [x] Happy path with the full documented field set, including `extra_unknown_field` to verify `extra="ignore"`
- [x] Minimal payload (`id` + `name` only) leaves every other field at `None`
- [x] Integer `priority` accepted alongside the string enum form
- [x] 404 response raises `KanbanToolHTTPError` with status + body excerpt
- [x] 401 response raises `KanbanToolPermissionError`
- [x] URL shape asserted: exactly one `GET tasks/{id}.json` request, no query string, no double `.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)