### PR TITLE
fix(client): follow redirects in httpx.AsyncClient

### DIFF
--- a/src/kanbantool_mcp/client.py
+++ b/src/kanbantool_mcp/client.py
@@ -113,6 +113,7 @@ class KanbanToolClient:
                 base_url=config.base_url,
                 headers={"Authorization": f"Bearer {config.api_token}"},
                 timeout=30.0,
+                follow_redirects=True,
             )
         )
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -147,3 +147,30 @@ async def test_404_with_empty_body(client: KanbanToolClient) -> None:
             await client.request("GET", "boards/999")
         assert exc_info.value.status_code == 404
         assert exc_info.value.body_excerpt == ""
+
+
+async def test_request_follows_302_redirect(client: KanbanToolClient) -> None:
+    # /users/current.json 302s to the resolved /users/{id}.json on real accounts.
+    # httpx must follow the redirect transparently and return the target's JSON.
+    target_url = f"{BASE_URL}users/42.json"
+    with respx.mock(assert_all_called=True) as router:
+        router.get(f"{BASE_URL}users/current.json").mock(
+            return_value=httpx.Response(302, headers={"Location": target_url})
+        )
+        router.get(target_url).mock(return_value=httpx.Response(200, json={"id": 42}))
+        result = await client.request("GET", "users/current")
+        assert result == {"id": 42}
+
+
+async def test_request_follows_relative_redirect(client: KanbanToolClient) -> None:
+    # The Kanban Tool API returns a path-only Location; httpx must resolve it
+    # against the base URL.
+    with respx.mock(assert_all_called=True) as router:
+        router.get(f"{BASE_URL}users/current.json").mock(
+            return_value=httpx.Response(302, headers={"Location": "/api/v3/users/42.json"})
+        )
+        router.get(f"{BASE_URL}users/42.json").mock(
+            return_value=httpx.Response(200, json={"id": 42})
+        )
+        result = await client.request("GET", "users/current")
+        assert result == {"id": 42}


### PR DESCRIPTION
## Summary

- Enable `follow_redirects=True` on the default `httpx.AsyncClient` in `KanbanToolClient.__init__`. Live API smoke testing showed `/api/v3/users/current.json` returns `302 Found` with `Location` pointing at the resolved `/api/v3/users/{id}.json`. httpx's default of `follow_redirects=False` left `request()` with an empty 302 body that `_raise_for_status` ignored (3xx is not in its branches) and that `response.json()` then choked on - surfacing as a `json.JSONDecodeError` or, post-#50, as a misleading `KanbanToolHTTPError(status_code=200, "malformed boards payload")` from `list_boards`.
- One-line client change. No error-handling refactor: 3xx is now resolved transparently by httpx, so the existing 4xx/5xx ladder is unchanged.
- Two new respx-backed tests covering absolute and relative `Location` headers.

Closes #57

## Test plan

- [x] `uv run ruff format --check .`
- [x] `uv run ruff check .`
- [x] `uv run ty check`
- [x] `uv run pytest` (114 passed; 2 new)

Generated with Claude Code.