### PR TITLE
feat: implement move_task MCP tool

### DIFF
--- a/src/kanbantool_mcp/server.py
+++ b/src/kanbantool_mcp/server.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any
+from typing import Any, Literal
 
 from fastmcp import FastMCP
 
@@ -186,8 +186,23 @@ async def create_task(
     return Task.model_validate(data)
 
 
-async def _patch_task(task_id: int, fields: dict[str, Any]) -> Task:
-    """PUT a partial-update body to ``/tasks/{task_id}.json``.
+# Caller-facing aliases mapped to their wire names. ``lane_id`` and
+# ``column_id`` are both ergonomic surfaces for the same wire field
+# (``workflow_stage_id``); ``update_task`` exposes ``lane_id`` and
+# ``move_task`` exposes ``column_id``, so the helper accepts either.
+_PATCH_TASK_RENAMES: dict[str, str] = {
+    "lane_id": "workflow_stage_id",
+    "column_id": "workflow_stage_id",
+}
+
+
+async def _patch_task(
+    task_id: int,
+    fields: dict[str, Any],
+    *,
+    method: Literal["PUT", "PATCH"] = "PUT",
+) -> Task:
+    """Send a partial-update body to ``/tasks/{task_id}.json``.
 
     Shared between ``update_task`` (#9) and ``move_task`` (#10) — the two tools
     differ only in *which* fields they expose to the LLM, not in how the wire
@@ -197,15 +212,23 @@ async def _patch_task(task_id: int, fields: dict[str, Any]) -> Task:
     Behavior:
 
     - Drops keys whose value is ``None`` (treat ``None`` as "omit", not
-      "clear" — Kanban Tool's PUT is Rails strong-params and ignores nulls
-      rather than clearing the column).
-    - Renames the caller-facing ``lane_id`` key to the wire's
-      ``workflow_stage_id``, mirroring the inbound alias on the ``Task`` model
+      "clear" — Kanban Tool's partial update ignores nulls rather than
+      clearing the column).
+    - Renames caller-facing aliases to their wire names per
+      ``_PATCH_TASK_RENAMES`` (e.g. ``lane_id``/``column_id`` →
+      ``workflow_stage_id``), mirroring the inbound alias on the ``Task`` model
       and the outbound rename in ``create_task``.
     - Wraps the cleaned dict in the ``{"task": {...}}`` Rails envelope.
-    - Raises ``ValueError`` if no fields remain after cleaning — issuing a
-      ``PUT`` with an empty body would round-trip the task unchanged and
-      consume a quota slot for nothing, so we reject it client-side.
+    - Raises ``ValueError`` if no fields remain after cleaning — issuing the
+      request with an empty body would round-trip the task unchanged and
+      consume a quota slot for nothing, so we reject it client-side. The
+      message lists the caller's *own* field names (built from ``fields``
+      before the None-skip pass), so each tool gets an actionable hint
+      scoped to its surface.
+
+    ``method`` selects between ``PUT`` (the default, used by ``update_task``)
+    and ``PATCH`` (used by ``move_task``, matching the Kanban Tool API v3
+    convention for partial updates). Both shapes are accepted by the API.
 
     Returns the updated ``Task`` parsed from the response body.
     """
@@ -213,18 +236,18 @@ async def _patch_task(task_id: int, fields: dict[str, Any]) -> Task:
     for key, value in fields.items():
         if value is None:
             continue
-        wire_key = "workflow_stage_id" if key == "lane_id" else key
+        wire_key = _PATCH_TASK_RENAMES.get(key, key)
         cleaned[wire_key] = value
 
     if not cleaned:
-        raise ValueError(
-            "No fields to update: pass at least one of name, description, "
-            "board_id, lane_id, swimlane_id, position, priority, color, "
-            "due_date, start_date, tags, assignees."
-        )
+        # Build the message from the caller's *original* field names so the
+        # error is scoped to whichever surface (update_task / move_task) the
+        # LLM actually called.
+        available = ", ".join(fields.keys())
+        raise ValueError(f"No fields to update: pass at least one of {available}.")
 
     body = {"task": cleaned}
-    data = await _get_client().request("PUT", f"tasks/{task_id}", json=body)
+    data = await _get_client().request(method, f"tasks/{task_id}", json=body)
     # M3: consider wrapping ValidationError as KanbanToolHTTPError("malformed task payload").
     return Task.model_validate(data)
 
@@ -287,6 +310,46 @@ async def update_task(
             "tags": tags,
             "assignees": assignees,
         },
+    )
+
+
+@mcp.tool
+async def move_task(
+    task_id: int,
+    column_id: int | None = None,
+    swimlane_id: int | None = None,
+    position: int | None = None,
+) -> Task:
+    """Move a task between columns, swimlanes, or positions on its board.
+
+    At least one of ``column_id`` / ``swimlane_id`` / ``position`` must be
+    provided; calling with all three unset raises ``ValueError`` before any
+    HTTP is issued.
+
+    There is no dedicated ``/move`` endpoint in Kanban Tool API v3 — column
+    and lane transitions are expressed as a partial update on the task. This
+    tool exists as a separate, intent-revealing surface so the LLM picks the
+    right tool for "move this card", and the implementation rides on the
+    same patch helper as ``update_task``.
+
+    ``column_id`` is the caller-facing alias for the wire's
+    ``workflow_stage_id`` (mirroring how ``lane_id`` is exposed elsewhere) —
+    pass the same id you'd see on a fetched ``Task.lane_id``.
+
+    Raises ``KanbanToolValidationError`` (a subclass of ``KanbanToolHTTPError``)
+    on a 422 with parsed ``field_errors`` — the typical case is a column id
+    that doesn't belong to this task's board, surfaced via the existing error
+    pipeline. Raises ``KanbanToolHTTPError`` on other 4xx/5xx;
+    ``KanbanToolPermissionError`` on 401/403.
+    """
+    return await _patch_task(
+        task_id,
+        {
+            "column_id": column_id,
+            "swimlane_id": swimlane_id,
+            "position": position,
+        },
+        method="PATCH",
     )
 
 

--- a/tests/test_move_task.py
+++ b/tests/test_move_task.py
@@ -1,0 +1,173 @@
+"""Tests for the move_task MCP tool."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+import respx
+
+from kanbantool_mcp.client import KanbanToolClient
+from kanbantool_mcp.exceptions import (
+    KanbanToolHTTPError,
+    KanbanToolPermissionError,
+    KanbanToolValidationError,
+)
+from kanbantool_mcp.server import move_task
+
+from .conftest import BASE_URL
+
+TASK_ID = 4242
+TASK_URL = f"{BASE_URL}tasks/{TASK_ID}.json"
+
+
+def _request_body(route: respx.Route) -> dict[str, object]:
+    return json.loads(route.calls.last.request.content)
+
+
+async def test_move_task_column_only_uses_patch(_inject_client: KanbanToolClient) -> None:
+    """A column-only move issues PATCH (not PUT) with a body containing only
+    ``workflow_stage_id`` — the caller-facing ``column_id`` alias is renamed
+    on the wire, mirroring the ``lane_id`` alias used by ``update_task``."""
+    response_payload = {"id": TASK_ID, "name": "Card", "workflow_stage_id": 100}
+    with respx.mock(assert_all_called=True) as router:
+        route = router.patch(TASK_URL).mock(return_value=httpx.Response(200, json=response_payload))
+        task = await move_task(task_id=TASK_ID, column_id=100)
+
+    assert task.id == TASK_ID
+    assert task.lane_id == 100
+
+    request = route.calls.last.request
+    assert request.method == "PATCH"
+    body = _request_body(route)
+    assert body == {"task": {"workflow_stage_id": 100}}
+    inner = body["task"]
+    assert isinstance(inner, dict)
+    # Caller-facing alias must not leak onto the wire.
+    assert "column_id" not in inner
+
+
+async def test_move_task_all_three_fields(_inject_client: KanbanToolClient) -> None:
+    """Passing column, swimlane, and position together produces a single
+    PATCH whose body carries all three (column_id renamed)."""
+    response_payload = {
+        "id": TASK_ID,
+        "name": "Card",
+        "workflow_stage_id": 200,
+        "swimlane_id": 9,
+        "position": 3,
+    }
+    with respx.mock(assert_all_called=True) as router:
+        route = router.patch(TASK_URL).mock(return_value=httpx.Response(200, json=response_payload))
+        task = await move_task(task_id=TASK_ID, column_id=200, swimlane_id=9, position=3)
+
+    inner = _request_body(route)["task"]
+    assert isinstance(inner, dict)
+    assert inner == {
+        "workflow_stage_id": 200,
+        "swimlane_id": 9,
+        "position": 3,
+    }
+    assert task.lane_id == 200
+    assert task.swimlane_id == 9
+    assert task.position == 3
+
+
+async def test_move_task_unset_fields_omitted(_inject_client: KanbanToolClient) -> None:
+    """Fields the caller didn't pass must be absent from the body, not sent
+    as ``null``. ``None`` means *omit* — the helper drops them before the
+    envelope is built."""
+    with respx.mock(assert_all_called=True) as router:
+        route = router.patch(TASK_URL).mock(
+            return_value=httpx.Response(200, json={"id": TASK_ID, "name": "Card", "position": 7})
+        )
+        await move_task(task_id=TASK_ID, position=7)
+
+    inner = _request_body(route)["task"]
+    assert isinstance(inner, dict)
+    assert inner == {"position": 7}
+    for absent_key in ("column_id", "workflow_stage_id", "swimlane_id"):
+        assert absent_key not in inner
+
+
+async def test_move_task_no_args_raises_value_error_without_http(
+    monkeypatch: pytest.MonkeyPatch,
+    _inject_client: KanbanToolClient,
+) -> None:
+    """All-None call is a client-side error — no HTTP issued, message names
+    *this tool's* fields (not update_task's full list), so the LLM gets an
+    actionable hint scoped to the move surface."""
+    sentinel = AsyncMock(side_effect=AssertionError("move_task issued an HTTP call for a no-op"))
+    monkeypatch.setattr(_inject_client, "request", sentinel)
+
+    with pytest.raises(ValueError) as exc_info:
+        await move_task(task_id=TASK_ID)
+
+    msg = str(exc_info.value)
+    # Each of move_task's caller-facing fields should be named.
+    assert "column_id" in msg
+    assert "swimlane_id" in msg
+    assert "position" in msg
+    # Fields that belong to update_task only must not bleed into this message.
+    # Match against the field-list tokens (split on commas) so substring noise
+    # from neighboring names — e.g. ``lane_id`` occurring inside
+    # ``swimlane_id`` — doesn't trigger a false positive.
+    listed = {token.strip().rstrip(".") for token in msg.split(":", 1)[1].split(",")}
+    assert "name" not in listed
+    assert "lane_id" not in listed
+    assert "description" not in listed
+    sentinel.assert_not_awaited()
+
+
+async def test_move_task_404_raises_http_error(_inject_client: KanbanToolClient) -> None:
+    """404 (task does not exist) surfaces as the base ``KanbanToolHTTPError``,
+    not the validation subclass."""
+    with respx.mock() as router:
+        router.patch(TASK_URL).mock(return_value=httpx.Response(404, text="not found"))
+        with pytest.raises(KanbanToolHTTPError) as exc_info:
+            await move_task(task_id=TASK_ID, column_id=100)
+
+    err = exc_info.value
+    assert err.status_code == 404
+    assert not isinstance(err, KanbanToolValidationError)
+
+
+async def test_move_task_422_raises_validation_error(_inject_client: KanbanToolClient) -> None:
+    """422 (typically: target column doesn't belong to this task's board) must
+    surface as the typed ``KanbanToolValidationError`` subclass with parsed
+    ``field_errors``."""
+    error_body = {"errors": {"workflow_stage_id": ["is not a valid stage on this board"]}}
+    with respx.mock() as router:
+        router.patch(TASK_URL).mock(return_value=httpx.Response(422, json=error_body))
+        with pytest.raises(KanbanToolValidationError) as exc_info:
+            await move_task(task_id=TASK_ID, column_id=999999)
+
+    err = exc_info.value
+    assert isinstance(err, KanbanToolValidationError)
+    assert err.status_code == 422
+    assert err.field_errors == {
+        "workflow_stage_id": ["is not a valid stage on this board"],
+    }
+
+
+async def test_move_task_401_raises_permission_error(_inject_client: KanbanToolClient) -> None:
+    with respx.mock() as router:
+        router.patch(TASK_URL).mock(return_value=httpx.Response(401, text="unauthorized"))
+        with pytest.raises(KanbanToolPermissionError):
+            await move_task(task_id=TASK_ID, column_id=100)
+
+
+async def test_move_task_url_shape(_inject_client: KanbanToolClient) -> None:
+    """PATCH hits ``tasks/{id}.json`` exactly — no double ``.json`` suffix, no
+    query string, no trailing slash artifact."""
+    with respx.mock(assert_all_called=True) as router:
+        route = router.patch(TASK_URL).mock(
+            return_value=httpx.Response(200, json={"id": TASK_ID, "name": "Card"})
+        )
+        await move_task(task_id=TASK_ID, column_id=100)
+
+    request = route.calls.last.request
+    assert request.method == "PATCH"
+    assert str(request.url) == TASK_URL

--- a/tests/test_update_task.py
+++ b/tests/test_update_task.py
@@ -129,10 +129,32 @@ async def test_update_task_no_args_raises_value_error_without_http(
     with pytest.raises(ValueError) as exc_info:
         await update_task(task_id=TASK_ID)
 
-    # Message should name some of the available fields so the LLM can self-correct.
+    # Message should name *every* available field so the LLM can self-correct.
+    # The list is built dynamically from the helper's ``fields`` dict; pinning
+    # all 12 names here catches a regression where a future caller (e.g.
+    # ``move_task``) accidentally widens this message back to a hardcoded
+    # superset of its own surface.
     msg = str(exc_info.value)
-    assert "name" in msg
-    assert "lane_id" in msg
+    for expected in (
+        "name",
+        "description",
+        "board_id",
+        "lane_id",
+        "swimlane_id",
+        "position",
+        "priority",
+        "color",
+        "due_date",
+        "start_date",
+        "tags",
+        "assignees",
+    ):
+        assert expected in msg, f"update_task ValueError message missing '{expected}': {msg!r}"
+    # The wire-only name must not surface to the LLM — they call ``lane_id``.
+    assert "workflow_stage_id" not in msg
+    # ``column_id`` belongs to ``move_task``'s surface only; it must not bleed
+    # into this message.
+    assert "column_id" not in msg
     sentinel.assert_not_awaited()
 
 


### PR DESCRIPTION
## Summary

- New `move_task(task_id, column_id?, swimlane_id?, position?) -> Task` MCP tool. Closes #10.
- The tool is a thin wrapper that delegates to `_patch_task` with `method="PATCH"` (the API v3 convention for partial updates) — no dedicated `/move` endpoint exists in v3, so the wire call is a column/lane patch. The separate tool exists so the LLM picks the right verb and the docstring stays scoped to the move workflow.
- 422 (typically: target column is not on this board) flows through the existing `_raise_for_status` pipeline and surfaces as the typed `KanbanToolValidationError` subclass with parsed `field_errors`.

## `_patch_task` interface change (heads-up for reviewers)

This PR iterates the M2 helper pattern set in #40/#41. Three small, additive changes — `update_task`'s public behavior is unchanged, but the helper signature and internals shifted, so callout for anyone diffing the helper:

- **New parameter:** `_patch_task(task_id, fields, *, method: Literal["PUT","PATCH"] = "PUT")`. Default keeps `update_task`'s PUT path verbatim; `move_task` passes `method="PATCH"` per the API v3 partial-update convention. Keyword-only to keep call sites self-documenting.
- **Rename map replaces the inline `lane_id` rename:** new module-level `_PATCH_TASK_RENAMES = {"lane_id": "workflow_stage_id", "column_id": "workflow_stage_id"}`. Both ergonomic caller-facing aliases collapse to the same wire field. Future tools that want a similar alias add an entry to the map rather than special-casing in their own body.
- **`ValueError` message is now built from `fields.keys()` before the None-skip pass.** Previously hardcoded to `update_task`'s 12-field list, which would mislead the LLM when a 3-field caller (`move_task`) hit the helper. Now each tool gets a message scoped to its own surface — `update_task`'s still lists all 12; `move_task`'s lists 3. Addresses the #41 review nit.

None of this changes the wire body shape or `update_task`'s observable behavior. Pinned by tests on both sides.

## Test plan

- [x] `tests/test_move_task.py` — happy path column-only PATCH (asserts method, exact URL, body `{"task": {"workflow_stage_id": 100}}`, and that `column_id` does not leak onto the wire); all-three-fields move; None-fields omitted (negative assertion); all-None call → `ValueError` with a scoped message *and* no HTTP issued; 404 → `KanbanToolHTTPError`; 422 → typed `KanbanToolValidationError`; 401 → `KanbanToolPermissionError`; URL shape.
- [x] `tests/test_update_task.py` — the existing no-op test is tightened to pin all 12 field names from the dynamic message, so a future regression that re-narrows the message gets caught. Also asserts that wire-only names (`workflow_stage_id`) and `move_task`-only names (`column_id`) do not leak into `update_task`'s message.
- [x] `uv run ruff format .`, `uv run ruff check .`, `uv run ruff format --check .`, `uv run ty check`, `uv run pytest` — all green locally (75 passed); CI green on 3.11/3.12/3.13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)