### PR TITLE
chore(deps): bump pydantic floor to >=2.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 dependencies = [
     "fastmcp>=2.0",
     "httpx>=0.27",
-    "pydantic>=2.7",
+    "pydantic>=2.11",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -584,7 +584,7 @@ dev = [
 requires-dist = [
     { name = "fastmcp", specifier = ">=2.0" },
     { name = "httpx", specifier = ">=0.27" },
-    { name = "pydantic", specifier = ">=2.7" },
+    { name = "pydantic", specifier = ">=2.11" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Summary

- `model_config = ConfigDict(..., serialize_by_alias=True)` was introduced in #51; that option requires pydantic >=2.11.
- The declared floor was still `pydantic>=2.7`, which would let installs resolve a runtime that doesn't support `serialize_by_alias`.
- Bump the floor to match what's actually required. `uv.lock` already pins 2.13.3, so no resolution change beyond the recorded specifier.

Closes #52

## Test plan

- [x] `uv run ruff format --check .`
- [x] `uv run ruff check .`
- [x] `uv run ty check`
- [x] `uv run pytest` (112 passed)

Generated with [Claude Code](https://claude.com/claude-code)