### PR TITLE
feat: implement archive_task MCP tool

### DIFF
--- a/src/kanbantool_mcp/server.py
+++ b/src/kanbantool_mcp/server.py
@@ -316,6 +316,10 @@ async def archive_task(task_id: int) -> Task:
     Raises ``KanbanToolHTTPError`` on 4xx/5xx (including a 404 if the task
     id is unknown), and ``KanbanToolPermissionError`` on 401/403.
     """
+    # Sentinel-action family on PATCH /tasks/{id}.json: "archive",
+    # "unarchive", "delete", "undelete". If we ever add unarchive_task /
+    # delete_task / restore_task, copy this 2-line shape — don't generalize
+    # into a helper until there's a second caller (YAGNI).
     body = {"_action": "archive"}
     data = await _get_client().request("PATCH", f"tasks/{task_id}", json=body)
     # M3: consider wrapping ValidationError as KanbanToolHTTPError("malformed task payload").

--- a/src/kanbantool_mcp/server.py
+++ b/src/kanbantool_mcp/server.py
@@ -290,5 +290,37 @@ async def update_task(
     )
 
 
+@mcp.tool
+async def archive_task(task_id: int) -> Task:
+    """Archive a task.
+
+    Archiving on Kanban Tool v3 is a sentinel-action call rather than a
+    field update: ``PATCH /tasks/{id}.json`` with the flat top-level body
+    ``{"_action": "archive"}``. It does NOT go through the standard
+    ``{"task": {...}}`` partial-update envelope, so this tool intentionally
+    bypasses ``_patch_task`` and shapes the request itself. The same
+    endpoint serves the symmetric ``unarchive``/``delete``/``undelete``
+    actions (not currently exposed as tools).
+
+    Idempotent by design: re-archiving an already-archived task issues
+    the same PATCH and returns the task in its archived state. The wire
+    is assumed to respond 200 with the archived ``Task`` regardless of
+    prior state — verify M3: confirm against a real account that
+    re-archiving returns 200 (not 4xx). If it does 4xx, add a status-only
+    fallback (e.g. 409/422 → ``GET /tasks/{id}.json``) — never branch on
+    response body wording, which is locale- and version-fragile.
+
+    Returns the archived ``Task`` so the caller can confirm
+    ``is_archived=True``.
+
+    Raises ``KanbanToolHTTPError`` on 4xx/5xx (including a 404 if the task
+    id is unknown), and ``KanbanToolPermissionError`` on 401/403.
+    """
+    body = {"_action": "archive"}
+    data = await _get_client().request("PATCH", f"tasks/{task_id}", json=body)
+    # M3: consider wrapping ValidationError as KanbanToolHTTPError("malformed task payload").
+    return Task.model_validate(data)
+
+
 def run() -> None:
     mcp.run()

--- a/tests/test_archive_task.py
+++ b/tests/test_archive_task.py
@@ -1,0 +1,109 @@
+"""Tests for the archive_task MCP tool."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+import respx
+
+from kanbantool_mcp.client import KanbanToolClient
+from kanbantool_mcp.exceptions import KanbanToolHTTPError, KanbanToolPermissionError
+from kanbantool_mcp.server import archive_task
+
+from .conftest import BASE_URL
+
+TASK_ID = 4242
+TASK_URL = f"{BASE_URL}tasks/{TASK_ID}.json"
+
+
+def _request_body(route: respx.Route) -> dict[str, object]:
+    return json.loads(route.calls.last.request.content)
+
+
+async def test_archive_task_happy_path(_inject_client: KanbanToolClient) -> None:
+    """Archiving a task issues PATCH /tasks/{id}.json with the flat
+    ``{"_action": "archive"}`` sentinel body — NOT the ``{"task": {...}}``
+    envelope used by update_task — and round-trips the response into a
+    ``Task`` with ``is_archived=True``."""
+    response_payload = {
+        "id": TASK_ID,
+        "name": "Wrap up Q2 release",
+        "board_id": 7,
+        "is_archived": True,
+    }
+    with respx.mock(assert_all_called=True) as router:
+        route = router.patch(TASK_URL).mock(return_value=httpx.Response(200, json=response_payload))
+        task = await archive_task(task_id=TASK_ID)
+
+    assert task.id == TASK_ID
+    assert task.is_archived is True
+
+    request = route.calls.last.request
+    assert request.method == "PATCH"
+    body = _request_body(route)
+    # Flat top-level sentinel — no "task" envelope, no "is_archived" field.
+    assert body == {"_action": "archive"}
+    assert "task" not in body
+
+
+async def test_archive_task_already_archived_is_idempotent(
+    _inject_client: KanbanToolClient,
+) -> None:
+    """Re-archiving an already-archived task must not error. The API is
+    assumed to return 200 with the task in its archived state regardless
+    of prior state, so the call shape is identical to the happy path."""
+    response_payload = {
+        "id": TASK_ID,
+        "name": "Already done",
+        "board_id": 7,
+        "is_archived": True,
+    }
+    with respx.mock(assert_all_called=True) as router:
+        route = router.patch(TASK_URL).mock(return_value=httpx.Response(200, json=response_payload))
+        # Two consecutive archives — neither raises.
+        first = await archive_task(task_id=TASK_ID)
+        second = await archive_task(task_id=TASK_ID)
+
+    assert first.is_archived is True
+    assert second.is_archived is True
+    assert len(route.calls) == 2
+    # Second call body is identical to the first — idempotent on the wire.
+    assert _request_body(route) == {"_action": "archive"}
+
+
+async def test_archive_task_404_raises_http_error(_inject_client: KanbanToolClient) -> None:
+    """A 404 (unknown task id) surfaces as the base ``KanbanToolHTTPError``."""
+    with respx.mock() as router:
+        router.patch(TASK_URL).mock(return_value=httpx.Response(404, text="task not found"))
+        with pytest.raises(KanbanToolHTTPError) as exc_info:
+            await archive_task(task_id=TASK_ID)
+
+    assert exc_info.value.status_code == 404
+    assert "task not found" in exc_info.value.body_excerpt
+
+
+async def test_archive_task_401_raises_permission_error(
+    _inject_client: KanbanToolClient,
+) -> None:
+    with respx.mock() as router:
+        router.patch(TASK_URL).mock(return_value=httpx.Response(401, text="unauthorized"))
+        with pytest.raises(KanbanToolPermissionError):
+            await archive_task(task_id=TASK_ID)
+
+
+async def test_archive_task_url_shape(_inject_client: KanbanToolClient) -> None:
+    """PATCH hits ``tasks/{id}.json`` exactly — no ``/archive`` path segment,
+    no double ``.json``, no query string, no trailing-slash artifact."""
+    with respx.mock(assert_all_called=True) as router:
+        route = router.patch(TASK_URL).mock(
+            return_value=httpx.Response(
+                200, json={"id": TASK_ID, "name": "x", "board_id": 2, "is_archived": True}
+            )
+        )
+        await archive_task(task_id=TASK_ID)
+
+    request = route.calls.last.request
+    assert request.method == "PATCH"
+    assert str(request.url) == TASK_URL


### PR DESCRIPTION
## Summary

Implements `archive_task` (M2 #11). Kanban Tool v3's archive endpoint is a **sentinel-action call** — `PATCH /tasks/{id}.json` with `{"_action": "archive"}` — not a field update on the standard partial-update envelope. The tool shapes that request itself and bypasses `_patch_task` (which stays untouched).

- **Endpoint:** `PATCH /tasks/{id}.json`, flat body `{"_action": "archive"}`, no `{"task": {...}}` envelope.
- **Sentinel-action family** (precedent for future tools): the same endpoint serves `"archive"` / `"unarchive"` / `"delete"` / `"undelete"`. If we add `unarchive_task` / `delete_task` / `restore_task` in M3, copy this 2-line shape — don't generalize into a helper until there's a second caller. Both the docstring and an inline comment at the call site name the family explicitly so future contributors find the precedent.
- **Idempotency:** delegated to the wire — re-archiving issues the same PATCH and is assumed to return 200 with the archived task. Docstring carries a `# verify M3:` note pointing at a status-code-only fallback (never body-regex matching) if real-account testing shows 4xx on re-archive.
- **Plan-review approaches** (A) `_patch_task(is_archived=True)` and (B) dedicated `/archive.json` endpoint were both ruled out after checking the v3 docs — neither matches the actual API. Cross-cutting context relayed to `team-lead` and `move-task-author` (no impact on `move_task`).

## Test plan

- [x] `uv run ruff format --check .`
- [x] `uv run ruff check .`
- [x] `uv run ty check`
- [x] `uv run pytest` — 72 passed
- [x] `tests/test_archive_task.py` covers: happy-path body/method/URL shape, idempotent re-archive (two consecutive calls), 404 → `KanbanToolHTTPError`, 401 → `KanbanToolPermissionError`, exact URL shape (no `/archive` segment, no double `.json`).
- [ ] Live-account verify (M3): confirm re-archive returns 200, otherwise add a status-code-only GET fallback.

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)