### PR TITLE
fix(list_boards): wrap ValidationError and cover defensive parse branch

### DIFF
--- a/src/kanbantool_mcp/server.py
+++ b/src/kanbantool_mcp/server.py
@@ -6,10 +6,18 @@ from datetime import datetime
 from typing import Any, Literal
 
 from fastmcp import FastMCP
+from pydantic import ValidationError
 
 from .client import KanbanToolClient
 from .config import Config
+from .exceptions import KanbanToolHTTPError
 from .models import Board, ChangelogEntry, Comment, Subtask, Task
+
+# Mirrors ``client._BODY_EXCERPT_LIMIT`` so payload-shape errors surface a
+# truncated repr consistent with HTTP-error excerpts. Kept inline (rather than
+# imported from ``client``) because that constant is module-private — exposing
+# it would widen the API for one caller.
+_PAYLOAD_EXCERPT_LIMIT = 200
 
 mcp: FastMCP = FastMCP("kanbantool-mcp")
 
@@ -36,8 +44,19 @@ async def list_boards() -> list[Board]:
     """List boards visible to the authenticated user."""
     data = await _get_client().request("GET", "users/current")
     raw = data.get("boards", []) if isinstance(data, dict) else []
-    # M3: consider wrapping ValidationError as KanbanToolHTTPError("malformed boards payload").
-    return [Board.model_validate(b) for b in raw]
+    try:
+        return [Board.model_validate(b) for b in raw]
+    except ValidationError as exc:
+        # The HTTP call succeeded (200) but a board entry was missing required
+        # fields or otherwise malformed. Wrap as KanbanToolHTTPError so the
+        # error surface stays consistent with 4xx/5xx flows — callers always
+        # see a typed KanbanToolError, never a raw pydantic exception.
+        excerpt = f"malformed boards payload: {exc!r}"[:_PAYLOAD_EXCERPT_LIMIT]
+        raise KanbanToolHTTPError(
+            "Kanban Tool API returned a malformed boards payload.",
+            status_code=200,
+            body_excerpt=excerpt,
+        ) from exc
 
 
 @mcp.tool

--- a/tests/test_list_boards.py
+++ b/tests/test_list_boards.py
@@ -90,3 +90,34 @@ async def test_list_boards_propagates_http_error(_inject_client: KanbanToolClien
         with pytest.raises(KanbanToolHTTPError) as exc_info:
             await list_boards()
         assert exc_info.value.status_code == 500
+
+
+async def test_list_boards_malformed_entry_raises_http_error(
+    _inject_client: KanbanToolClient,
+) -> None:
+    payload = {
+        "boards": [
+            {"id": 1, "name": "Eng"},
+            {"name": "no-id"},
+        ]
+    }
+    with respx.mock(assert_all_called=True) as router:
+        router.get(USERS_CURRENT_URL).mock(return_value=httpx.Response(200, json=payload))
+        with pytest.raises(KanbanToolHTTPError) as exc_info:
+            await list_boards()
+
+    assert exc_info.value.status_code == 200
+    assert "malformed" in exc_info.value.body_excerpt
+
+
+async def test_list_boards_list_rooted_response_returns_empty(
+    _inject_client: KanbanToolClient,
+) -> None:
+    # Defensive parse: the API contract is a dict with a ``boards`` key, but if
+    # it ever responds with a bare list we fall through to ``[]`` rather than
+    # blowing up on ``.get``. Locks the ``isinstance(data, dict)`` else-branch.
+    with respx.mock(assert_all_called=True) as router:
+        router.get(USERS_CURRENT_URL).mock(return_value=httpx.Response(200, json=[]))
+        result = await list_boards()
+
+    assert result == []


### PR DESCRIPTION
## Summary

Two surgical follow-ups from the M3 review of `list_boards`:

- **Wrap `pydantic.ValidationError` as `KanbanToolHTTPError`.** If the API ever returns 200 with a malformed `boards[]` entry (missing required `id`/`name`, wrong types, etc.), `Board.model_validate(b)` would currently raise a raw `pydantic.ValidationError` straight to the MCP client. That breaks the typed-exception contract every other tool honours. Now it surfaces as `KanbanToolHTTPError(status_code=200, body_excerpt="malformed boards payload: <truncated repr>")`. Status 200 because the HTTP call succeeded; the failure is payload shape. Excerpt is truncated to 200 chars to mirror `client._BODY_EXCERPT_LIMIT`.
- **Cover the `isinstance(data, dict)` else-branch.** The `else []` defensive parse was uncovered. Added a test that returns `json=[]` (a list-rooted response) and asserts the tool returns `[]`.

Removed the now-stale `# M3:` comment on `list_boards` (the gap is closed). Other tools' `# M3:` markers are intentionally untouched — they're separate follow-ups (own issues / out of scope for this PR).

## Test plan

- [x] `uv run ruff format --check .`
- [x] `uv run ruff check .`
- [x] `uv run ty check`
- [x] `uv run pytest` — 106 passed (5 original list_boards tests + 2 new still green)
- [x] New `test_list_boards_malformed_entry_raises_http_error`: missing `id` on second entry → `KanbanToolHTTPError`, `status_code == 200`, "malformed" in `body_excerpt`
- [x] New `test_list_boards_list_rooted_response_returns_empty`: `json=[]` → `[]` (locks the defensive `isinstance(data, dict)` else-branch)

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)