### PR TITLE
chore(ci): pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,8 @@ jobs:
       matrix:
         python-version: ["3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v7
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
         with:
           enable-cache: true
       - run: uv python install ${{ matrix.python-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,11 +11,11 @@ jobs:
       id-token: write
       contents: write
     steps:
-      - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v7
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
       - run: uv build
-      - uses: pypa/gh-action-pypi-publish@release/v1
-      - uses: softprops/action-gh-release@v3
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
+      - uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3.0.0
         with:
           generate_release_notes: true
           files: dist/*


### PR DESCRIPTION
## Summary

- Pins every third-party action in `ci.yml` and `release.yml` to a full commit SHA, with the human-readable version preserved as a trailing comment so Dependabot can keep bumping.
- Closes the supply-chain hole where a compromised maintainer could retarget a mutable tag (e.g. `v6`) at malicious code. Especially important in `release.yml`, which holds `id-token: write` for PyPI publishing.
- No other changes: `dependabot.yml` already handles SHA-pinned actions with version comments natively, so it's untouched.

Pin map (resolved via `gh api /repos/{owner}/{repo}/git/refs/tags/{tag}`):

| Action | Old | New |
| --- | --- | --- |
| `actions/checkout` | `@v6` | `@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2` |
| `astral-sh/setup-uv` | `@v7` | `@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0` |
| `softprops/action-gh-release` | `@v3` | `@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3.0.0` |
| `pypa/gh-action-pypi-publish` | `@release/v1` | `@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0` |

Closes #25

## Test plan

- [x] `python3 -c "import yaml; [yaml.safe_load(open(f)) for f in ['.github/workflows/ci.yml', '.github/workflows/release.yml']]"` parses cleanly.
- [ ] CI green on this PR (the SHAs resolve to the same commits the tags pointed to, so behavior is identical).
- [ ] Spot-check on the GitHub Actions UI that runs use the pinned SHA refs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)