### PR TITLE
fix(server): use assigned_user_id on create_task/update_task writes

### DIFF
--- a/src/kanbantool_mcp/server.py
+++ b/src/kanbantool_mcp/server.py
@@ -163,7 +163,7 @@ async def create_task(
     description: str | None = None,
     lane_id: int | None = None,
     position: int | None = None,
-    assignees: list[int] | None = None,
+    assigned_user_id: int | None = None,
     due_date: str | None = None,
     priority: int | str | None = None,
     tags: str | None = None,
@@ -171,6 +171,9 @@ async def create_task(
     """Create a new task on a board. Only ``name`` and ``board_id`` are required.
 
     ``lane_id`` is the target column (matches ``Task.lane_id`` on fetched tasks).
+    ``assigned_user_id`` sets the single assignee — Kanban Tool tasks have one
+    assignee, not a list. (The API silently ignores a legacy ``assignees: [int]``
+    payload on writes, so this kwarg is the wire field name directly.)
     ``priority`` accepts the string enum or the raw integer; ``tags`` is a
     comma-separated string; ``due_date`` is an ISO 8601 string forwarded as-is.
     Unset kwargs are omitted from the request, never sent as explicit null."""
@@ -183,8 +186,8 @@ async def create_task(
         payload["workflow_stage_id"] = lane_id
     if position is not None:
         payload["position"] = position
-    if assignees is not None:
-        payload["assignees"] = assignees
+    if assigned_user_id is not None:
+        payload["assigned_user_id"] = assigned_user_id
     if due_date is not None:
         payload["due_date"] = due_date
     if priority is not None:
@@ -280,14 +283,16 @@ async def update_task(
     due_date: str | None = None,
     start_date: str | None = None,
     tags: str | None = None,
-    assignees: list[int] | None = None,
+    assigned_user_id: int | None = None,
 ) -> Task:
     """Partially update a task's fields. Only the kwargs you pass are sent;
     ``None`` means *omit*, not *clear* (the API ignores nulls, doesn't wipe).
 
     Field set mirrors ``create_task``; same wire conventions for ``priority``,
-    ``tags``, and date fields. For column/lane/position changes prefer
-    ``move_task`` — it's the intent-revealing surface for that workflow.
+    ``tags``, and date fields. ``assigned_user_id`` sets the single assignee —
+    Kanban Tool tasks have one assignee, not a list. For column/lane/position
+    changes prefer ``move_task`` — it's the intent-revealing surface for that
+    workflow.
     Raises ``ValueError`` if every field is ``None`` (no-op guard)."""
     return await _patch_task(
         task_id,
@@ -303,7 +308,7 @@ async def update_task(
             "due_date": due_date,
             "start_date": start_date,
             "tags": tags,
-            "assignees": assignees,
+            "assigned_user_id": assigned_user_id,
         },
     )
 

--- a/tests/test_create_task.py
+++ b/tests/test_create_task.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from typing import Any
 
 import httpx
 import pytest
@@ -65,7 +66,7 @@ async def test_create_task_full_payload_renames_lane_id(_inject_client: KanbanTo
             description="Cut a release once CI is green.",
             lane_id=100,
             position=3,
-            assignees=[11, 22],
+            assigned_user_id=11,
             due_date="2026-05-15T00:00:00Z",
             priority="high",
             tags="release,urgent",
@@ -80,12 +81,15 @@ async def test_create_task_full_payload_renames_lane_id(_inject_client: KanbanTo
         "description": "Cut a release once CI is green.",
         "workflow_stage_id": 100,
         "position": 3,
-        "assignees": [11, 22],
+        "assigned_user_id": 11,
         "due_date": "2026-05-15T00:00:00Z",
         "priority": "high",
         "tags": "release,urgent",
     }
     assert "lane_id" not in inner
+    # The legacy list-shaped key must never reach the wire — the API silently
+    # ignores it (#62) and the LLM-facing kwarg has been removed.
+    assert "assignees" not in inner
 
     # Round-trip: the response is parsed back into a Task with the same alias.
     assert task.id == 4242
@@ -116,12 +120,43 @@ async def test_create_task_unset_optionals_omitted_not_nulled(
         "workflow_stage_id",
         "lane_id",
         "position",
+        "assigned_user_id",
         "assignees",
         "due_date",
         "priority",
         "tags",
     ):
         assert absent_key not in inner
+
+
+async def test_create_task_assigned_user_id_serializes_directly(
+    _inject_client: KanbanToolClient,
+) -> None:
+    """``assigned_user_id`` is the wire field name (not an alias) — it must
+    land in the body as ``{"task": {"assigned_user_id": <int>, ...}}``."""
+    response_payload = {"id": 1, "name": "x", "board_id": 2, "assigned_user_id": 11}
+    with respx.mock(assert_all_called=True) as router:
+        route = router.post(TASKS_URL).mock(return_value=httpx.Response(201, json=response_payload))
+        task = await create_task(name="x", board_id=2, assigned_user_id=11)
+
+    assert task.assigned_user_id == 11
+    inner = _request_body(route)["task"]
+    assert isinstance(inner, dict)
+    assert inner == {"name": "x", "board_id": 2, "assigned_user_id": 11}
+
+
+async def test_create_task_legacy_assignees_kwarg_rejected(
+    _inject_client: KanbanToolClient,
+) -> None:
+    """The legacy ``assignees=[int]`` kwarg has been removed (the API silently
+    ignored it — see #62). Calling with it must raise ``TypeError`` before any
+    HTTP traffic, so the LLM gets an immediate signal to migrate."""
+    # Route through a kwargs dict typed as ``dict[str, Any]`` so the static
+    # type-checker doesn't flag the removed kwarg — we're deliberately
+    # exercising runtime rejection.
+    legacy_kwargs: dict[str, Any] = {"name": "x", "board_id": 2, "assignees": [11]}
+    with pytest.raises(TypeError):
+        await create_task(**legacy_kwargs)
 
 
 async def test_create_task_422_field_errors_parsed(_inject_client: KanbanToolClient) -> None:

--- a/tests/test_update_task.py
+++ b/tests/test_update_task.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from typing import Any
 from unittest.mock import AsyncMock
 
 import httpx
@@ -110,9 +111,45 @@ async def test_update_task_unset_optionals_omitted_not_nulled(
         "due_date",
         "start_date",
         "tags",
+        "assigned_user_id",
         "assignees",
     ):
         assert absent_key not in inner
+
+
+async def test_update_task_assigned_user_id_serializes_directly(
+    _inject_client: KanbanToolClient,
+) -> None:
+    """``assigned_user_id`` is the wire field name (not an alias) — a
+    single-field update must land as ``{"task": {"assigned_user_id": <int>}}``."""
+    response_payload = {
+        "id": TASK_ID,
+        "name": "x",
+        "board_id": 2,
+        "assigned_user_id": 11,
+    }
+    with respx.mock(assert_all_called=True) as router:
+        route = router.put(TASK_URL).mock(return_value=httpx.Response(200, json=response_payload))
+        task = await update_task(task_id=TASK_ID, assigned_user_id=11)
+
+    assert task.assigned_user_id == 11
+    inner = _request_body(route)["task"]
+    assert isinstance(inner, dict)
+    assert inner == {"assigned_user_id": 11}
+
+
+async def test_update_task_legacy_assignees_kwarg_rejected(
+    _inject_client: KanbanToolClient,
+) -> None:
+    """The legacy ``assignees=[int]`` kwarg has been removed (the API silently
+    ignored it — see #62). Calling with it must raise ``TypeError`` before any
+    HTTP traffic."""
+    # Route through a kwargs dict typed as ``dict[str, Any]`` so the static
+    # type-checker doesn't flag the removed kwarg — we're deliberately
+    # exercising runtime rejection.
+    legacy_kwargs: dict[str, Any] = {"task_id": TASK_ID, "assignees": [11]}
+    with pytest.raises(TypeError):
+        await update_task(**legacy_kwargs)
 
 
 async def test_update_task_no_args_raises_value_error_without_http(
@@ -147,9 +184,11 @@ async def test_update_task_no_args_raises_value_error_without_http(
         "due_date",
         "start_date",
         "tags",
-        "assignees",
+        "assigned_user_id",
     ):
         assert expected in msg, f"update_task ValueError message missing '{expected}': {msg!r}"
+    # The legacy list-shaped key has been removed from this surface (#62).
+    assert "assignees" not in msg.replace("assigned_user_id", "")
     # The wire-only name must not surface to the LLM — they call ``lane_id``.
     assert "workflow_stage_id" not in msg
     # ``column_id`` belongs to ``move_task``'s surface only; it must not bleed


### PR DESCRIPTION
## Summary

- Fixes write-side counterpart of #61: changes the `assignees: list[int]` kwarg on `create_task` and `update_task` to `assigned_user_id: int | None`, the actual Kanban Tool API v3 wire field.
- Per the [spike findings on #62](https://github.com/VeryLongOrgNameSuchWow/kanbantool-mcp/issues/62), the API silently ignores `assignees: [int]` on `POST/PATCH /tasks.json` — tasks are created/updated successfully but the response comes back with `assigned_user_id: null`. Our previous tool surface was silently dropping the assignee in production.
- Adds focused tests: `assigned_user_id=11` lands on the wire as `{"task": {"assigned_user_id": 11}}`; the default (`None`) is omitted from the body; the removed `assignees` kwarg now raises `TypeError`.

## Breaking API change (pre-1.0 alpha)

- `create_task(assignees=[int])` → `create_task(assigned_user_id=int)`
- `update_task(assignees=[int])` → `update_task(assigned_user_id=int)`

No backwards-compat shim — shipping a kwarg that silently dropped data is worse than a clean `TypeError` that points the LLM at the new name. Symmetric with the read-side rename in #61.

## Test plan

- [x] `uv run ruff format --check .`
- [x] `uv run ruff check .`
- [x] `uv run ty check`
- [x] `uv run pytest` (119 passed)
- [ ] CI green

Closes #62

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>