### PR TITLE
fix(models): polish Board/Column/CustomField surface for get_board

### DIFF
--- a/src/kanbantool_mcp/models.py
+++ b/src/kanbantool_mcp/models.py
@@ -1,4 +1,16 @@
-"""Pydantic models for Kanban Tool resources. Expanded in M1/M2."""
+"""Pydantic models for Kanban Tool resources. Expanded in M1/M2.
+
+Abstraction layer — internal name vs. wire name. The Kanban Tool API exposes
+several fields under names we deliberately rename for ergonomics on the MCP
+surface; the mapping is centralised here so the next maintainer doesn't have
+to grep for it:
+
+- ``Board.columns`` ↔ API ``workflow_stages``
+- ``Board.custom_fields`` ↔ API ``card_template``
+- ``Task.lane_id`` ↔ API ``workflow_stage_id``
+- ``Column.type_`` / ``CustomField.type_`` ↔ API ``type`` (avoids shadowing
+  the Python builtin internally; serialised back as ``type`` via alias).
+"""
 
 from __future__ import annotations
 
@@ -11,15 +23,17 @@ from pydantic import BaseModel, ConfigDict, Field
 class Column(BaseModel):
     """A workflow stage on a board (the API calls these ``workflow_stages``)."""
 
-    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+    model_config = ConfigDict(extra="ignore", populate_by_name=True, serialize_by_alias=True)
 
     id: int
     name: str
     position: int | None = None
     parent_id: int | None = None
     wip_limit: int | None = None
-    # ``type`` shadows a Python builtin; accept the raw API key via alias.
-    type_: str | None = Field(default=None, alias="type")
+    # ``type`` shadows a Python builtin internally; ``serialization_alias``
+    # keeps the wire/MCP-schema name as ``type`` while the Python attribute
+    # stays ``type_``.
+    type_: str | None = Field(default=None, alias="type", serialization_alias="type")
 
 
 class Swimlane(BaseModel):
@@ -35,13 +49,16 @@ class Swimlane(BaseModel):
 class CustomField(BaseModel):
     """A custom field definition from the board's card template."""
 
-    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+    model_config = ConfigDict(extra="ignore", populate_by_name=True, serialize_by_alias=True)
 
     label: str | None = None
     position: int | None = None
-    options: str | None = None
-    # ``type`` shadows a Python builtin; accept the raw API key via alias.
-    type_: str | None = Field(default=None, alias="type")
+    # Kanban Tool returns a bare string for simple fields and a structured
+    # list for select-style fields; accept either rather than dropping the
+    # field on a type mismatch.
+    options: list[str] | str | None = None
+    # See ``Column.type_`` for the alias rationale.
+    type_: str | None = Field(default=None, alias="type", serialization_alias="type")
 
 
 class Board(BaseModel):

--- a/src/kanbantool_mcp/server.py
+++ b/src/kanbantool_mcp/server.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, Literal
+from typing import Annotated, Any, Literal
 
 from fastmcp import FastMCP
+from pydantic import Field, validate_call
 
 from .client import KanbanToolClient
 from .config import Config
@@ -41,8 +42,12 @@ async def list_boards() -> list[Board]:
 
 
 @mcp.tool
-async def get_board(board_id: int) -> Board:
+@validate_call
+async def get_board(board_id: Annotated[int, Field(ge=1)]) -> Board:
     """Fetch a board with its columns, swimlanes, and custom-field definitions."""
+    # ``validate_call`` enforces ``ge=1`` on direct callers (and tests) so a
+    # bogus 0/-N never reaches the API as a confusing 404. FastMCP also
+    # validates this from the wire side via the JSON schema.
     data = await _get_client().request("GET", f"boards/{board_id}")
     # M3: consider wrapping ValidationError as KanbanToolHTTPError("malformed board payload").
     return Board.model_validate(data)

--- a/tests/test_get_board.py
+++ b/tests/test_get_board.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 import httpx
 import pytest
 import respx
+from pydantic import ValidationError
 
 from kanbantool_mcp.client import KanbanToolClient
 from kanbantool_mcp.exceptions import KanbanToolHTTPError
+from kanbantool_mcp.models import Column, CustomField
 from kanbantool_mcp.server import get_board
 
 from .conftest import BASE_URL
@@ -125,3 +127,62 @@ async def test_get_board_404_raises_http_error(_inject_client: KanbanToolClient)
             await get_board(999)
         assert exc_info.value.status_code == 404
         assert "not found" in exc_info.value.body_excerpt
+
+
+def test_column_serializes_type_alias_not_underscore() -> None:
+    """A JSON dump of a Column uses key ``type``, not ``type_``."""
+    column = Column.model_validate(
+        {"id": 1, "name": "Backlog", "type": "queue"},
+    )
+    dumped = column.model_dump()
+    assert "type" in dumped
+    assert "type_" not in dumped
+    assert dumped["type"] == "queue"
+    # JSON-mode dump must agree (this is what FastMCP renders to the client).
+    json_dumped = column.model_dump(mode="json")
+    assert "type" in json_dumped
+    assert "type_" not in json_dumped
+
+
+def test_custom_field_serializes_type_alias_not_underscore() -> None:
+    """A JSON dump of a CustomField uses key ``type``, not ``type_``."""
+    field = CustomField.model_validate(
+        {"label": "Owner", "type": "user", "position": 1},
+    )
+    dumped = field.model_dump()
+    assert "type" in dumped
+    assert "type_" not in dumped
+    assert dumped["type"] == "user"
+
+
+def test_custom_field_options_accepts_string() -> None:
+    """Bare-string ``options`` (simple fields) parses cleanly."""
+    field = CustomField.model_validate({"label": "Notes", "options": "single"})
+    assert field.options == "single"
+
+
+def test_custom_field_options_accepts_list() -> None:
+    """Structured list ``options`` (select-style fields) parses cleanly."""
+    field = CustomField.model_validate(
+        {"label": "Severity", "options": ["low", "medium", "high"]},
+    )
+    assert field.options == ["low", "medium", "high"]
+
+
+async def test_get_board_rejects_zero_board_id_before_http() -> None:
+    """``board_id=0`` raises a pydantic ValidationError before any HTTP call."""
+    with respx.mock(assert_all_called=False) as router:
+        # Register a route that would explode the test if it were ever hit.
+        route = router.get(_board_url(0)).mock(return_value=httpx.Response(200, json={}))
+        with pytest.raises(ValidationError):
+            await get_board(0)
+        assert not route.called
+
+
+async def test_get_board_rejects_negative_board_id_before_http() -> None:
+    """Negative ``board_id`` is also rejected before any HTTP call."""
+    with respx.mock(assert_all_called=False) as router:
+        route = router.get(_board_url(-5)).mock(return_value=httpx.Response(200, json={}))
+        with pytest.raises(ValidationError):
+            await get_board(-5)
+        assert not route.called


### PR DESCRIPTION
## Summary

Three follow-ups from the `get_board` review (issue #34):

- **`type_` serialization alias.** `Column.type_` and `CustomField.type_` now carry `serialization_alias="type"` and the model uses `serialize_by_alias=True`. The external surface — including the FastMCP tool schema the LLM sees — is now `type`, while the Python attribute keeps the trailing underscore to avoid shadowing the builtin. Verified by inspecting `model_json_schema(mode='serialization')`.
- **`CustomField.options` shape.** Widened from `str | None` to `list[str] | str | None`. Kanban Tool returns a structured list for select-style fields; `extra="ignore"` doesn't paper over a type mismatch on a known field, so the old shape would have raised `ValidationError` on real payloads.
- **`board_id` constraint.** `get_board(board_id)` now takes `Annotated[int, Field(ge=1)]` and is wrapped in `pydantic.validate_call`. FastMCP's input schema picks up `"minimum": 1` *and* direct Python callers (incl. tests) get the same enforcement, so a bogus `0`/negative never reaches the API as a confusing 404. The constraint is on the tool input — `Board.id` (server-side data) is untouched.

Bonus: module docstring on `models.py` mapping the wire-name abstraction layer (columns ↔ workflow_stages, custom_fields ↔ card_template, lane_id ↔ workflow_stage_id, type_ ↔ type) so the next maintainer doesn't go hunting.

## Test plan

- [x] `uv run ruff format --check .` — green
- [x] `uv run ruff check .` — green
- [x] `uv run ty check` — green
- [x] `uv run pytest` — 110 passed (was 104; 6 new tests in `test_get_board.py`)
- New tests cover:
  - `Column` and `CustomField` JSON dumps use key `type`, not `type_` (also verified in `mode="json"`)
  - `CustomField` parses both `options="single"` and `options=["a", "b"]`
  - `get_board(0)` and `get_board(-5)` raise `pydantic.ValidationError` and never hit HTTP (assert `route.called is False` against a respx mock)

Closes #34

Co-authored with Claude Opus 4.7 (1M context).