### PR TITLE
fix(models): align Task, Board, ChangelogEntry with live API (critical tier)

### DIFF
--- a/examples/01-board-status.md
+++ b/examples/01-board-status.md
@@ -38,7 +38,7 @@ walks `list_boards` → `get_board` → `search_tasks` and summarises by column.
     {"id": 90004, "name": "Done",        "position": 4, "type": "done"}
   ],
   "swimlanes": [],
-  "custom_fields": []
+  "card_template": {"description": {"enabled": true, "position": 1}, "priority": {"enabled": true, "position": 2}}
 }
 ```
 
@@ -48,10 +48,10 @@ walks `list_boards` → `get_board` → `search_tasks` and summarises by column.
 
 ```json
 [
-  {"id": 50231, "name": "Wire up Stripe webhook",  "lane_id": 90002, "priority": "high",   "assignees": [12], "tags": "backend,billing"},
-  {"id": 50232, "name": "Refactor auth middleware","lane_id": 90002, "priority": "medium", "assignees": [12, 18]},
-  {"id": 50233, "name": "Onboarding tour copy",    "lane_id": 90003, "priority": "low",    "assignees": [44]},
-  {"id": 50234, "name": "Migrate Postgres to 16",  "lane_id": 90001, "priority": "high",   "assignees": []}
+  {"id": 50231, "name": "Wire up Stripe webhook",  "lane_id": 90002, "priority": "high",   "assigned_user_id": 12, "tags": "backend,billing"},
+  {"id": 50232, "name": "Refactor auth middleware","lane_id": 90002, "priority": "medium", "assigned_user_id": 18},
+  {"id": 50233, "name": "Onboarding tour copy",    "lane_id": 90003, "priority": "low",    "assigned_user_id": 44},
+  {"id": 50234, "name": "Migrate Postgres to 16",  "lane_id": 90001, "priority": "high",   "assigned_user_id": null}
 ]
 ```
 

--- a/examples/02-create-and-comment.md
+++ b/examples/02-create-and-comment.md
@@ -39,10 +39,11 @@ annotated with reproduction steps. The assistant resolves the board, calls
   "board_id": 4711,
   "lane_id": 90001,
   "priority": "high",
-  "assignees": [12],
+  "assigned_user_id": 12,
+  "archived_at": null,
   "is_archived": false,
   "subtasks_count": 0,
-  "comment_count": 0,
+  "comments_count": 0,
   "created_at": "2026-04-30T11:14:08Z"
 }
 ```

--- a/examples/03-poll-recent-changes.md
+++ b/examples/03-poll-recent-changes.md
@@ -46,12 +46,12 @@ than pretending push semantics exist. Two consequences worth internalising:
   {
     "id": 770211,
     "created_at": "2026-04-30T11:14:42Z",
-    "action": "task_moved",
-    "actor_id": 18,
-    "actor_name": "Priya N.",
-    "target_type": "Task",
-    "target_id": 50232,
-    "details": {"from_stage_id": 90002, "to_stage_id": 90003}
+    "what": "task_moved",
+    "user_id": 18,
+    "changed_object_type": "Task",
+    "changed_object_id": 50232,
+    "description": "Priya N. moved Refactor auth middleware from In Progress to Review.",
+    "data": {"from_stage_id": 90002, "to_stage_id": 90003, "user_initials": "PN"}
   }
 ]
 ```
@@ -69,12 +69,12 @@ than pretending push semantics exist. Two consequences worth internalising:
   {
     "id": 770212,
     "created_at": "2026-04-30T11:15:30Z",
-    "action": "comment_added",
-    "actor_id": 44,
-    "actor_name": "Tom R.",
-    "target_type": "Task",
-    "target_id": 50231,
-    "details": {"comment_id": 88110}
+    "what": "comment_added",
+    "user_id": 44,
+    "changed_object_type": "Task",
+    "changed_object_id": 50231,
+    "description": "Tom R. commented on Wire up Stripe webhook.",
+    "data": {"comment_id": 88110, "user_initials": "TR"}
   }
 ]
 ```

--- a/src/kanbantool_mcp/models.py
+++ b/src/kanbantool_mcp/models.py
@@ -6,10 +6,9 @@ surface; the mapping is centralised here so the next maintainer doesn't have
 to grep for it:
 
 - ``Board.columns`` ↔ API ``workflow_stages``
-- ``Board.custom_fields`` ↔ API ``card_template``
 - ``Task.lane_id`` ↔ API ``workflow_stage_id``
-- ``Column.type_`` / ``CustomField.type_`` ↔ API ``type`` (avoids shadowing
-  the Python builtin internally; serialised back as ``type`` via alias).
+- ``Column.type_`` ↔ API ``type`` (avoids shadowing the Python builtin
+  internally; serialised back as ``type`` via alias).
 """
 
 from __future__ import annotations
@@ -30,6 +29,10 @@ class Column(BaseModel):
     position: int | None = None
     parent_id: int | None = None
     wip_limit: int | None = None
+    # Semantic role string from the API ("backlog_inventory", "in_progress",
+    # "completed", ...). The LLM uses this to distinguish columns by intent
+    # rather than by display name.
+    lane_type: str | None = None
     # ``type`` shadows a Python builtin internally; ``serialization_alias``
     # keeps the wire/MCP-schema name as ``type`` while the Python attribute
     # stays ``type_``.
@@ -46,21 +49,6 @@ class Swimlane(BaseModel):
     position: int | None = None
 
 
-class CustomField(BaseModel):
-    """A custom field definition from the board's card template."""
-
-    model_config = ConfigDict(extra="ignore", populate_by_name=True, serialize_by_alias=True)
-
-    label: str | None = None
-    position: int | None = None
-    # Kanban Tool returns a bare string for simple fields and a structured
-    # list for select-style fields; accept either rather than dropping the
-    # field on a type mismatch.
-    options: list[str] | str | None = None
-    # See ``Column.type_`` for the alias rationale.
-    type_: str | None = Field(default=None, alias="type", serialization_alias="type")
-
-
 class Board(BaseModel):
     model_config = ConfigDict(extra="ignore", populate_by_name=True)
 
@@ -74,7 +62,16 @@ class Board(BaseModel):
     # Detail-only collections; absent from list_boards' compact payload, hence defaults.
     columns: list[Column] = Field(default_factory=list, alias="workflow_stages")
     swimlanes: list[Swimlane] = Field(default_factory=list)
-    custom_fields: list[CustomField] = Field(default_factory=list, alias="card_template")
+    # ``card_template`` is the API's per-board "which card fields are shown"
+    # config — a dict keyed by field name (``description``, ``priority``,
+    # ``custom_field_1``, ...) whose values describe each field's enabled
+    # state, position, and (for ``custom_field_*``) label/type/options.
+    # Exposed verbatim as a dict; a typed wrapper can come in v0.2.0 once
+    # we have a use case beyond "show the LLM the config".
+    card_template: dict[str, Any] | None = None
+    # v0.2.0: embedded ``tasks: list[Task]`` (live-API spike showed the API
+    # returns these on the detail endpoint — could remove a round-trip for
+    # many flows). Pending design call.
 
 
 class Task(BaseModel):
@@ -106,19 +103,38 @@ class Task(BaseModel):
     due_date: str | None = None
     start_date: str | None = None
     tags: str | None = None
-    # User ids only. The full Assignee submodel can land alongside a tool that
-    # actually needs it.
-    assignees: list[int] | None = None
-    is_archived: bool | None = None
-    is_blocked: bool | None = None
+    # The API surfaces a single user id, not a list. The richer Assignee
+    # submodel (and any multi-user collaborators) can land alongside a tool
+    # that actually needs it.
+    assigned_user_id: int | None = None
+    # Archival is timestamped on the wire; ``is_archived`` is a derived
+    # convenience exposed via a property below.
+    archived_at: str | None = None
+    # ``block_reason`` is the only block-related field the API actually
+    # returns — ``is_blocked`` is derived from "reason is set".
     block_reason: str | None = None
     subtasks_count: int | None = None
-    comment_count: int | None = None
+    comments_count: int | None = None
     # Flat seconds. The wrapped ``{ "total": ..., "by_user": ... }`` shape is a
     # separate concern — exposed via a dedicated time-tracker tool later.
-    time_tracker_total: int | None = None
+    timers_total: int | None = None
     created_at: str | None = None
     updated_at: str | None = None
+    # v0.2.0: additive fields confirmed in the live-API spike — ``size_estimate``,
+    # ``card_color``, ``search_tags``, ``collaborators``, ``card_type_id``,
+    # ``custom_field_1..15``, ``recurring_schedule``, ``reminders_schedule``,
+    # ``linked_tasks``, ``task_dependencies``. Tracked under the High-Value
+    # tier of #38; the 15 numbered custom fields need a dict-shaped design call.
+
+    @property
+    def is_archived(self) -> bool:
+        """True iff the task has an archival timestamp."""
+        return self.archived_at is not None
+
+    @property
+    def is_blocked(self) -> bool:
+        """True iff the task has a non-empty block reason."""
+        return self.block_reason is not None
 
 
 class Comment(BaseModel):
@@ -156,17 +172,26 @@ class Subtask(BaseModel):
 class ChangelogEntry(BaseModel):
     """A single entry from a board's changelog feed.
 
-    Fields beyond ``id`` and ``created_at`` are optional — the API's exact
-    shape varies by event type, and we keep this model permissive so the
-    poller never blows up on an unfamiliar action."""
+    Field names mirror the API verbatim (no aliasing) — the wire keys are
+    already pleasant Python identifiers. Fields beyond ``id`` and
+    ``created_at`` are optional: the API's exact shape varies by event type,
+    and ``data`` is the catch-all for action-specific context (e.g. for
+    ``what="created"`` it carries ``user_initials``, ``task_name``,
+    ``workflow_stage_name``, ...)."""
 
     model_config = ConfigDict(extra="ignore")
 
     id: int
     created_at: datetime
-    action: str | None = None
-    actor_id: int | None = None
-    actor_name: str | None = None
-    target_type: str | None = None
-    target_id: int | None = None
-    details: dict[str, Any] | None = None
+    # Action verb (``"created"``, ``"updated"``, ``"moved"``, ...).
+    what: str | None = None
+    user_id: int | None = None
+    # Object the action targeted — ``"Task"``, ``"Board"``, etc.
+    changed_object_type: str | None = None
+    changed_object_id: int | None = None
+    # Pre-rendered human-readable summary. Useful for LLM consumers that just
+    # want a one-line "what happened" string without re-templating ``data``.
+    description: str | None = None
+    # Action-specific payload (e.g. ``user_initials``, ``task_name``,
+    # ``workflow_stage_name``). Shape varies by ``what``.
+    data: dict[str, Any] | None = None

--- a/src/kanbantool_mcp/models.py
+++ b/src/kanbantool_mcp/models.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, computed_field
 
 
 class Column(BaseModel):
@@ -126,11 +126,18 @@ class Task(BaseModel):
     # ``linked_tasks``, ``task_dependencies``. Tracked under the High-Value
     # tier of #38; the 15 numbered custom fields need a dict-shaped design call.
 
+    # ``@computed_field`` is required so pydantic v2 includes the derived
+    # boolean in ``model_dump()`` and ``model_json_schema()`` — a bare
+    # ``@property`` is invisible to the serialiser, which means FastMCP would
+    # never surface the flag to the LLM. The ``prop-decorator`` ignore quiets
+    # the pydantic v2 ``@computed_field`` + ``@property`` decorator-order quirk.
+    @computed_field  # type: ignore[prop-decorator]
     @property
     def is_archived(self) -> bool:
         """True iff the task has an archival timestamp."""
         return self.archived_at is not None
 
+    @computed_field  # type: ignore[prop-decorator]
     @property
     def is_blocked(self) -> bool:
         """True iff the task has a non-empty block reason."""

--- a/tests/test_archive_task.py
+++ b/tests/test_archive_task.py
@@ -26,24 +26,25 @@ async def test_archive_task_happy_path(_inject_client: KanbanToolClient) -> None
     """Archiving a task issues PATCH /tasks/{id}.json with the flat
     ``{"_action": "archive"}`` sentinel body — NOT the ``{"task": {...}}``
     envelope used by update_task — and round-trips the response into a
-    ``Task`` with ``is_archived=True``."""
+    ``Task`` whose computed ``is_archived`` reflects the wire ``archived_at``."""
     response_payload = {
         "id": TASK_ID,
         "name": "Wrap up Q2 release",
         "board_id": 7,
-        "is_archived": True,
+        "archived_at": "2026-04-30T18:00:00Z",
     }
     with respx.mock(assert_all_called=True) as router:
         route = router.patch(TASK_URL).mock(return_value=httpx.Response(200, json=response_payload))
         task = await archive_task(task_id=TASK_ID)
 
     assert task.id == TASK_ID
+    assert task.archived_at == "2026-04-30T18:00:00Z"
     assert task.is_archived is True
 
     request = route.calls.last.request
     assert request.method == "PATCH"
     body = _request_body(route)
-    # Flat top-level sentinel — no "task" envelope, no "is_archived" field.
+    # Flat top-level sentinel — no "task" envelope, no "archived_at" field.
     assert body == {"_action": "archive"}
     assert "task" not in body
 
@@ -58,7 +59,7 @@ async def test_archive_task_already_archived_is_idempotent(
         "id": TASK_ID,
         "name": "Already done",
         "board_id": 7,
-        "is_archived": True,
+        "archived_at": "2026-04-30T18:00:00Z",
     }
     with respx.mock(assert_all_called=True) as router:
         route = router.patch(TASK_URL).mock(return_value=httpx.Response(200, json=response_payload))
@@ -107,7 +108,13 @@ async def test_archive_task_url_shape(_inject_client: KanbanToolClient) -> None:
     with respx.mock(assert_all_called=True) as router:
         route = router.patch(TASK_URL).mock(
             return_value=httpx.Response(
-                200, json={"id": TASK_ID, "name": "x", "board_id": 2, "is_archived": True}
+                200,
+                json={
+                    "id": TASK_ID,
+                    "name": "x",
+                    "board_id": 2,
+                    "archived_at": "2026-04-30T18:00:00Z",
+                },
             )
         )
         await archive_task(task_id=TASK_ID)

--- a/tests/test_create_task.py
+++ b/tests/test_create_task.py
@@ -55,7 +55,7 @@ async def test_create_task_full_payload_renames_lane_id(_inject_client: KanbanTo
         "priority": "high",
         "due_date": "2026-05-15T00:00:00Z",
         "tags": "release,urgent",
-        "assignees": [11, 22],
+        "assigned_user_id": 11,
     }
     with respx.mock(assert_all_called=True) as router:
         route = router.post(TASKS_URL).mock(return_value=httpx.Response(201, json=response_payload))
@@ -95,7 +95,7 @@ async def test_create_task_full_payload_renames_lane_id(_inject_client: KanbanTo
     assert task.priority == "high"
     assert task.due_date == "2026-05-15T00:00:00Z"
     assert task.tags == "release,urgent"
-    assert task.assignees == [11, 22]
+    assert task.assigned_user_id == 11
 
 
 async def test_create_task_unset_optionals_omitted_not_nulled(

--- a/tests/test_get_board.py
+++ b/tests/test_get_board.py
@@ -9,7 +9,7 @@ from pydantic import ValidationError
 
 from kanbantool_mcp.client import KanbanToolClient
 from kanbantool_mcp.exceptions import KanbanToolHTTPError
-from kanbantool_mcp.models import Column, CustomField
+from kanbantool_mcp.models import Column
 from kanbantool_mcp.server import get_board
 
 from .conftest import BASE_URL
@@ -37,6 +37,7 @@ async def test_get_board_happy_path(_inject_client: KanbanToolClient) -> None:
                 "parent_id": None,
                 "wip_limit": None,
                 "type": "queue",
+                "lane_type": "backlog_inventory",
                 "extra_stage_field": "ignored",
             },
             {
@@ -45,25 +46,23 @@ async def test_get_board_happy_path(_inject_client: KanbanToolClient) -> None:
                 "position": 2,
                 "wip_limit": 5,
                 "type": "in-progress",
+                "lane_type": "in_progress",
             },
         ],
         "swimlanes": [
             {"id": 200, "name": "Default", "position": 1, "extra_lane_field": "ignored"},
             {"id": 201, "name": "Expedite", "position": 2},
         ],
-        "card_template": [
-            {
+        "card_template": {
+            "description": {"enabled": True, "position": 1},
+            "priority": {"enabled": True, "position": 2},
+            "custom_field_1": {
+                "enabled": True,
+                "position": 3,
                 "label": "Story Points",
                 "type": "number",
-                "position": 1,
-                "extra_field_meta": "ignored",
             },
-            {
-                "label": "Owner",
-                "type": "user",
-                "position": 2,
-            },
-        ],
+        },
     }
     with respx.mock(assert_all_called=True) as router:
         router.get(_board_url(42)).mock(return_value=httpx.Response(200, json=payload))
@@ -85,8 +84,10 @@ async def test_get_board_happy_path(_inject_client: KanbanToolClient) -> None:
     assert backlog.parent_id is None
     assert backlog.wip_limit is None
     assert backlog.type_ == "queue"
+    assert backlog.lane_type == "backlog_inventory"
     assert in_progress.wip_limit == 5
     assert in_progress.type_ == "in-progress"
+    assert in_progress.lane_type == "in_progress"
 
     assert len(board.swimlanes) == 2
     default_lane, expedite_lane = board.swimlanes
@@ -95,13 +96,12 @@ async def test_get_board_happy_path(_inject_client: KanbanToolClient) -> None:
     assert default_lane.position == 1
     assert expedite_lane.name == "Expedite"
 
-    assert len(board.custom_fields) == 2
-    story_points, owner = board.custom_fields
-    assert story_points.label == "Story Points"
-    assert story_points.type_ == "number"
-    assert story_points.position == 1
-    assert owner.label == "Owner"
-    assert owner.type_ == "user"
+    # ``card_template`` is exposed verbatim as a dict — the API's per-board
+    # config of which card fields are shown.
+    assert board.card_template is not None
+    assert board.card_template["description"] == {"enabled": True, "position": 1}
+    assert board.card_template["custom_field_1"]["label"] == "Story Points"
+    assert board.card_template["custom_field_1"]["type"] == "number"
 
 
 async def test_get_board_minimal_payload_defaults_collections(
@@ -117,7 +117,7 @@ async def test_get_board_minimal_payload_defaults_collections(
     assert board.name == "Tiny"
     assert board.columns == []
     assert board.swimlanes == []
-    assert board.custom_fields == []
+    assert board.card_template is None
 
 
 async def test_get_board_404_raises_http_error(_inject_client: KanbanToolClient) -> None:
@@ -142,31 +142,6 @@ def test_column_serializes_type_alias_not_underscore() -> None:
     json_dumped = column.model_dump(mode="json")
     assert "type" in json_dumped
     assert "type_" not in json_dumped
-
-
-def test_custom_field_serializes_type_alias_not_underscore() -> None:
-    """A JSON dump of a CustomField uses key ``type``, not ``type_``."""
-    field = CustomField.model_validate(
-        {"label": "Owner", "type": "user", "position": 1},
-    )
-    dumped = field.model_dump()
-    assert "type" in dumped
-    assert "type_" not in dumped
-    assert dumped["type"] == "user"
-
-
-def test_custom_field_options_accepts_string() -> None:
-    """Bare-string ``options`` (simple fields) parses cleanly."""
-    field = CustomField.model_validate({"label": "Notes", "options": "single"})
-    assert field.options == "single"
-
-
-def test_custom_field_options_accepts_list() -> None:
-    """Structured list ``options`` (select-style fields) parses cleanly."""
-    field = CustomField.model_validate(
-        {"label": "Severity", "options": ["low", "medium", "high"]},
-    )
-    assert field.options == ["low", "medium", "high"]
 
 
 async def test_get_board_rejects_zero_board_id_before_http() -> None:

--- a/tests/test_get_task.py
+++ b/tests/test_get_task.py
@@ -8,6 +8,7 @@ import respx
 
 from kanbantool_mcp.client import KanbanToolClient
 from kanbantool_mcp.exceptions import KanbanToolHTTPError, KanbanToolPermissionError
+from kanbantool_mcp.models import Task
 from kanbantool_mcp.server import get_task
 
 from .conftest import BASE_URL
@@ -31,13 +32,12 @@ async def test_get_task_happy_path(_inject_client: KanbanToolClient) -> None:
         "due_date": "2026-05-15T00:00:00Z",
         "start_date": "2026-04-30T00:00:00Z",
         "tags": "release,urgent",
-        "assignees": [11, 22],
-        "is_archived": False,
-        "is_blocked": True,
+        "assigned_user_id": 11,
+        "archived_at": None,
         "block_reason": "Waiting on review",
         "subtasks_count": 4,
-        "comment_count": 12,
-        "time_tracker_total": 3600,
+        "comments_count": 12,
+        "timers_total": 3600,
         "created_at": "2026-04-01T09:30:00Z",
         "updated_at": "2026-04-29T17:45:00Z",
         "extra_unknown_field": "ignored",
@@ -58,13 +58,14 @@ async def test_get_task_happy_path(_inject_client: KanbanToolClient) -> None:
     assert task.due_date == "2026-05-15T00:00:00Z"
     assert task.start_date == "2026-04-30T00:00:00Z"
     assert task.tags == "release,urgent"
-    assert task.assignees == [11, 22]
+    assert task.assigned_user_id == 11
+    assert task.archived_at is None
     assert task.is_archived is False
     assert task.is_blocked is True
     assert task.block_reason == "Waiting on review"
     assert task.subtasks_count == 4
-    assert task.comment_count == 12
-    assert task.time_tracker_total == 3600
+    assert task.comments_count == 12
+    assert task.timers_total == 3600
     assert task.created_at == "2026-04-01T09:30:00Z"
     assert task.updated_at == "2026-04-29T17:45:00Z"
 
@@ -93,10 +94,13 @@ async def test_get_task_minimal_payload(_inject_client: KanbanToolClient) -> Non
     assert task.board_id is None
     assert task.lane_id is None
     assert task.swimlane_id is None
-    assert task.assignees is None
+    assert task.assigned_user_id is None
     assert task.subtasks_count is None
-    assert task.comment_count is None
-    assert task.time_tracker_total is None
+    assert task.comments_count is None
+    assert task.timers_total is None
+    # Computed flags default to False when their backing fields are unset.
+    assert task.is_archived is False
+    assert task.is_blocked is False
 
 
 async def test_get_task_404_raises_http_error(_inject_client: KanbanToolClient) -> None:
@@ -128,3 +132,24 @@ async def test_get_task_url_shape(_inject_client: KanbanToolClient) -> None:
     request = route.calls.last.request
     assert request.method == "GET"
     assert str(request.url) == _task_url(123)
+
+
+def test_task_is_archived_property_tracks_archived_at() -> None:
+    """``is_archived`` is True iff ``archived_at`` is set; absence is False."""
+    unarchived = Task.model_validate({"id": 1, "name": "live"})
+    assert unarchived.is_archived is False
+
+    explicit_null = Task.model_validate({"id": 2, "name": "live", "archived_at": None})
+    assert explicit_null.is_archived is False
+
+    archived = Task.model_validate({"id": 3, "name": "old", "archived_at": "2026-04-30T00:00:00Z"})
+    assert archived.is_archived is True
+
+
+def test_task_is_blocked_property_tracks_block_reason() -> None:
+    """``is_blocked`` is True iff ``block_reason`` is set; absence is False."""
+    unblocked = Task.model_validate({"id": 1, "name": "free"})
+    assert unblocked.is_blocked is False
+
+    blocked = Task.model_validate({"id": 2, "name": "stuck", "block_reason": "Waiting on review"})
+    assert blocked.is_blocked is True

--- a/tests/test_get_task.py
+++ b/tests/test_get_task.py
@@ -153,3 +153,39 @@ def test_task_is_blocked_property_tracks_block_reason() -> None:
 
     blocked = Task.model_validate({"id": 2, "name": "stuck", "block_reason": "Waiting on review"})
     assert blocked.is_blocked is True
+
+
+def test_task_model_dump_includes_computed_flags() -> None:
+    """``is_archived`` / ``is_blocked`` must appear in ``model_dump()`` so that
+    FastMCP serialises them onto the wire. A bare ``@property`` is invisible
+    to pydantic v2's serialiser; only ``@computed_field`` is picked up."""
+    archived_and_blocked = Task.model_validate(
+        {
+            "id": 1,
+            "name": "stuck-and-archived",
+            "archived_at": "2026-04-30T12:00:00Z",
+            "block_reason": "Waiting on review",
+        }
+    )
+    dumped = archived_and_blocked.model_dump()
+    assert "is_archived" in dumped
+    assert "is_blocked" in dumped
+    assert dumped["is_archived"] is True
+    assert dumped["is_blocked"] is True
+
+    live_and_unblocked = Task.model_validate({"id": 2, "name": "fresh"})
+    dumped = live_and_unblocked.model_dump()
+    assert "is_archived" in dumped
+    assert "is_blocked" in dumped
+    assert dumped["is_archived"] is False
+    assert dumped["is_blocked"] is False
+
+
+def test_task_model_json_schema_advertises_computed_flags() -> None:
+    """The serialization JSON schema (the one FastMCP shows the LLM for the
+    *output* of a tool) must list both computed flags. Computed fields are
+    output-only, so they live in the serialization schema, not the default
+    validation one."""
+    schema = Task.model_json_schema(mode="serialization")
+    assert "is_archived" in schema["properties"]
+    assert "is_blocked" in schema["properties"]

--- a/tests/test_list_boards.py
+++ b/tests/test_list_boards.py
@@ -56,7 +56,7 @@ async def test_list_boards_happy_path(_inject_client: KanbanToolClient) -> None:
     # The compact /users/current payload omits detail-only collections.
     assert first.columns == []
     assert first.swimlanes == []
-    assert first.custom_fields == []
+    assert first.card_template is None
 
 
 async def test_list_boards_empty(_inject_client: KanbanToolClient) -> None:

--- a/tests/test_recent_changes.py
+++ b/tests/test_recent_changes.py
@@ -25,20 +25,20 @@ async def test_recent_changes_happy_path(_inject_client: KanbanToolClient) -> No
             {
                 "id": 1001,
                 "created_at": "2026-04-30T10:15:00Z",
-                "action": "task_created",
-                "actor_id": 7,
-                "actor_name": "Ada Lovelace",
-                "target_type": "Task",
-                "target_id": 555,
-                "details": {"title": "Write spec"},
+                "what": "created",
+                "user_id": 7,
+                "changed_object_type": "Task",
+                "changed_object_id": 555,
+                "description": "Ada Lovelace created Write spec",
+                "data": {"user_initials": "AL", "task_name": "Write spec"},
                 "extra_unknown_field": "ignored",
             },
             {
                 "id": 1000,
                 "created_at": "2026-04-30T09:00:00Z",
-                "action": "task_moved",
-                "target_type": "Task",
-                "target_id": 555,
+                "what": "moved",
+                "changed_object_type": "Task",
+                "changed_object_id": 555,
             },
         ]
     }
@@ -50,18 +50,18 @@ async def test_recent_changes_happy_path(_inject_client: KanbanToolClient) -> No
     newest, older = result
     assert newest.id == 1001
     assert newest.created_at == datetime(2026, 4, 30, 10, 15, 0, tzinfo=UTC)
-    assert newest.action == "task_created"
-    assert newest.actor_id == 7
-    assert newest.actor_name == "Ada Lovelace"
-    assert newest.target_type == "Task"
-    assert newest.target_id == 555
-    assert newest.details == {"title": "Write spec"}
+    assert newest.what == "created"
+    assert newest.user_id == 7
+    assert newest.changed_object_type == "Task"
+    assert newest.changed_object_id == 555
+    assert newest.description == "Ada Lovelace created Write spec"
+    assert newest.data == {"user_initials": "AL", "task_name": "Write spec"}
 
     assert older.id == 1000
-    assert older.action == "task_moved"
-    assert older.actor_id is None
-    assert older.actor_name is None
-    assert older.details is None
+    assert older.what == "moved"
+    assert older.user_id is None
+    assert older.description is None
+    assert older.data is None
 
 
 async def test_recent_changes_passes_since_as_query_param(

--- a/tests/test_search_tasks.py
+++ b/tests/test_search_tasks.py
@@ -26,7 +26,7 @@ async def test_search_tasks_happy_path(_inject_client: KanbanToolClient) -> None
                 "priority": "high",
                 "tags": "release,urgent",
                 "subtasks_count": 2,
-                "comment_count": 3,
+                "comments_count": 3,
                 "extra_unknown_field": "ignored",
             },
             {
@@ -50,7 +50,7 @@ async def test_search_tasks_happy_path(_inject_client: KanbanToolClient) -> None
     assert first.priority == "high"
     assert first.tags == "release,urgent"
     assert first.subtasks_count == 2
-    assert first.comment_count == 3
+    assert first.comments_count == 3
     assert second.id == 2
     assert second.name == "Write changelog"
     assert second.priority == 1


### PR DESCRIPTION
## Summary

Live-API spike (test account, welcome board) showed `extra="ignore"` was masking shape and name mismatches across three models — every endpoint that returns these silently drops real data. This PR fixes the **critical tier only** for #38, #59, and #60. High-Value and v0.2.0 work continues in follow-ups.

### `Task` (#38, critical tier)
- Rename `comment_count` -> `comments_count`.
- Rename `time_tracker_total` -> `timers_total`.
- Replace `assignees: list[int]` with `assigned_user_id: int | None` — API returns one user, not a list.
- Replace `is_archived: bool` with `archived_at: str | None` plus a computed `is_archived` property (matches wire shape, preserves caller convenience).
- Drop `is_blocked: bool` (not in API); add a computed `is_blocked` derived from `block_reason`.

### `Board` (#59, critical tier)
- Drop `custom_fields: list[CustomField]` and the `CustomField` model — `card_template` is a config dict, not a user-defined-fields list.
- Add `card_template: dict[str, Any] | None` exposing the real per-board "which card fields are shown" config.
- Expose `Column.lane_type` so the LLM can distinguish columns semantically (`"backlog_inventory"`, `"in_progress"`, `"completed"`, ...).

### `ChangelogEntry` (#60, fully critical — every field name was wrong)
- `action` -> `what`
- `actor_id` -> `user_id`
- `target_type` -> `changed_object_type`
- `target_id` -> `changed_object_id`
- `details` -> `data`
- Drop `actor_name` (not in API at this position; use `data["user_initials"]`).
- Add `description` — the human-readable summary the API renders.

### Out of scope (follow-up PRs)
Per the issue bodies, these are intentionally deferred and marked with `# v0.2.0:` comments where useful:
- **High-Value (#38):** additive Task fields — `size_estimate`, `card_color`, `search_tags`, `collaborators`, `card_type_id`, `custom_field_1..15`, ...
- **High-Value (#59):** embedded `tasks: list[Task]` on `Board`, `card_types`, `collaborators`, expanded `Column`/`Swimlane` shapes, hierarchy modelling.
- **v0.2.0:** `recurring_schedule`, `reminders_schedule`, `linked_tasks`, `task_dependencies`, the 15 numbered `custom_field_N` design call.

### Tests
Updated every fixture and assertion across `test_get_task`, `test_search_tasks`, `test_get_board`, `test_list_boards`, `test_recent_changes`, `test_archive_task`, `test_create_task` to match the new shape. Added direct coverage for `Task.is_archived` and `Task.is_blocked` computed properties. The `CustomField` round-trip tests are dropped along with the model.

## Test plan

- [x] `uv run ruff format --check .`
- [x] `uv run ruff check .`
- [x] `uv run ty check`
- [x] `uv run pytest -q` — 113 passed
- [ ] CI green on push

Closes #38
Closes #59
Closes #60

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>