### PR TITLE
feat: implement search_tasks MCP tool with DSL passthrough

### DIFF
--- a/src/kanbantool_mcp/models.py
+++ b/src/kanbantool_mcp/models.py
@@ -60,6 +60,50 @@ class Board(BaseModel):
     custom_fields: list[CustomField] = Field(default_factory=list, alias="card_template")
 
 
+class Task(BaseModel):
+    """A task (card) on a board.
+
+    Mirrors the GET ``/tasks/{id}.json`` response. Heavier nested resources
+    (full subtasks, comments, time-tracker entries) are intentionally elided
+    here — only their counts/totals are surfaced. Dedicated tools fetch the
+    deep objects when an agent actually needs them.
+    """
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    id: int
+    name: str
+    description: str | None = None
+    board_id: int | None = None
+    # ``workflow_stage_id`` is the on-the-wire name; expose the column id under
+    # the terser ``lane_id`` alias that matches how callers reason about a
+    # card's location (column/lane).
+    lane_id: int | None = Field(default=None, alias="workflow_stage_id")
+    swimlane_id: int | None = None
+    position: int | None = None
+    # ``priority`` is a small enum on most accounts but some installs return
+    # raw integers; accept either rather than guessing.
+    priority: int | str | None = None
+    color: str | None = None
+    # ISO 8601 strings as returned by the API; no native datetime parsing here.
+    due_date: str | None = None
+    start_date: str | None = None
+    tags: str | None = None
+    # User ids only. The full Assignee submodel can land alongside a tool that
+    # actually needs it.
+    assignees: list[int] | None = None
+    is_archived: bool | None = None
+    is_blocked: bool | None = None
+    block_reason: str | None = None
+    subtasks_count: int | None = None
+    comment_count: int | None = None
+    # Flat seconds. The wrapped ``{ "total": ..., "by_user": ... }`` shape is a
+    # separate concern — exposed via a dedicated time-tracker tool later.
+    time_tracker_total: int | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
+
+
 class ChangelogEntry(BaseModel):
     """A single entry from a board's changelog feed.
 

--- a/src/kanbantool_mcp/server.py
+++ b/src/kanbantool_mcp/server.py
@@ -8,7 +8,7 @@ from fastmcp import FastMCP
 
 from .client import KanbanToolClient
 from .config import Config
-from .models import Board, ChangelogEntry
+from .models import Board, ChangelogEntry, Task
 
 mcp: FastMCP = FastMCP("kanbantool-mcp")
 
@@ -61,6 +61,61 @@ async def recent_changes(board_id: int, since: datetime | None = None) -> list[C
     raw = data.get("changelog", []) if isinstance(data, dict) else []
     # M3: consider wrapping ValidationError as KanbanToolHTTPError("malformed changelog payload").
     return [ChangelogEntry.model_validate(entry) for entry in raw]
+
+
+# Hard ceiling on a single page. Defends against an LLM hallucinating a huge
+# limit and pulling far more than the API or the agent's context can sanely
+# absorb in one round-trip. Pagination via ``page`` is the supported way to
+# walk past it.
+_SEARCH_TASKS_MAX_LIMIT = 50
+
+
+@mcp.tool
+async def search_tasks(
+    query: str,
+    board_id: int | None = None,
+    limit: int = 25,
+    page: int = 1,
+) -> list[Task]:
+    """Search tasks across boards using Kanban Tool's query DSL.
+
+    ``query`` is forwarded to the API verbatim — do not URL-encode it,
+    do not wrap the whole expression in quotes, and do not reconstruct it
+    from individual operator keyword arguments. Quote a single value only
+    when it contains spaces (e.g. ``name:"ship the thing"``).
+
+    Supported operators (combine with spaces; terms are AND-ed together):
+
+    - ``@username``           — assignee, e.g. ``@alice``
+    - ``name:<text>``         — title contains, e.g. ``name:"deploy script"``
+    - ``priority:<level>``    — priority level, e.g. ``priority:high``
+    - ``tags:<tag>``          — tag match, e.g. ``tags:bug``
+    - ``due_date=<iso-date>`` — due-date equality, e.g. ``due_date=2026-05-01``
+    - ``subtasks_count<N>``   — also ``>``, ``=``; e.g. ``subtasks_count>0``
+    - ``archived:<bool>``     — include archived, e.g. ``archived:true``
+
+    If the user asks for something the operators above don't cover (full-text
+    search of comments, fuzzy matching, etc.), say so plainly rather than
+    inventing syntax — the API will silently return zero results for unknown
+    operators.
+
+    ``board_id`` scopes the search to a single board when provided; omit it
+    to search every board the token can see. ``limit`` is clamped to
+    ``50`` server-side here; use ``page`` (1-indexed) to walk further results.
+    """
+    capped_limit = min(limit, _SEARCH_TASKS_MAX_LIMIT)
+    params: dict[str, str | int] = {
+        "query": query,
+        "limit": capped_limit,
+        "page": page,
+    }
+    if board_id is not None:
+        params["board_id"] = board_id
+
+    data = await _get_client().request("GET", "tasks/search", params=params)
+    raw = data.get("tasks", []) if isinstance(data, dict) else []
+    # M3: consider wrapping ValidationError as KanbanToolHTTPError("malformed search payload").
+    return [Task.model_validate(t) for t in raw]
 
 
 def run() -> None:

--- a/tests/test_search_tasks.py
+++ b/tests/test_search_tasks.py
@@ -1,0 +1,162 @@
+"""Tests for the search_tasks MCP tool."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+
+from kanbantool_mcp.client import KanbanToolClient
+from kanbantool_mcp.exceptions import KanbanToolHTTPError, KanbanToolPermissionError
+from kanbantool_mcp.server import search_tasks
+
+from .conftest import BASE_URL
+
+SEARCH_URL = f"{BASE_URL}tasks/search.json"
+
+
+async def test_search_tasks_happy_path(_inject_client: KanbanToolClient) -> None:
+    payload = {
+        "tasks": [
+            {
+                "id": 1,
+                "name": "Ship release",
+                "board_id": 7,
+                "workflow_stage_id": 100,
+                "priority": "high",
+                "tags": "release,urgent",
+                "subtasks_count": 2,
+                "comment_count": 3,
+                "extra_unknown_field": "ignored",
+            },
+            {
+                "id": 2,
+                "name": "Write changelog",
+                "board_id": 7,
+                "priority": 1,
+            },
+        ]
+    }
+    with respx.mock(assert_all_called=True) as router:
+        router.get(SEARCH_URL).mock(return_value=httpx.Response(200, json=payload))
+        results = await search_tasks(query="@alice priority:high")
+
+    assert len(results) == 2
+    first, second = results
+    assert first.id == 1
+    assert first.name == "Ship release"
+    assert first.board_id == 7
+    assert first.lane_id == 100
+    assert first.priority == "high"
+    assert first.tags == "release,urgent"
+    assert first.subtasks_count == 2
+    assert first.comment_count == 3
+    assert second.id == 2
+    assert second.name == "Write changelog"
+    assert second.priority == 1
+
+
+async def test_search_tasks_dsl_passthrough_unmodified(
+    _inject_client: KanbanToolClient,
+) -> None:
+    """The full DSL string must reach the API verbatim — no rebuilding,
+    no extra quoting, no operator splitting."""
+    raw_query = '@alice priority:high tags:"bug,urgent"'
+    with respx.mock(assert_all_called=True) as router:
+        route = router.get(SEARCH_URL).mock(return_value=httpx.Response(200, json={"tasks": []}))
+        await search_tasks(query=raw_query)
+
+    request = route.calls.last.request
+    assert request.url.params["query"] == raw_query
+
+
+async def test_search_tasks_omits_board_id_when_none(
+    _inject_client: KanbanToolClient,
+) -> None:
+    with respx.mock(assert_all_called=True) as router:
+        route = router.get(SEARCH_URL).mock(return_value=httpx.Response(200, json={"tasks": []}))
+        await search_tasks(query="name:foo")
+
+    request = route.calls.last.request
+    assert "board_id" not in request.url.params
+
+
+async def test_search_tasks_forwards_board_id_when_provided(
+    _inject_client: KanbanToolClient,
+) -> None:
+    with respx.mock(assert_all_called=True) as router:
+        route = router.get(SEARCH_URL).mock(return_value=httpx.Response(200, json={"tasks": []}))
+        await search_tasks(query="name:foo", board_id=42)
+
+    request = route.calls.last.request
+    assert request.url.params["board_id"] == "42"
+
+
+async def test_search_tasks_empty_results(_inject_client: KanbanToolClient) -> None:
+    with respx.mock(assert_all_called=True) as router:
+        router.get(SEARCH_URL).mock(return_value=httpx.Response(200, json={"tasks": []}))
+        results = await search_tasks(query="name:nothing-matches")
+
+    assert results == []
+
+
+async def test_search_tasks_pagination_forwarded(_inject_client: KanbanToolClient) -> None:
+    with respx.mock(assert_all_called=True) as router:
+        route = router.get(SEARCH_URL).mock(return_value=httpx.Response(200, json={"tasks": []}))
+        await search_tasks(query="name:foo", limit=10, page=2)
+
+    params = route.calls.last.request.url.params
+    assert params["limit"] == "10"
+    assert params["page"] == "2"
+
+
+async def test_search_tasks_limit_is_clamped_to_50(_inject_client: KanbanToolClient) -> None:
+    """Hallucinated huge limits must be capped before they hit the API."""
+    with respx.mock(assert_all_called=True) as router:
+        route = router.get(SEARCH_URL).mock(return_value=httpx.Response(200, json={"tasks": []}))
+        await search_tasks(query="name:foo", limit=200)
+
+    assert route.calls.last.request.url.params["limit"] == "50"
+
+
+async def test_search_tasks_401_raises_permission_error(
+    _inject_client: KanbanToolClient,
+) -> None:
+    with respx.mock() as router:
+        router.get(SEARCH_URL).mock(return_value=httpx.Response(401, text="unauthorized"))
+        with pytest.raises(KanbanToolPermissionError):
+            await search_tasks(query="name:foo")
+
+
+async def test_search_tasks_500_raises_http_error(_inject_client: KanbanToolClient) -> None:
+    with respx.mock() as router:
+        router.get(SEARCH_URL).mock(return_value=httpx.Response(500, text="boom"))
+        with pytest.raises(KanbanToolHTTPError) as exc_info:
+            await search_tasks(query="name:foo")
+        assert exc_info.value.status_code == 500
+        assert "boom" in exc_info.value.body_excerpt
+
+
+async def test_search_tasks_drops_unknown_task_fields(
+    _inject_client: KanbanToolClient,
+) -> None:
+    """Confirms ``extra="ignore"`` round-trip — unknown task fields are
+    silently dropped rather than failing validation."""
+    payload = {
+        "tasks": [
+            {
+                "id": 99,
+                "name": "Round trip",
+                "speculative_future_field": {"nested": True},
+                "another_unknown": [1, 2, 3],
+            }
+        ]
+    }
+    with respx.mock(assert_all_called=True) as router:
+        router.get(SEARCH_URL).mock(return_value=httpx.Response(200, json=payload))
+        results = await search_tasks(query="name:round-trip")
+
+    assert len(results) == 1
+    assert results[0].id == 99
+    assert results[0].name == "Round trip"
+    assert not hasattr(results[0], "speculative_future_field")


### PR DESCRIPTION
## Summary

- Adds the `search_tasks` MCP tool (GET `/tasks/search.json`), Closes #5.
- Forwards the caller's full Kanban Tool query string verbatim — no rebuilding from kwargs, no extra encoding, no defensive multi-shape probing. Operator cheat-sheet (`@assignee`, `name:`, `priority:`, `tags:`, `due_date=`, `subtasks_count`, `archived`) lives in the tool docstring so the LLM stays inside the API's actual grammar instead of inventing syntax.
- Returns a bare `list[Task]`. No `SearchTasksResult` wrapper — pagination is documented in the docstring (`limit` clamped at 50, walk further via `page`), not encoded in the return type. Matches the shape of `get_board` / `recent_changes`.
- `board_id` is only forwarded when provided; `limit` is hard-capped at 50 to defend against hallucinated huge values.

## Note on the `Task` model

This PR also includes the `Task` pydantic model the tool returns. PR #37 (`feat: implement get_task`) introduces the same model for its tool. The two definitions are byte-identical, so whichever PR merges second resolves trivially on `models.py`.

## Test plan

- [x] `uv run ruff format --check .`
- [x] `uv run ruff check .`
- [x] `uv run ty check`
- [x] `uv run pytest` (42 passed)
- [x] Happy path with two `Task` results parses correctly (incl. `extra_unknown_field` dropped)
- [x] DSL passthrough — `query='@alice priority:high tags:"bug,urgent"'` arrives unmodified in `params["query"]`
- [x] `board_id` omitted -> no `board_id` query param sent
- [x] `board_id` provided -> forwarded as int
- [x] Empty results
- [x] Pagination — `page=2`, `limit=10` forwarded; clamping (`limit=200` becomes `limit=50` in the request)
- [x] 401 -> `KanbanToolPermissionError`
- [x] 500 -> `KanbanToolHTTPError` (status code + body excerpt)
- [x] `extra="ignore"` round-trip — unknown task fields dropped silently

🤖 Generated with [Claude Code](https://claude.com/claude-code)