### PR TITLE
feat: prepend actionable hints to 404/5xx and round out write-tool error coverage

### DIFF
--- a/src/kanbantool_mcp/client.py
+++ b/src/kanbantool_mcp/client.py
@@ -89,8 +89,15 @@ def _raise_for_status(response: httpx.Response, method: str, path: str) -> None:
             body_excerpt=body_excerpt,
             field_errors=_parse_field_errors(body_text),
         )
+    generic_message = f"Kanban Tool API returned HTTP {status} for {method} {path}"
+    if status == 404:
+        message = f"no such task/board (or you lack access). {generic_message}"
+    elif status >= 500:
+        message = f"Kanban Tool API is having issues; retry shortly. {generic_message}"
+    else:
+        message = generic_message
     raise KanbanToolHTTPError(
-        f"Kanban Tool API returned HTTP {status} for {method} {path}",
+        message,
         status_code=status,
         body_excerpt=body_excerpt,
     )

--- a/tests/test_add_comment.py
+++ b/tests/test_add_comment.py
@@ -110,3 +110,20 @@ async def test_add_comment_422_raises_validation_error(
     assert isinstance(err, KanbanToolValidationError)
     assert err.status_code == 422
     assert err.field_errors == {"text": ["can't be blank"]}
+
+
+async def test_add_comment_404_raises_http_error(_inject_client: KanbanToolClient) -> None:
+    with respx.mock() as router:
+        router.post(COMMENTS_URL).mock(return_value=httpx.Response(404, text="task not found"))
+        with pytest.raises(KanbanToolHTTPError) as exc_info:
+            await add_comment(task_id=TASK_ID, text="hi")
+    assert exc_info.value.status_code == 404
+    assert not isinstance(exc_info.value, KanbanToolValidationError)
+
+
+async def test_add_comment_500_raises_http_error(_inject_client: KanbanToolClient) -> None:
+    with respx.mock() as router:
+        router.post(COMMENTS_URL).mock(return_value=httpx.Response(500, text="server exploded"))
+        with pytest.raises(KanbanToolHTTPError) as exc_info:
+            await add_comment(task_id=TASK_ID, text="hi")
+    assert exc_info.value.status_code == 500

--- a/tests/test_archive_task.py
+++ b/tests/test_archive_task.py
@@ -93,6 +93,14 @@ async def test_archive_task_401_raises_permission_error(
             await archive_task(task_id=TASK_ID)
 
 
+async def test_archive_task_500_raises_http_error(_inject_client: KanbanToolClient) -> None:
+    with respx.mock() as router:
+        router.patch(TASK_URL).mock(return_value=httpx.Response(500, text="server exploded"))
+        with pytest.raises(KanbanToolHTTPError) as exc_info:
+            await archive_task(task_id=TASK_ID)
+    assert exc_info.value.status_code == 500
+
+
 async def test_archive_task_url_shape(_inject_client: KanbanToolClient) -> None:
     """PATCH hits ``tasks/{id}.json`` exactly — no ``/archive`` path segment,
     no double ``.json``, no query string, no trailing-slash artifact."""

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -56,6 +56,10 @@ async def test_404_raises_http_error_with_body(client: KanbanToolClient) -> None
         assert exc_info.value.status_code == 404
         assert exc_info.value.body_excerpt
         assert "not found" in exc_info.value.body_excerpt
+        rendered = str(exc_info.value)
+        assert "no such task/board (or you lack access)" in rendered
+        # Path is preserved so the LLM still sees which resource was missing.
+        assert "boards/999.json" in rendered
 
 
 async def test_500_raises_http_error(client: KanbanToolClient) -> None:
@@ -64,6 +68,9 @@ async def test_500_raises_http_error(client: KanbanToolClient) -> None:
         with pytest.raises(KanbanToolHTTPError) as exc_info:
             await client.request("GET", "boards/1")
         assert exc_info.value.status_code == 500
+        rendered = str(exc_info.value)
+        assert "Kanban Tool API is having issues; retry shortly." in rendered
+        assert "boards/1.json" in rendered
 
 
 async def test_transport_error_then_success_retries(client: KanbanToolClient) -> None:

--- a/tests/test_create_task.py
+++ b/tests/test_create_task.py
@@ -243,6 +243,27 @@ async def test_create_task_401_raises_permission_error(
             await create_task(name="x", board_id=7)
 
 
+async def test_create_task_403_raises_permission_error(
+    _inject_client: KanbanToolClient,
+) -> None:
+    """403 (token valid but not authorized to write to this board) surfaces as
+    ``KanbanToolPermissionError`` — distinct from a 422 validation failure."""
+    with respx.mock() as router:
+        router.post(TASKS_URL).mock(
+            return_value=httpx.Response(403, text="forbidden"),
+        )
+        with pytest.raises(KanbanToolPermissionError):
+            await create_task(name="x", board_id=7)
+
+
+async def test_create_task_500_raises_http_error(_inject_client: KanbanToolClient) -> None:
+    with respx.mock() as router:
+        router.post(TASKS_URL).mock(return_value=httpx.Response(500, text="server exploded"))
+        with pytest.raises(KanbanToolHTTPError) as exc_info:
+            await create_task(name="x", board_id=7)
+    assert exc_info.value.status_code == 500
+
+
 async def test_create_task_url_shape(_inject_client: KanbanToolClient) -> None:
     """POST hits ``tasks.json`` exactly — no ``tasks.json.json`` double-suffix,
     no ``tasks/.json``, no query string."""

--- a/tests/test_move_task.py
+++ b/tests/test_move_task.py
@@ -159,6 +159,14 @@ async def test_move_task_401_raises_permission_error(_inject_client: KanbanToolC
             await move_task(task_id=TASK_ID, column_id=100)
 
 
+async def test_move_task_500_raises_http_error(_inject_client: KanbanToolClient) -> None:
+    with respx.mock() as router:
+        router.patch(TASK_URL).mock(return_value=httpx.Response(500, text="server exploded"))
+        with pytest.raises(KanbanToolHTTPError) as exc_info:
+            await move_task(task_id=TASK_ID, column_id=100)
+    assert exc_info.value.status_code == 500
+
+
 async def test_move_task_url_shape(_inject_client: KanbanToolClient) -> None:
     """PATCH hits ``tasks/{id}.json`` exactly — no double ``.json`` suffix, no
     query string, no trailing slash artifact."""

--- a/tests/test_subtasks.py
+++ b/tests/test_subtasks.py
@@ -189,3 +189,20 @@ async def test_add_subtask_url_shape(_inject_client: KanbanToolClient) -> None:
     request = route.calls.last.request
     assert request.method == "POST"
     assert str(request.url) == SUBTASKS_URL
+
+
+async def test_add_subtask_404_raises_http_error(_inject_client: KanbanToolClient) -> None:
+    with respx.mock() as router:
+        router.post(SUBTASKS_URL).mock(return_value=httpx.Response(404, text="task not found"))
+        with pytest.raises(KanbanToolHTTPError) as exc_info:
+            await add_subtask(task_id=TASK_ID, title="x")
+    assert exc_info.value.status_code == 404
+    assert not isinstance(exc_info.value, KanbanToolValidationError)
+
+
+async def test_add_subtask_500_raises_http_error(_inject_client: KanbanToolClient) -> None:
+    with respx.mock() as router:
+        router.post(SUBTASKS_URL).mock(return_value=httpx.Response(500, text="server exploded"))
+        with pytest.raises(KanbanToolHTTPError) as exc_info:
+            await add_subtask(task_id=TASK_ID, title="x")
+    assert exc_info.value.status_code == 500

--- a/tests/test_update_task.py
+++ b/tests/test_update_task.py
@@ -203,6 +203,19 @@ async def test_update_task_500_raises_http_error(_inject_client: KanbanToolClien
     assert not isinstance(err, KanbanToolValidationError)
 
 
+async def test_update_task_404_raises_http_error(_inject_client: KanbanToolClient) -> None:
+    """404 (unknown task id) surfaces as the base ``KanbanToolHTTPError`` —
+    not promoted to the validation subclass."""
+    with respx.mock() as router:
+        router.put(TASK_URL).mock(return_value=httpx.Response(404, text="task not found"))
+        with pytest.raises(KanbanToolHTTPError) as exc_info:
+            await update_task(task_id=TASK_ID, name="x")
+
+    err = exc_info.value
+    assert err.status_code == 404
+    assert not isinstance(err, KanbanToolValidationError)
+
+
 async def test_update_task_url_shape(_inject_client: KanbanToolClient) -> None:
     """PUT hits ``tasks/{id}.json`` exactly — no double ``.json`` suffix, no
     query string, no trailing slash artifact."""


### PR DESCRIPTION
## Summary

Closes #14. Two small UX polish gaps from a recent audit of the M2 write paths — most of #14 (typed exception hierarchy, 401/403/422 branches, body scrubbing, 422 field-error parsing) was already in place from #40 and follow-ups.

- ``_raise_for_status`` now prepends a short, LLM-actionable hint to the generic 404 (``no such task/board (or you lack access).``) and 5xx (``Kanban Tool API is having issues; retry shortly.``) messages. The full path is still rendered so the model sees which resource was missing; ``status_code`` and ``body_excerpt`` are unchanged. Other 4xx (anything that isn't 401/403/404/422) keeps the bare generic message — the typed branches already say enough.
- Round out per-tool error tests so every write tool exercises the realistic error paths it can hit: a 403 on ``create_task``, a 500 on ``create_task``/``move_task``/``archive_task``/``add_comment``/``add_subtask``, and a 404 on ``update_task``/``add_comment``/``add_subtask``. Existing 4xx/5xx tests on ``update_task``, ``list_boards``, etc. were already in place and aren't duplicated.

Out of scope: ``exceptions.py``, ``server.py``, ``models.py``, README, CI, packaging — none changed.

## Test plan

- [x] ``uv run ruff format .``
- [x] ``uv run ruff check .``
- [x] ``uv run ruff format --check .``
- [x] ``uv run ty check``
- [x] ``uv run pytest`` — 104 passed (was 92)
- [ ] CI green on PR

Generated with Claude Code (Opus 4.7, 1M context).