### PR TITLE
feat: implement create_task MCP tool with 422 field-error surfacing

### DIFF
--- a/src/kanbantool_mcp/client.py
+++ b/src/kanbantool_mcp/client.py
@@ -35,7 +35,12 @@ def _parse_field_errors(body: str) -> dict[str, list[str]]:
     """Parse a 422 body's Rails-idiomatic ``{"errors": {field: [msg, ...]}}``
     envelope. Returns an empty dict if the body is not JSON, the envelope is
     missing, or the values are not the expected list-of-strings shape — the
-    caller still surfaces the raw (scrubbed) excerpt in that case."""
+    caller still surfaces the raw (scrubbed) excerpt in that case.
+
+    Both message strings and field keys are run through ``_scrub_secrets`` so
+    a token leaked inside the JSON envelope (e.g. an upstream proxy echoing
+    ``Authorization: Bearer X`` into a field message) cannot survive into
+    ``KanbanToolValidationError.field_errors`` or its ``__str__`` output."""
     try:
         decoded = json.loads(body)
     except (json.JSONDecodeError, ValueError):
@@ -49,10 +54,11 @@ def _parse_field_errors(body: str) -> dict[str, list[str]]:
     for field, messages in errors.items():
         if not isinstance(field, str):
             continue
+        scrubbed_field = _scrub_secrets(field)
         if isinstance(messages, list):
-            parsed[field] = [str(m) for m in messages]
+            parsed[scrubbed_field] = [_scrub_secrets(str(m)) for m in messages]
         else:
-            parsed[field] = [str(messages)]
+            parsed[scrubbed_field] = [_scrub_secrets(str(messages))]
     return parsed
 
 
@@ -74,13 +80,14 @@ def _raise_for_status(response: httpx.Response, method: str, path: str) -> None:
             "Kanban Tool API denied the request as forbidden (403). "
             "The token does not have permission for this resource."
         )
-    body_excerpt = _scrub_secrets(response.text)[:_BODY_EXCERPT_LIMIT]
+    body_text = response.text
+    body_excerpt = _scrub_secrets(body_text)[:_BODY_EXCERPT_LIMIT]
     if status == 422:
         raise KanbanToolValidationError(
             f"Kanban Tool API rejected {method} {path} as invalid (422).",
             status_code=422,
             body_excerpt=body_excerpt,
-            field_errors=_parse_field_errors(response.text),
+            field_errors=_parse_field_errors(body_text),
         )
     raise KanbanToolHTTPError(
         f"Kanban Tool API returned HTTP {status} for {method} {path}",

--- a/src/kanbantool_mcp/client.py
+++ b/src/kanbantool_mcp/client.py
@@ -14,6 +14,7 @@ from .exceptions import (
     KanbanToolHTTPError,
     KanbanToolPermissionError,
     KanbanToolTransportError,
+    KanbanToolValidationError,
 )
 
 _BODY_EXCERPT_LIMIT = 200
@@ -28,6 +29,64 @@ def _scrub_secrets(text: str) -> str:
     Kanban Tool API uses bearer auth exclusively, so this covers the realistic
     leak path (upstream proxy/WAF echoing the Authorization header)."""
     return _BEARER_PATTERN.sub("Bearer ***", text)
+
+
+def _parse_field_errors(body: str) -> dict[str, list[str]]:
+    """Parse a 422 body's Rails-idiomatic ``{"errors": {field: [msg, ...]}}``
+    envelope. Returns an empty dict if the body is not JSON, the envelope is
+    missing, or the values are not the expected list-of-strings shape — the
+    caller still surfaces the raw (scrubbed) excerpt in that case."""
+    try:
+        decoded = json.loads(body)
+    except (json.JSONDecodeError, ValueError):
+        return {}
+    if not isinstance(decoded, dict):
+        return {}
+    errors = decoded.get("errors")
+    if not isinstance(errors, dict):
+        return {}
+    parsed: dict[str, list[str]] = {}
+    for field, messages in errors.items():
+        if not isinstance(field, str):
+            continue
+        if isinstance(messages, list):
+            parsed[field] = [str(m) for m in messages]
+        else:
+            parsed[field] = [str(messages)]
+    return parsed
+
+
+def _raise_for_status(response: httpx.Response, method: str, path: str) -> None:
+    """Translate a non-2xx ``httpx.Response`` into the appropriate Kanban Tool
+    exception. Returns silently for 2xx so the caller can proceed to JSON
+    decoding. Splitting this out keeps ``request()`` focused on transport
+    concerns while error-shape policy lives in one place."""
+    status = response.status_code
+    if status < 400:
+        return
+    if status == 401:
+        raise KanbanToolPermissionError(
+            "Kanban Tool API rejected the request as unauthorized (401). "
+            "Check that the KANBANTOOL_API_TOKEN env var is set to a valid token."
+        )
+    if status == 403:
+        raise KanbanToolPermissionError(
+            "Kanban Tool API denied the request as forbidden (403). "
+            "The token does not have permission for this resource."
+        )
+    body_excerpt = _scrub_secrets(response.text)[:_BODY_EXCERPT_LIMIT]
+    if status == 422:
+        raise KanbanToolValidationError(
+            f"Kanban Tool API rejected {method} {path} as invalid (422).",
+            status_code=422,
+            body_excerpt=body_excerpt,
+            field_errors=_parse_field_errors(response.text),
+        )
+    raise KanbanToolHTTPError(
+        f"Kanban Tool API returned HTTP {status} for {method} {path}",
+        status_code=status,
+        body_excerpt=body_excerpt,
+    )
 
 
 class KanbanToolClient:
@@ -71,30 +130,13 @@ class KanbanToolClient:
                     f"Transport error contacting Kanban Tool API: {second_error}"
                 ) from second_error
 
-        status = response.status_code
-        if status == 401:
-            raise KanbanToolPermissionError(
-                "Kanban Tool API rejected the request as unauthorized (401). "
-                "Check that the KANBANTOOL_API_TOKEN env var is set to a valid token."
-            )
-        if status == 403:
-            raise KanbanToolPermissionError(
-                "Kanban Tool API denied the request as forbidden (403). "
-                "The token does not have permission for this resource."
-            )
-        if status >= 400:
-            body_excerpt = _scrub_secrets(response.text)[:_BODY_EXCERPT_LIMIT]
-            raise KanbanToolHTTPError(
-                f"Kanban Tool API returned HTTP {status} for {method} {normalized}",
-                status_code=status,
-                body_excerpt=body_excerpt,
-            )
+        _raise_for_status(response, method, normalized)
 
         try:
             return response.json()
         except json.JSONDecodeError:
             raise KanbanToolHTTPError(
                 f"Kanban Tool API returned non-JSON body for {method} {normalized}",
-                status_code=status,
+                status_code=response.status_code,
                 body_excerpt=_scrub_secrets(response.text)[:_BODY_EXCERPT_LIMIT],
             ) from None

--- a/src/kanbantool_mcp/exceptions.py
+++ b/src/kanbantool_mcp/exceptions.py
@@ -20,5 +20,34 @@ class KanbanToolHTTPError(KanbanToolError):
         self.body_excerpt = body_excerpt
 
 
+class KanbanToolValidationError(KanbanToolHTTPError):
+    """Raised on a 422 Unprocessable Entity response.
+
+    Subclasses ``KanbanToolHTTPError`` so existing ``except KanbanToolHTTPError``
+    callers continue to catch validation failures, while callers that want
+    field-level detail can branch on this subclass and read ``field_errors``.
+    """
+
+    def __init__(
+        self,
+        message: str = "Kanban Tool API rejected the request as invalid (422).",
+        *,
+        status_code: int = 422,
+        body_excerpt: str,
+        field_errors: dict[str, list[str]],
+    ) -> None:
+        super().__init__(message, status_code=status_code, body_excerpt=body_excerpt)
+        self.field_errors = field_errors
+
+    def __str__(self) -> str:
+        base = super().__str__()
+        if not self.field_errors:
+            return base
+        rendered = "; ".join(
+            f"{field}: {', '.join(messages)}" for field, messages in self.field_errors.items()
+        )
+        return f"{base} {rendered}"
+
+
 class KanbanToolTransportError(KanbanToolError):
     """Raised when the underlying httpx transport fails after a retry."""

--- a/src/kanbantool_mcp/exceptions.py
+++ b/src/kanbantool_mcp/exceptions.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+import re
+
+_BEARER_PATTERN = re.compile(r"(?i)\bbearer\s+\S+")
+
 
 class KanbanToolError(Exception):
     """Base class for all Kanban Tool client errors."""
@@ -46,7 +50,11 @@ class KanbanToolValidationError(KanbanToolHTTPError):
         rendered = "; ".join(
             f"{field}: {', '.join(messages)}" for field, messages in self.field_errors.items()
         )
-        return f"{base} {rendered}"
+        # Belt-and-suspenders: scrub again here so direct construction of the
+        # exception with un-scrubbed input cannot leak a bearer token through
+        # the rendered string. The client construction path scrubs on the way
+        # in; this is a second line of defense for callers that bypass it.
+        return _BEARER_PATTERN.sub("Bearer ***", f"{base} {rendered}")
 
 
 class KanbanToolTransportError(KanbanToolError):

--- a/src/kanbantool_mcp/server.py
+++ b/src/kanbantool_mcp/server.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Any
 
 from fastmcp import FastMCP
 
@@ -129,6 +130,60 @@ async def search_tasks(
     raw = data.get("tasks", []) if isinstance(data, dict) else []
     # M3: consider wrapping ValidationError as KanbanToolHTTPError("malformed search payload").
     return [Task.model_validate(t) for t in raw]
+
+
+@mcp.tool
+async def create_task(
+    name: str,
+    board_id: int,
+    description: str | None = None,
+    lane_id: int | None = None,
+    position: int | None = None,
+    assignees: list[int] | None = None,
+    due_date: str | None = None,
+    priority: int | str | None = None,
+    tags: str | None = None,
+) -> Task:
+    """Create a new task on a board.
+
+    ``name`` and ``board_id`` are required; everything else is optional and
+    omitted from the request when left unset (the API may treat an explicit
+    ``null`` as a clear, which is rarely what a caller wants on create).
+
+    ``lane_id`` is the column / workflow stage the card lands in — pass the
+    same id you'd see on a fetched ``Task.lane_id``. ``due_date`` is an ISO
+    8601 string forwarded verbatim. ``priority`` accepts either the string
+    enum or the raw integer some accounts use. ``tags`` is a comma-separated
+    string per the API's wire format.
+
+    Raises ``KanbanToolValidationError`` (a subclass of ``KanbanToolHTTPError``)
+    on a 422 with parsed ``field_errors``; ``KanbanToolHTTPError`` on other
+    4xx/5xx; ``KanbanToolPermissionError`` on 401/403.
+    """
+    payload: dict[str, Any] = {"name": name, "board_id": board_id}
+    if description is not None:
+        payload["description"] = description
+    if lane_id is not None:
+        # Caller-facing ``lane_id`` maps to the wire's ``workflow_stage_id``,
+        # mirroring the inbound alias on the ``Task`` model.
+        payload["workflow_stage_id"] = lane_id
+    if position is not None:
+        payload["position"] = position
+    if assignees is not None:
+        payload["assignees"] = assignees
+    if due_date is not None:
+        payload["due_date"] = due_date
+    if priority is not None:
+        payload["priority"] = priority
+    if tags is not None:
+        payload["tags"] = tags
+
+    # M3: confirm against a real account that POST /tasks.json expects the
+    # ``{"task": {...}}`` Rails-style envelope (vs. flat top-level fields).
+    body = {"task": payload}
+    data = await _get_client().request("POST", "tasks", json=body)
+    # M3: consider wrapping ValidationError as KanbanToolHTTPError("malformed task payload").
+    return Task.model_validate(data)
 
 
 def run() -> None:

--- a/tests/test_create_task.py
+++ b/tests/test_create_task.py
@@ -1,0 +1,228 @@
+"""Tests for the create_task MCP tool."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+import respx
+
+from kanbantool_mcp.client import KanbanToolClient
+from kanbantool_mcp.exceptions import (
+    KanbanToolHTTPError,
+    KanbanToolPermissionError,
+    KanbanToolValidationError,
+)
+from kanbantool_mcp.server import create_task
+
+from .conftest import BASE_URL
+
+TASKS_URL = f"{BASE_URL}tasks.json"
+
+
+def _request_body(route: respx.Route) -> dict[str, object]:
+    return json.loads(route.calls.last.request.content)
+
+
+async def test_create_task_happy_path_minimal_body(_inject_client: KanbanToolClient) -> None:
+    """A minimal call (name + board_id) should produce a ``{"task": {...}}``
+    envelope with exactly those two fields and round-trip into a ``Task``."""
+    with respx.mock(assert_all_called=True) as router:
+        route = router.post(TASKS_URL).mock(
+            return_value=httpx.Response(201, json={"id": 99, "name": "Tiny", "board_id": 7})
+        )
+        task = await create_task(name="Tiny", board_id=7)
+
+    assert task.id == 99
+    assert task.name == "Tiny"
+    assert task.board_id == 7
+
+    body = _request_body(route)
+    assert body == {"task": {"name": "Tiny", "board_id": 7}}
+
+
+async def test_create_task_full_payload_renames_lane_id(_inject_client: KanbanToolClient) -> None:
+    """Every optional field set; ``lane_id`` must serialize as
+    ``workflow_stage_id`` on the wire, matching the inbound alias."""
+    response_payload = {
+        "id": 4242,
+        "name": "Ship the thing",
+        "description": "Cut a release once CI is green.",
+        "board_id": 7,
+        "workflow_stage_id": 100,
+        "position": 3,
+        "priority": "high",
+        "due_date": "2026-05-15T00:00:00Z",
+        "tags": "release,urgent",
+        "assignees": [11, 22],
+    }
+    with respx.mock(assert_all_called=True) as router:
+        route = router.post(TASKS_URL).mock(return_value=httpx.Response(201, json=response_payload))
+        task = await create_task(
+            name="Ship the thing",
+            board_id=7,
+            description="Cut a release once CI is green.",
+            lane_id=100,
+            position=3,
+            assignees=[11, 22],
+            due_date="2026-05-15T00:00:00Z",
+            priority="high",
+            tags="release,urgent",
+        )
+
+    body = _request_body(route)
+    inner = body["task"]
+    assert isinstance(inner, dict)
+    assert inner == {
+        "name": "Ship the thing",
+        "board_id": 7,
+        "description": "Cut a release once CI is green.",
+        "workflow_stage_id": 100,
+        "position": 3,
+        "assignees": [11, 22],
+        "due_date": "2026-05-15T00:00:00Z",
+        "priority": "high",
+        "tags": "release,urgent",
+    }
+    assert "lane_id" not in inner
+
+    # Round-trip: the response is parsed back into a Task with the same alias.
+    assert task.id == 4242
+    assert task.name == "Ship the thing"
+    assert task.lane_id == 100
+    assert task.board_id == 7
+    assert task.priority == "high"
+    assert task.due_date == "2026-05-15T00:00:00Z"
+    assert task.tags == "release,urgent"
+    assert task.assignees == [11, 22]
+
+
+async def test_create_task_unset_optionals_omitted_not_nulled(
+    _inject_client: KanbanToolClient,
+) -> None:
+    """Fields the caller didn't pass must be absent from the body, not sent
+    as ``null`` (Kanban Tool may interpret null as an explicit clear)."""
+    with respx.mock(assert_all_called=True) as router:
+        route = router.post(TASKS_URL).mock(
+            return_value=httpx.Response(201, json={"id": 1, "name": "x", "board_id": 2})
+        )
+        await create_task(name="x", board_id=2)
+
+    inner = _request_body(route)["task"]
+    assert isinstance(inner, dict)
+    for absent_key in (
+        "description",
+        "workflow_stage_id",
+        "lane_id",
+        "position",
+        "assignees",
+        "due_date",
+        "priority",
+        "tags",
+    ):
+        assert absent_key not in inner
+
+
+async def test_create_task_422_field_errors_parsed(_inject_client: KanbanToolClient) -> None:
+    error_body = {"errors": {"name": ["can't be blank"], "board_id": ["not found"]}}
+    with respx.mock() as router:
+        router.post(TASKS_URL).mock(
+            return_value=httpx.Response(422, json=error_body),
+        )
+        with pytest.raises(KanbanToolValidationError) as exc_info:
+            await create_task(name="", board_id=7)
+
+    err = exc_info.value
+    assert err.status_code == 422
+    assert err.field_errors == {
+        "name": ["can't be blank"],
+        "board_id": ["not found"],
+    }
+    assert err.body_excerpt
+    # __str__ renders compactly so callers logging the exception get the gist.
+    rendered = str(err)
+    assert "name: can't be blank" in rendered
+    assert "board_id: not found" in rendered
+
+
+async def test_create_task_422_is_also_caught_as_http_error(
+    _inject_client: KanbanToolClient,
+) -> None:
+    """Subclassing ``KanbanToolHTTPError`` keeps existing handlers working."""
+    with respx.mock() as router:
+        router.post(TASKS_URL).mock(
+            return_value=httpx.Response(422, json={"errors": {"name": ["blank"]}}),
+        )
+        with pytest.raises(KanbanToolHTTPError) as exc_info:
+            await create_task(name="", board_id=7)
+    # Specifically a validation error, not the bare base class.
+    assert isinstance(exc_info.value, KanbanToolValidationError)
+
+
+async def test_create_task_422_non_json_body_falls_back(
+    _inject_client: KanbanToolClient,
+) -> None:
+    with respx.mock() as router:
+        router.post(TASKS_URL).mock(
+            return_value=httpx.Response(422, text="<html>nope</html>"),
+        )
+        with pytest.raises(KanbanToolValidationError) as exc_info:
+            await create_task(name="", board_id=7)
+
+    err = exc_info.value
+    assert err.status_code == 422
+    assert err.field_errors == {}
+    assert "<html>" in err.body_excerpt
+
+
+async def test_create_task_422_body_scrubs_bearer_token(
+    _inject_client: KanbanToolClient,
+) -> None:
+    """Even on a validation error, the surfaced excerpt must not echo a
+    leaked bearer token from an upstream proxy/WAF."""
+    leak = "Authorization: Bearer leaked-token-secret-xyz failed"
+    with respx.mock() as router:
+        router.post(TASKS_URL).mock(return_value=httpx.Response(422, text=leak))
+        with pytest.raises(KanbanToolValidationError) as exc_info:
+            await create_task(name="", board_id=7)
+    assert "leaked-token-secret-xyz" not in exc_info.value.body_excerpt
+    assert "Bearer ***" in exc_info.value.body_excerpt
+
+
+async def test_create_task_404_raises_http_error(_inject_client: KanbanToolClient) -> None:
+    with respx.mock() as router:
+        router.post(TASKS_URL).mock(
+            return_value=httpx.Response(404, text="board not found"),
+        )
+        with pytest.raises(KanbanToolHTTPError) as exc_info:
+            await create_task(name="x", board_id=999999)
+    assert exc_info.value.status_code == 404
+    assert "not found" in exc_info.value.body_excerpt
+    # 404 must NOT be promoted to a validation error.
+    assert not isinstance(exc_info.value, KanbanToolValidationError)
+
+
+async def test_create_task_401_raises_permission_error(
+    _inject_client: KanbanToolClient,
+) -> None:
+    with respx.mock() as router:
+        router.post(TASKS_URL).mock(
+            return_value=httpx.Response(401, text="unauthorized"),
+        )
+        with pytest.raises(KanbanToolPermissionError):
+            await create_task(name="x", board_id=7)
+
+
+async def test_create_task_url_shape(_inject_client: KanbanToolClient) -> None:
+    """POST hits ``tasks.json`` exactly — no ``tasks.json.json`` double-suffix,
+    no ``tasks/.json``, no query string."""
+    with respx.mock(assert_all_called=True) as router:
+        route = router.post(TASKS_URL).mock(
+            return_value=httpx.Response(201, json={"id": 1, "name": "x", "board_id": 2})
+        )
+        await create_task(name="x", board_id=2)
+
+    request = route.calls.last.request
+    assert request.method == "POST"
+    assert str(request.url) == TASKS_URL

--- a/tests/test_create_task.py
+++ b/tests/test_create_task.py
@@ -190,6 +190,35 @@ async def test_create_task_422_body_scrubs_bearer_token(
     assert "Bearer ***" in exc_info.value.body_excerpt
 
 
+async def test_create_task_422_field_errors_scrub_bearer_token(
+    _inject_client: KanbanToolClient,
+) -> None:
+    """A bearer token leaked inside a 422 JSON field-error message must be
+    scrubbed out of ``field_errors`` and the rendered ``__str__`` — covers the
+    JSON-decoded path, not just the raw ``body_excerpt`` fallback."""
+    leaked_token = "leaked-token-foo-xyz"
+    error_body = {
+        "errors": {
+            "name": [f"can't be blank (Authorization: Bearer {leaked_token})"],
+        }
+    }
+    with respx.mock() as router:
+        router.post(TASKS_URL).mock(
+            return_value=httpx.Response(422, json=error_body),
+        )
+        with pytest.raises(KanbanToolValidationError) as exc_info:
+            await create_task(name="", board_id=7)
+
+    err = exc_info.value
+    rendered_field_errors = json.dumps(err.field_errors)
+    assert leaked_token not in rendered_field_errors
+    assert "Bearer ***" in rendered_field_errors
+
+    rendered = str(err)
+    assert leaked_token not in rendered
+    assert "Bearer ***" in rendered
+
+
 async def test_create_task_404_raises_http_error(_inject_client: KanbanToolClient) -> None:
     with respx.mock() as router:
         router.post(TASKS_URL).mock(


### PR DESCRIPTION
## Summary

- Adds the first M2 write tool: `create_task` (POST `/tasks.json`) — accepts `name`, `board_id`, plus optional `description`, `lane_id`, `position`, `assignees`, `due_date`, `priority`, `tags`. Body is wrapped as `{"task": {...}}`; unset optionals are omitted (the API may treat explicit nulls as clears); caller-facing `lane_id` maps to `workflow_stage_id` on the wire, mirroring the inbound alias on `Task`.
- New `KanbanToolValidationError` subclasses `KanbanToolHTTPError` so existing `except KanbanToolHTTPError` callers keep working. Carries a `field_errors: dict[str, list[str]]` parsed from the Rails-idiomatic `{"errors": {field: [msg, ...]}}` envelope, with graceful fallback to `{}` (and the scrubbed `body_excerpt`) when the body isn't JSON or has an unexpected shape.
- `client.request()` now delegates non-2xx handling to a dedicated `_raise_for_status(response, method, path)` helper. Sets up the pattern later M2 PRs will reuse and keeps `request()` focused on transport while error-shape policy lives in one place.

Establishes the M2 error-handling pattern; later M2 PRs build on these locked decisions.

Closes #8

## Test plan

- [x] `uv run ruff format --check .` passes
- [x] `uv run ruff check .` passes
- [x] `uv run ty check` passes
- [x] `uv run pytest` — 58/58 pass (10 new in `tests/test_create_task.py`)
- [x] New tests cover: minimal happy-path body shape, full-payload + `lane_id`→`workflow_stage_id` rename + `Task` round-trip, unset optionals absent (not null), 422 with parsed `field_errors`, 422 fallback (non-JSON), 422 `body_excerpt` scrubbing, 422-also-caught-as-HTTPError, 404, 401, URL shape (no double-suffix)
- [ ] CI green on GitHub