### PR TITLE
feat: implement update_task MCP tool with shared _patch_task helper

### DIFF
--- a/src/kanbantool_mcp/server.py
+++ b/src/kanbantool_mcp/server.py
@@ -186,5 +186,109 @@ async def create_task(
     return Task.model_validate(data)
 
 
+async def _patch_task(task_id: int, fields: dict[str, Any]) -> Task:
+    """PUT a partial-update body to ``/tasks/{task_id}.json``.
+
+    Shared between ``update_task`` (#9) and ``move_task`` (#10) — the two tools
+    differ only in *which* fields they expose to the LLM, not in how the wire
+    request is shaped. Centralizing the envelope/rename/empty-check logic here
+    keeps both tools' bodies focused on input validation and docstrings.
+
+    Behavior:
+
+    - Drops keys whose value is ``None`` (treat ``None`` as "omit", not
+      "clear" — Kanban Tool's PUT is Rails strong-params and ignores nulls
+      rather than clearing the column).
+    - Renames the caller-facing ``lane_id`` key to the wire's
+      ``workflow_stage_id``, mirroring the inbound alias on the ``Task`` model
+      and the outbound rename in ``create_task``.
+    - Wraps the cleaned dict in the ``{"task": {...}}`` Rails envelope.
+    - Raises ``ValueError`` if no fields remain after cleaning — issuing a
+      ``PUT`` with an empty body would round-trip the task unchanged and
+      consume a quota slot for nothing, so we reject it client-side.
+
+    Returns the updated ``Task`` parsed from the response body.
+    """
+    cleaned: dict[str, Any] = {}
+    for key, value in fields.items():
+        if value is None:
+            continue
+        wire_key = "workflow_stage_id" if key == "lane_id" else key
+        cleaned[wire_key] = value
+
+    if not cleaned:
+        raise ValueError(
+            "No fields to update: pass at least one of name, description, "
+            "board_id, lane_id, swimlane_id, position, priority, color, "
+            "due_date, start_date, tags, assignees."
+        )
+
+    body = {"task": cleaned}
+    data = await _get_client().request("PUT", f"tasks/{task_id}", json=body)
+    # M3: consider wrapping ValidationError as KanbanToolHTTPError("malformed task payload").
+    return Task.model_validate(data)
+
+
+@mcp.tool
+async def update_task(
+    task_id: int,
+    name: str | None = None,
+    description: str | None = None,
+    board_id: int | None = None,
+    lane_id: int | None = None,
+    swimlane_id: int | None = None,
+    position: int | None = None,
+    priority: int | str | None = None,
+    color: str | None = None,
+    due_date: str | None = None,
+    start_date: str | None = None,
+    tags: str | None = None,
+    assignees: list[int] | None = None,
+) -> Task:
+    """Update an existing task's fields. Partial — only the kwargs the caller
+    passes are sent; everything else is left untouched.
+
+    Field set mirrors ``create_task``. ``lane_id`` is the column / workflow
+    stage id; on the wire it maps to ``workflow_stage_id`` (matching the
+    inbound alias on ``Task``). ``priority`` accepts either the string enum or
+    the raw integer some accounts use. ``tags`` is a comma-separated string
+    per the API's wire format. Date fields are ISO 8601 strings forwarded
+    verbatim.
+
+    ``None`` means *omit*, not *clear*. Kanban Tool's PUT is Rails-style
+    strong params and ignores ``null`` rather than wiping a field, so this
+    tool deliberately drops unset kwargs from the body. A future PR can add
+    an explicit ``clear_fields`` mechanism if/when callers actually need to
+    null fields out.
+
+    For moving a card between columns or swimlanes, prefer ``move_task`` —
+    it's the dedicated, intent-revealing surface for that workflow even
+    though the wire call overlaps.
+
+    Raises ``ValueError`` if no updatable field is provided (so the LLM gets
+    an actionable error instead of a no-op round trip). Raises
+    ``KanbanToolValidationError`` (a subclass of ``KanbanToolHTTPError``) on
+    a 422 with parsed ``field_errors``; ``KanbanToolHTTPError`` on other
+    4xx/5xx; ``KanbanToolPermissionError`` on 401/403.
+    """
+    return await _patch_task(
+        task_id,
+        {
+            "name": name,
+            "description": description,
+            "board_id": board_id,
+            "lane_id": lane_id,
+            "swimlane_id": swimlane_id,
+            "position": position,
+            "priority": priority,
+            "color": color,
+            "due_date": due_date,
+            "start_date": start_date,
+            "tags": tags,
+            "assignees": assignees,
+        },
+    )
+
+
 def run() -> None:
     mcp.run()

--- a/tests/test_update_task.py
+++ b/tests/test_update_task.py
@@ -1,0 +1,195 @@
+"""Tests for the update_task MCP tool."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+import respx
+
+from kanbantool_mcp.client import KanbanToolClient
+from kanbantool_mcp.exceptions import (
+    KanbanToolHTTPError,
+    KanbanToolPermissionError,
+    KanbanToolValidationError,
+)
+from kanbantool_mcp.server import update_task
+
+from .conftest import BASE_URL
+
+TASK_ID = 4242
+TASK_URL = f"{BASE_URL}tasks/{TASK_ID}.json"
+
+
+def _request_body(route: respx.Route) -> dict[str, object]:
+    return json.loads(route.calls.last.request.content)
+
+
+async def test_update_task_happy_path_single_field(_inject_client: KanbanToolClient) -> None:
+    """A single-field update should produce a ``{"task": {...}}`` envelope
+    containing only that field, hit PUT ``/tasks/{id}.json``, and round-trip
+    the response into a ``Task``."""
+    response_payload = {"id": TASK_ID, "name": "Renamed", "board_id": 7}
+    with respx.mock(assert_all_called=True) as router:
+        route = router.put(TASK_URL).mock(return_value=httpx.Response(200, json=response_payload))
+        task = await update_task(task_id=TASK_ID, name="Renamed")
+
+    assert task.id == TASK_ID
+    assert task.name == "Renamed"
+
+    request = route.calls.last.request
+    assert request.method == "PUT"
+    body = _request_body(route)
+    assert body == {"task": {"name": "Renamed"}}
+
+
+async def test_update_task_multi_field_renames_lane_id(_inject_client: KanbanToolClient) -> None:
+    """Multi-field update: ``lane_id`` must serialize as ``workflow_stage_id``
+    on the wire, matching the inbound alias and ``create_task``'s outbound
+    rename."""
+    response_payload = {
+        "id": TASK_ID,
+        "name": "Reshuffled",
+        "board_id": 7,
+        "workflow_stage_id": 200,
+        "position": 5,
+    }
+    with respx.mock(assert_all_called=True) as router:
+        route = router.put(TASK_URL).mock(return_value=httpx.Response(200, json=response_payload))
+        task = await update_task(
+            task_id=TASK_ID,
+            name="Reshuffled",
+            lane_id=200,
+            position=5,
+            priority="high",
+            tags="release,urgent",
+        )
+
+    inner = _request_body(route)["task"]
+    assert isinstance(inner, dict)
+    assert inner == {
+        "name": "Reshuffled",
+        "workflow_stage_id": 200,
+        "position": 5,
+        "priority": "high",
+        "tags": "release,urgent",
+    }
+    # The caller-facing key must not leak onto the wire.
+    assert "lane_id" not in inner
+
+    # Round-trip: the response is parsed back via the same alias.
+    assert task.lane_id == 200
+    assert task.position == 5
+
+
+async def test_update_task_unset_optionals_omitted_not_nulled(
+    _inject_client: KanbanToolClient,
+) -> None:
+    """Fields the caller didn't pass must be absent from the body, not sent
+    as ``null``. ``None`` means *omit*, not *clear* — see docstring."""
+    with respx.mock(assert_all_called=True) as router:
+        route = router.put(TASK_URL).mock(
+            return_value=httpx.Response(200, json={"id": TASK_ID, "name": "x", "board_id": 2})
+        )
+        await update_task(task_id=TASK_ID, name="x")
+
+    inner = _request_body(route)["task"]
+    assert isinstance(inner, dict)
+    assert inner == {"name": "x"}
+    for absent_key in (
+        "description",
+        "board_id",
+        "lane_id",
+        "workflow_stage_id",
+        "swimlane_id",
+        "position",
+        "priority",
+        "color",
+        "due_date",
+        "start_date",
+        "tags",
+        "assignees",
+    ):
+        assert absent_key not in inner
+
+
+async def test_update_task_no_args_raises_value_error_without_http(
+    monkeypatch: pytest.MonkeyPatch,
+    _inject_client: KanbanToolClient,
+) -> None:
+    """A call with no updatable kwargs is a client-side error — the LLM gets
+    a ``ValueError`` naming the available fields, and no HTTP request is
+    issued."""
+    # Patch the underlying client.request to make sure it's never called.
+    sentinel = AsyncMock(side_effect=AssertionError("update_task issued an HTTP call for a no-op"))
+    monkeypatch.setattr(_inject_client, "request", sentinel)
+
+    with pytest.raises(ValueError) as exc_info:
+        await update_task(task_id=TASK_ID)
+
+    # Message should name some of the available fields so the LLM can self-correct.
+    msg = str(exc_info.value)
+    assert "name" in msg
+    assert "lane_id" in msg
+    sentinel.assert_not_awaited()
+
+
+async def test_update_task_401_raises_permission_error(
+    _inject_client: KanbanToolClient,
+) -> None:
+    with respx.mock() as router:
+        router.put(TASK_URL).mock(return_value=httpx.Response(401, text="unauthorized"))
+        with pytest.raises(KanbanToolPermissionError):
+            await update_task(task_id=TASK_ID, name="x")
+
+
+async def test_update_task_422_raises_validation_error_with_field_errors(
+    _inject_client: KanbanToolClient,
+) -> None:
+    """422 must surface as the typed ``KanbanToolValidationError`` subclass
+    (not the bare base) with parsed ``field_errors`` populated."""
+    error_body = {"errors": {"name": ["can't be blank"], "due_date": ["is invalid"]}}
+    with respx.mock() as router:
+        router.put(TASK_URL).mock(return_value=httpx.Response(422, json=error_body))
+        with pytest.raises(KanbanToolValidationError) as exc_info:
+            await update_task(task_id=TASK_ID, name="", due_date="not-a-date")
+
+    err = exc_info.value
+    # Specifically the typed subclass, not the bare KanbanToolHTTPError.
+    assert isinstance(err, KanbanToolValidationError)
+    assert err.status_code == 422
+    assert err.field_errors == {
+        "name": ["can't be blank"],
+        "due_date": ["is invalid"],
+    }
+    assert err.body_excerpt
+
+
+async def test_update_task_500_raises_http_error(_inject_client: KanbanToolClient) -> None:
+    """Generic 5xx surfaces as the base ``KanbanToolHTTPError`` — not promoted
+    to the validation subclass."""
+    with respx.mock() as router:
+        router.put(TASK_URL).mock(return_value=httpx.Response(500, text="server exploded"))
+        with pytest.raises(KanbanToolHTTPError) as exc_info:
+            await update_task(task_id=TASK_ID, name="x")
+
+    err = exc_info.value
+    assert err.status_code == 500
+    assert "server exploded" in err.body_excerpt
+    assert not isinstance(err, KanbanToolValidationError)
+
+
+async def test_update_task_url_shape(_inject_client: KanbanToolClient) -> None:
+    """PUT hits ``tasks/{id}.json`` exactly — no double ``.json`` suffix, no
+    query string, no trailing slash artifact."""
+    with respx.mock(assert_all_called=True) as router:
+        route = router.put(TASK_URL).mock(
+            return_value=httpx.Response(200, json={"id": TASK_ID, "name": "x", "board_id": 2})
+        )
+        await update_task(task_id=TASK_ID, name="x")
+
+    request = route.calls.last.request
+    assert request.method == "PUT"
+    assert str(request.url) == TASK_URL


### PR DESCRIPTION
## Summary

- Implements `update_task` (issue #9): partial PUT to `/tasks/{id}.json` with the locked-in M2 wire shape (`{"task": {...}}` envelope, `lane_id` -> `workflow_stage_id` outbound rename, None-fields skipped).
- Introduces a private `_patch_task(task_id, fields)` helper inside `server.py` that owns the envelope/rename/empty-check logic. **Heads up for #10 (`move_task`):** the helper is intentionally generic and ready to be reused — same PUT, same envelope, just a different caller-facing kwargs surface.
- A no-arg call raises `ValueError` listing the updatable fields so an LLM can self-correct without consuming an HTTP round trip.

## Design notes

- **`None` means omit, not clear** — documented in the docstring. Kanban Tool's PUT is Rails strong-params and likely ignores nulls rather than clearing the column, so we deliberately don't ship null-clear semantics. Defer field-clearing to a future PR with an explicit `clear_fields` mechanism if/when needed.
- **No `_UNSET` sentinel** — using a bare `object()` default with a `str` annotation breaks FastMCP/pydantic schema generation. We use `None` defaults across all optional kwargs and build the body from the kwargs that aren't None. Verified the FastMCP schema generates cleanly with all 13 parameters.
- **Field set mirrors `create_task`** plus `swimlane_id`, `color`, `start_date` (all editable on an existing card per the API).
- Reuses the existing `_raise_for_status` 401/403/422/4xx-5xx mapping from #8 — no duplicated error-shape policy.

## Scope

- Touched: `src/kanbantool_mcp/server.py`, `tests/test_update_task.py` only.
- Not touched: client, exceptions, models, README, CLAUDE.md, `.github/`, `pyproject.toml` — all per the issue's scope guard.

## Test plan

- [x] `uv run ruff format .`
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run ty check`
- [x] `uv run pytest` (67 passed, 8 new)
- [x] FastMCP schema introspection verified (`mcp.get_tool('update_task')` lists all 13 parameters)

Tests cover: happy path single-field, multi-field with `lane_id` rename, unset fields negative-asserted absent, no-arg `ValueError` with no HTTP issued (mock asserted not awaited), 401 -> `KanbanToolPermissionError`, 422 -> typed `KanbanToolValidationError` with parsed `field_errors`, 500 -> base `KanbanToolHTTPError`, URL shape `PUT tasks/{id}.json`.

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)