### PR TITLE
docs(examples): add usage transcripts for read, write, and polling flows

### DIFF
--- a/examples/01-board-status.md
+++ b/examples/01-board-status.md
@@ -1,0 +1,65 @@
+# Example 1: Board status summary
+
+A read-only flow. The user asks for the current state of a board; the assistant
+walks `list_boards` → `get_board` → `search_tasks` and summarises by column.
+
+> JSON snippets are illustrative — shapes match `Board` / `Task`, ids are made up.
+
+---
+
+**User:** What's the current state of my Engineering board?
+
+**Assistant:** I'll find the board first, fetch its columns, then pull the active tasks.
+
+```text
+> list_boards()
+```
+
+```json
+[
+  {"id": 4711, "name": "Engineering", "slug": "engineering", "use_swimlanes": false, "is_archived": false, "user_role": "admin"},
+  {"id": 4712, "name": "Marketing",   "slug": "marketing",   "use_swimlanes": false, "is_archived": false, "user_role": "member"}
+]
+```
+
+```text
+> get_board(board_id=4711)
+```
+
+```json
+{
+  "id": 4711,
+  "name": "Engineering",
+  "use_swimlanes": false,
+  "columns": [
+    {"id": 90001, "name": "Backlog",     "position": 1, "type": "queue"},
+    {"id": 90002, "name": "In Progress", "position": 2, "type": "in_progress", "wip_limit": 4},
+    {"id": 90003, "name": "Review",      "position": 3, "type": "in_progress", "wip_limit": 3},
+    {"id": 90004, "name": "Done",        "position": 4, "type": "done"}
+  ],
+  "swimlanes": [],
+  "custom_fields": []
+}
+```
+
+```text
+> search_tasks(query="archived:false", board_id=4711, limit=50)
+```
+
+```json
+[
+  {"id": 50231, "name": "Wire up Stripe webhook",  "lane_id": 90002, "priority": "high",   "assignees": [12], "tags": "backend,billing"},
+  {"id": 50232, "name": "Refactor auth middleware","lane_id": 90002, "priority": "medium", "assignees": [12, 18]},
+  {"id": 50233, "name": "Onboarding tour copy",    "lane_id": 90003, "priority": "low",    "assignees": [44]},
+  {"id": 50234, "name": "Migrate Postgres to 16",  "lane_id": 90001, "priority": "high",   "assignees": []}
+]
+```
+
+**Assistant:** Engineering has 4 active tasks:
+
+- **In Progress (2/4)** — *Wire up Stripe webhook* (high), *Refactor auth middleware* (medium)
+- **Review (1/3)** — *Onboarding tour copy* (low)
+- **Backlog** — *Migrate Postgres to 16* (high, unassigned)
+
+Both WIP-limited columns have headroom; the Postgres migration is the only
+unassigned high-priority item — worth picking up next.

--- a/examples/02-create-and-comment.md
+++ b/examples/02-create-and-comment.md
@@ -1,0 +1,66 @@
+# Example 2: Create a task and add a comment
+
+A write flow. The user asks for a high-priority task to be created and
+annotated with reproduction steps. The assistant resolves the board, calls
+`create_task`, then follows up with `add_comment`.
+
+> JSON snippets are illustrative — shapes match `Task` / `Comment`, ids are made up.
+
+---
+
+**User:** Create a high-priority task in Engineering called "Fix login bug" assigned to me, and add a comment with steps to reproduce.
+
+**Assistant:** I'll find the Engineering board first, then create the task, then attach the repro steps as a comment.
+
+```text
+> list_boards()
+```
+
+```json
+[
+  {"id": 4711, "name": "Engineering", "slug": "engineering", "user_role": "admin"},
+  {"id": 4712, "name": "Marketing",   "slug": "marketing",   "user_role": "member"}
+]
+```
+
+```text
+> create_task(
+    name="Fix login bug",
+    board_id=4711,
+    priority="high",
+    assignees=[12],
+  )
+```
+
+```json
+{
+  "id": 50240,
+  "name": "Fix login bug",
+  "board_id": 4711,
+  "lane_id": 90001,
+  "priority": "high",
+  "assignees": [12],
+  "is_archived": false,
+  "subtasks_count": 0,
+  "comment_count": 0,
+  "created_at": "2026-04-30T11:14:08Z"
+}
+```
+
+```text
+> add_comment(
+    task_id=50240,
+    text="Steps to reproduce:\n1. Log out.\n2. Visit /login on Safari 17.\n3. Submit valid creds — page reloads with no session cookie set.\nExpected: redirect to /dashboard.",
+  )
+```
+
+```json
+{
+  "id": 88102,
+  "text": "Steps to reproduce:\n1. Log out.\n2. Visit /login on Safari 17.\n3. Submit valid creds — page reloads with no session cookie set.\nExpected: redirect to /dashboard.",
+  "user_id": 12,
+  "created_at": "2026-04-30T11:14:09Z"
+}
+```
+
+**Assistant:** Done. Created task `#50240` "Fix login bug" on Engineering at high priority, assigned to you, and posted the repro steps as the first comment. The card landed in Backlog (`lane_id 90001`) — let me know if you'd like it moved straight to In Progress.

--- a/examples/03-poll-recent-changes.md
+++ b/examples/03-poll-recent-changes.md
@@ -1,0 +1,88 @@
+# Example 3: Polling for recent changes
+
+`recent_changes(board_id, since=...)` is the change-tracking primitive
+exposed by `kanbantool-mcp`. Kanban Tool ships **no webhook support**, so
+polling the board changelog is the only way to detect activity. This example
+shows an LLM agent monitoring a board over a few minutes.
+
+> JSON snippets are illustrative — shapes match `ChangelogEntry`, ids are made up.
+
+## Why polling, not webhooks
+
+Kanban Tool API v3 does not provide outbound webhooks. The server therefore
+exposes a single periodic-fetch tool over `/boards/:id/changelog.json` rather
+than pretending push semantics exist. Two consequences worth internalising:
+
+- The agent owns the cadence. The tool's docstring asks for **30–120s
+  between polls** — fast enough to feel responsive, slow enough to stay well
+  inside Kanban Tool's rate limit and avoid burning tokens on noise.
+- Always pass `since`. Omitting it returns the entire history of the board,
+  which can be huge.
+
+## Transcript
+
+**User:** Keep an eye on the Engineering board and tell me when something interesting happens.
+
+**Assistant:** I'll poll the changelog every ~60s, advancing `since` to the newest entry I've already seen.
+
+**First poll** — initial bootstrap, `since` set to "now" so we only see new activity:
+
+```text
+> recent_changes(board_id=4711, since="2026-04-30T11:14:00Z")
+```
+
+```json
+[]
+```
+
+**~60s later** — someone moved a card:
+
+```text
+> recent_changes(board_id=4711, since="2026-04-30T11:14:00Z")
+```
+
+```json
+[
+  {
+    "id": 770211,
+    "created_at": "2026-04-30T11:14:42Z",
+    "action": "task_moved",
+    "actor_id": 18,
+    "actor_name": "Priya N.",
+    "target_type": "Task",
+    "target_id": 50232,
+    "details": {"from_stage_id": 90002, "to_stage_id": 90003}
+  }
+]
+```
+
+**Assistant:** Priya moved *Refactor auth middleware* from In Progress → Review. I'll keep watching.
+
+**~60s later** — `since` advanced to the newest entry's `created_at`:
+
+```text
+> recent_changes(board_id=4711, since="2026-04-30T11:14:42Z")
+```
+
+```json
+[
+  {
+    "id": 770212,
+    "created_at": "2026-04-30T11:15:30Z",
+    "action": "comment_added",
+    "actor_id": 44,
+    "actor_name": "Tom R.",
+    "target_type": "Task",
+    "target_id": 50231,
+    "details": {"comment_id": 88110}
+  }
+]
+```
+
+**Assistant:** New comment on *Wire up Stripe webhook* by Tom. Want me to fetch the comment text with `get_task`?
+
+---
+
+Pattern recap: poll on a steady cadence, always pass `since`, advance `since`
+to the newest entry's `created_at` after each call. Entries come back
+newest-first per the API.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,16 @@
+# Examples
+
+Short transcripts showing what Claude Code can do once `kanbantool-mcp` is wired
+up. The JSON snippets in each file are illustrative — they have realistic
+shapes, but the ids, names, and timestamps are made up.
+
+All examples assume an account at `rynbou.kanbantool.com` (i.e. `KANBANTOOL_DOMAIN=rynbou`).
+
+- [`01-board-status.md`](01-board-status.md) — read-only flow: summarising the
+  current state of a board (`list_boards` → `get_board` → `search_tasks`).
+- [`02-create-and-comment.md`](02-create-and-comment.md) — write flow: creating
+  a high-priority task and following up with a comment (`search_tasks` →
+  `create_task` → `add_comment`).
+- [`03-poll-recent-changes.md`](03-poll-recent-changes.md) — polling flow:
+  using `recent_changes` to track board activity over time, and a note on why
+  there are no webhooks.


### PR DESCRIPTION
## Summary

Adds an `examples/` directory with three short Claude Code transcripts and a
small README index. Closes #17.

- `examples/01-board-status.md` — read flow: `list_boards` → `get_board` → `search_tasks`, summarised per column.
- `examples/02-create-and-comment.md` — write flow: `create_task` for a high-priority bug + `add_comment` with repro steps.
- `examples/03-poll-recent-changes.md` — polling flow: `recent_changes(board_id, since=...)` repeated with advancing `since`, plus a note on the no-webhooks design.

JSON snippets are illustrative — shapes match `Board` / `Task` / `Comment` /
`ChangelogEntry` from `models.py`; ids and timestamps are made up. Examples
use `rynbou.kanbantool.com` as the demo subdomain.

Out of scope: only files under `examples/` are touched — no source, tests,
README, CI, or pyproject changes.

## Test plan

- [x] `uv run pytest` — 112 passed (no source touched).
- [ ] Eyeball each transcript on GitHub for rendering / typos.
- [ ] Confirm CI is green on the PR.

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)