### PR TITLE
feat: implement list_subtasks and add_subtask MCP tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,6 @@ Read tools (M1):
 - `search_tasks`
 - `get_task`
 - `recent_changes`
-- `list_subtasks`
 
 Write tools (M2):
 - `create_task`
@@ -35,6 +34,7 @@ Write tools (M2):
 - `archive_task`
 - `add_comment`
 - `add_subtask`
+- `list_subtasks`
 
 ## Kanban Tool API quirks
 
@@ -48,8 +48,8 @@ Write tools (M2):
 ## Phases
 
 - **M0** — Scaffold: package layout, CI, license, docs (this commit).
-- **M1** — Read tools: list_boards, get_board, search_tasks, get_task, recent_changes, list_subtasks.
-- **M2** — Write tools: create_task, update_task, move_task, archive_task, add_comment, add_subtask.
+- **M1** — Read tools: list_boards, get_board, search_tasks, get_task, recent_changes.
+- **M2** — Write tools: create_task, update_task, move_task, archive_task, add_comment, add_subtask, list_subtasks.
 - **M3** — Polish & release: error messages, retries, docs pass, PyPI publish.
 
 ## Testing

--- a/src/kanbantool_mcp/models.py
+++ b/src/kanbantool_mcp/models.py
@@ -104,6 +104,24 @@ class Task(BaseModel):
     updated_at: str | None = None
 
 
+class Subtask(BaseModel):
+    """A subtask attached to a task.
+
+    Mirrors the GET/POST ``/tasks/{id}/subtasks.json`` payload. ``name`` is
+    the API-native field — kept verbatim rather than aliased to ``title`` so
+    there's no rename to maintain on either edge.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    id: int
+    name: str
+    is_completed: bool | None = None
+    completed_at: str | None = None
+    position: int | None = None
+    # M3: consider wrapping ValidationError as KanbanToolHTTPError("malformed subtask payload").
+
+
 class ChangelogEntry(BaseModel):
     """A single entry from a board's changelog feed.
 

--- a/src/kanbantool_mcp/server.py
+++ b/src/kanbantool_mcp/server.py
@@ -9,7 +9,7 @@ from fastmcp import FastMCP
 
 from .client import KanbanToolClient
 from .config import Config
-from .models import Board, ChangelogEntry, Task
+from .models import Board, ChangelogEntry, Subtask, Task
 
 mcp: FastMCP = FastMCP("kanbantool-mcp")
 
@@ -288,6 +288,41 @@ async def update_task(
             "assignees": assignees,
         },
     )
+
+
+@mcp.tool
+async def list_subtasks(task_id: int) -> list[Subtask]:
+    """List subtasks attached to a task.
+
+    Returns each subtask's id, name, completion state, and position. Returns
+    an empty list if the task has no subtasks (or if the API returns a body
+    without a ``subtasks`` key — defensive parse mirroring ``list_boards``).
+    """
+    data = await _get_client().request("GET", f"tasks/{task_id}/subtasks")
+    raw = data.get("subtasks", []) if isinstance(data, dict) else []
+    # M3: consider wrapping ValidationError as KanbanToolHTTPError("malformed subtasks payload").
+    return [Subtask.model_validate(s) for s in raw]
+
+
+@mcp.tool
+async def add_subtask(task_id: int, title: str) -> Subtask:
+    """Add a subtask to a task.
+
+    ``title`` is the human-readable label for the subtask; it maps to the
+    API's ``name`` field on the wire. The kwarg is exposed as ``title`` to
+    keep the LLM-facing surface consistent regardless of upstream naming.
+
+    Raises ``KanbanToolValidationError`` (a subclass of ``KanbanToolHTTPError``)
+    on a 422 with parsed ``field_errors``; ``KanbanToolHTTPError`` on other
+    4xx/5xx; ``KanbanToolPermissionError`` on 401/403.
+    """
+    body = {"subtask": {"name": title}}
+    data = await _get_client().request("POST", f"tasks/{task_id}/subtasks", json=body)
+    # Trusting the bare-object response shape (mirrors get_task on main); no
+    # defensive ``{"subtask": {...}}`` unwrap. M3 can revisit if the API ever
+    # surprises us.
+    # M3: consider wrapping ValidationError as KanbanToolHTTPError("malformed subtask payload").
+    return Subtask.model_validate(data)
 
 
 def run() -> None:

--- a/tests/test_subtasks.py
+++ b/tests/test_subtasks.py
@@ -1,0 +1,191 @@
+"""Tests for the list_subtasks and add_subtask MCP tools."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+import respx
+
+from kanbantool_mcp.client import KanbanToolClient
+from kanbantool_mcp.exceptions import (
+    KanbanToolHTTPError,
+    KanbanToolPermissionError,
+    KanbanToolValidationError,
+)
+from kanbantool_mcp.server import add_subtask, list_subtasks
+
+from .conftest import BASE_URL
+
+TASK_ID = 42
+SUBTASKS_URL = f"{BASE_URL}tasks/{TASK_ID}/subtasks.json"
+
+
+def _request_body(route: respx.Route) -> dict[str, object]:
+    return json.loads(route.calls.last.request.content)
+
+
+# ---------------------------------------------------------------------------
+# list_subtasks
+# ---------------------------------------------------------------------------
+
+
+async def test_list_subtasks_happy_path(_inject_client: KanbanToolClient) -> None:
+    """A two-element ``subtasks`` array — one fully populated, one minimal —
+    should round-trip into the typed model with optional fields defaulting to
+    ``None`` on the minimal entry."""
+    payload = {
+        "subtasks": [
+            {
+                "id": 1,
+                "name": "Write spec",
+                "is_completed": True,
+                "completed_at": "2026-04-29T10:00:00Z",
+                "position": 1,
+                "extra_unknown_field": "ignored",
+            },
+            {"id": 2, "name": "Review PR"},
+        ]
+    }
+    with respx.mock(assert_all_called=True) as router:
+        router.get(SUBTASKS_URL).mock(return_value=httpx.Response(200, json=payload))
+        result = await list_subtasks(TASK_ID)
+
+    assert len(result) == 2
+    first, second = result
+    assert first.id == 1
+    assert first.name == "Write spec"
+    assert first.is_completed is True
+    assert first.completed_at == "2026-04-29T10:00:00Z"
+    assert first.position == 1
+
+    assert second.id == 2
+    assert second.name == "Review PR"
+    assert second.is_completed is None
+    assert second.completed_at is None
+    assert second.position is None
+
+
+async def test_list_subtasks_empty(_inject_client: KanbanToolClient) -> None:
+    with respx.mock(assert_all_called=True) as router:
+        router.get(SUBTASKS_URL).mock(return_value=httpx.Response(200, json={"subtasks": []}))
+        result = await list_subtasks(TASK_ID)
+
+    assert result == []
+
+
+async def test_list_subtasks_missing_key(_inject_client: KanbanToolClient) -> None:
+    """Defensive parse: a dict without a ``subtasks`` key returns ``[]`` rather
+    than raising — mirrors ``list_boards`` so an unfamiliar wire shape doesn't
+    blow up the tool."""
+    with respx.mock(assert_all_called=True) as router:
+        router.get(SUBTASKS_URL).mock(return_value=httpx.Response(200, json={"unrelated": "shape"}))
+        result = await list_subtasks(TASK_ID)
+
+    assert result == []
+
+
+async def test_list_subtasks_url_shape(_inject_client: KanbanToolClient) -> None:
+    """GET hits ``tasks/{id}/subtasks.json`` exactly — no double-suffix, no
+    trailing slash, no query string."""
+    with respx.mock(assert_all_called=True) as router:
+        route = router.get(SUBTASKS_URL).mock(
+            return_value=httpx.Response(200, json={"subtasks": []})
+        )
+        await list_subtasks(TASK_ID)
+
+    request = route.calls.last.request
+    assert request.method == "GET"
+    assert str(request.url) == SUBTASKS_URL
+
+
+async def test_list_subtasks_404_raises_http_error(_inject_client: KanbanToolClient) -> None:
+    with respx.mock() as router:
+        router.get(SUBTASKS_URL).mock(return_value=httpx.Response(404, text="task not found"))
+        with pytest.raises(KanbanToolHTTPError) as exc_info:
+            await list_subtasks(TASK_ID)
+    assert exc_info.value.status_code == 404
+
+
+async def test_list_subtasks_401_raises_permission_error(
+    _inject_client: KanbanToolClient,
+) -> None:
+    with respx.mock() as router:
+        router.get(SUBTASKS_URL).mock(return_value=httpx.Response(401, text="unauthorized"))
+        with pytest.raises(KanbanToolPermissionError):
+            await list_subtasks(TASK_ID)
+
+
+# ---------------------------------------------------------------------------
+# add_subtask
+# ---------------------------------------------------------------------------
+
+
+async def test_add_subtask_happy_path(_inject_client: KanbanToolClient) -> None:
+    """Body must be the ``{"subtask": {"name": ...}}`` Rails envelope; response
+    parses straight into a ``Subtask`` (no defensive unwrap)."""
+    response_payload = {
+        "id": 17,
+        "name": "Draft tests",
+        "is_completed": False,
+        "position": 3,
+    }
+    with respx.mock(assert_all_called=True) as router:
+        route = router.post(SUBTASKS_URL).mock(
+            return_value=httpx.Response(201, json=response_payload)
+        )
+        subtask = await add_subtask(task_id=TASK_ID, title="Draft tests")
+
+    assert subtask.id == 17
+    assert subtask.name == "Draft tests"
+    assert subtask.is_completed is False
+    assert subtask.position == 3
+
+    body = _request_body(route)
+    assert body == {"subtask": {"name": "Draft tests"}}
+
+
+async def test_add_subtask_minimal_response(_inject_client: KanbanToolClient) -> None:
+    """A response with only ``id`` and ``name`` should still validate; optional
+    fields fall back to ``None``."""
+    with respx.mock(assert_all_called=True) as router:
+        router.post(SUBTASKS_URL).mock(
+            return_value=httpx.Response(201, json={"id": 1, "name": "x"})
+        )
+        subtask = await add_subtask(task_id=TASK_ID, title="x")
+
+    assert subtask.id == 1
+    assert subtask.name == "x"
+    assert subtask.is_completed is None
+    assert subtask.completed_at is None
+    assert subtask.position is None
+
+
+async def test_add_subtask_422_raises_validation_error(
+    _inject_client: KanbanToolClient,
+) -> None:
+    """A 422 must surface as the typed ``KanbanToolValidationError`` with parsed
+    ``field_errors`` — not just the base ``KanbanToolHTTPError``."""
+    error_body = {"errors": {"name": ["can't be blank"]}}
+    with respx.mock() as router:
+        router.post(SUBTASKS_URL).mock(return_value=httpx.Response(422, json=error_body))
+        with pytest.raises(KanbanToolValidationError) as exc_info:
+            await add_subtask(task_id=TASK_ID, title="")
+
+    err = exc_info.value
+    assert err.status_code == 422
+    assert err.field_errors == {"name": ["can't be blank"]}
+
+
+async def test_add_subtask_url_shape(_inject_client: KanbanToolClient) -> None:
+    """POST hits ``tasks/{id}/subtasks.json`` exactly."""
+    with respx.mock(assert_all_called=True) as router:
+        route = router.post(SUBTASKS_URL).mock(
+            return_value=httpx.Response(201, json={"id": 1, "name": "x"})
+        )
+        await add_subtask(task_id=TASK_ID, title="x")
+
+    request = route.calls.last.request
+    assert request.method == "POST"
+    assert str(request.url) == SUBTASKS_URL


### PR DESCRIPTION
## Summary

Closes #13. Two MCP tools sharing one impl file — subtasks are first-class enough for both, not enough for separate issues.

- `list_subtasks(task_id) -> list[Subtask]` — `GET /tasks/{id}/subtasks.json`, defensive parse of the `subtasks` array (mirrors `list_boards`).
- `add_subtask(task_id, title) -> Subtask` — `POST /tasks/{id}/subtasks.json` with the `{"subtask": {"name": ...}}` Rails envelope. The LLM-facing kwarg is `title`; on the wire it maps to the API-native `name` field with no `Field(alias=...)` indirection (per the M2 plan-review adjustment — fewer mappings to maintain).
- New `Subtask` pydantic model — `extra="ignore"` so a future API field doesn't blow up the parser.
- 422 surfaces as the typed `KanbanToolValidationError` (subclass of `KanbanToolHTTPError`) via the shared `_raise_for_status` path.
- Response is parsed straight into `Subtask` (no defensive `{"subtask": {...}}` unwrap — picked the bare-object shape per the plan-review adjustment, matching `get_task` on main).

CLAUDE.md: moved the `list_subtasks` bullet from M1 to M2 to reflect actual delivery milestone (per-merge doc hygiene).

## Test plan

- [x] `uv run pytest` — 77 passed (10 new in `tests/test_subtasks.py`)
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run ty check` — clean
- [ ] Reviewer: confirm against a real Kanban Tool account that `POST /tasks/{id}/subtasks.json` accepts the `{"subtask": {...}}` envelope and returns the bare-object response shape (M3 follow-up if it doesn't).

Coverage in `tests/test_subtasks.py`:

- `list_subtasks`: happy path (one full + one minimal subtask), empty list, missing `subtasks` key returns `[]`, URL-shape assertion, 404 → `KanbanToolHTTPError`, 401 → `KanbanToolPermissionError`.
- `add_subtask`: happy path (asserts request body envelope), minimal response payload, 422 → `KanbanToolValidationError` (typed), URL-shape assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)