### PR TITLE
ci(integration): add manual live integration workflow against real account

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,32 @@
+name: Live Integration
+
+# Manual-only: this workflow hits a real Kanban Tool account and consumes
+# API quota, so we do not run it on push/PR. Dispatch via the GitHub UI or
+# ``gh workflow run integration.yml``.
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  live:
+    runs-on: ubuntu-latest
+    # Single Python version on purpose — these calls hit the real API, so a
+    # matrix would multiply quota cost without adding signal. Pin to the
+    # repo's primary supported version.
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
+        with:
+          enable-cache: true
+      - run: uv python install 3.13
+      - run: uv sync --dev
+      # Only the read tools are exercised live — write tools would create real
+      # artifacts on the test account every run, and the #62 spike already
+      # validated the write path. Read coverage proves the wire contract for
+      # our renamed/aliased fields, which is the bit most likely to drift.
+      - run: uv run pytest tests/integration/ -v
+        env:
+          KANBANTOOL_DOMAIN: ${{ secrets.KANBANTOOL_DOMAIN_TEST }}
+          KANBANTOOL_API_TOKEN: ${{ secrets.KANBANTOOL_API_TOKEN_TEST }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,4 +59,8 @@ quote-style = "double"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+# Live integration tests hit a real Kanban Tool account — exclude from the
+# default run so ``uv run pytest`` stays offline. The ``Live Integration``
+# workflow opts in via ``pytest tests/integration/``.
+addopts = "--ignore=tests/integration"
 asyncio_mode = "auto"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,45 @@
+"""Fixtures for live integration tests.
+
+These tests hit a real Kanban Tool account via HTTP. They are excluded from
+the default ``pytest`` run (see ``pyproject.toml``'s ``testpaths``) and only
+execute in the ``Live Integration`` workflow, where ``KANBANTOOL_DOMAIN`` and
+``KANBANTOOL_API_TOKEN`` come from repository secrets.
+
+The parent ``tests/conftest.py`` defines an autouse fixture that pins the env
+to dummy ``testacct``/``test-token`` values for offline unit tests. We override
+that fixture here as a no-op so the real env vars survive into ``Config.from_env()``.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import AsyncIterator
+
+import pytest
+
+from kanbantool_mcp.client import KanbanToolClient
+from kanbantool_mcp.config import Config
+
+
+@pytest.fixture(autouse=True)
+def _kanbantool_env() -> None:
+    """No-op override of the parent autouse fixture.
+
+    The unit-test conftest pins ``KANBANTOOL_DOMAIN``/``KANBANTOOL_API_TOKEN``
+    to dummy values; live tests must keep the real env vars set by the workflow.
+    Skip the whole module if either is missing — running these locally without
+    credentials would either 401 or hit the wrong account.
+    """
+    for var in ("KANBANTOOL_DOMAIN", "KANBANTOOL_API_TOKEN"):
+        if not os.environ.get(var):
+            pytest.skip(f"{var} not set; live integration tests require real credentials.")
+
+
+@pytest.fixture
+async def live_client() -> AsyncIterator[KanbanToolClient]:
+    """A ``KanbanToolClient`` wired to the real account from env."""
+    c = KanbanToolClient(Config.from_env())
+    try:
+        yield c
+    finally:
+        await c.aclose()

--- a/tests/integration/test_live_read_tools.py
+++ b/tests/integration/test_live_read_tools.py
@@ -1,0 +1,151 @@
+"""Live integration tests for the read tools.
+
+These hit a real Kanban Tool test account. They are excluded from the default
+``pytest`` run (see ``pyproject.toml``'s ``testpaths``) and only execute under
+the ``Live Integration`` workflow on demand.
+
+Coverage scope: the five read tools end-to-end against the seeded "Welcome"
+board on the test account. We deliberately do NOT exercise the write tools
+live — they would create real artifacts on the account every run and the
+spike in #62 already confirmed the write path. Read coverage proves the wire
+contract for our renamed/aliased fields, which is the bit most likely to
+silently drift.
+
+Assertions are SHAPE-not-VALUE: the test account's task counts and content
+will shift over time as we exercise the integration. Locking exact numbers
+would make the suite brittle without adding signal.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kanbantool_mcp import server
+from kanbantool_mcp.client import KanbanToolClient
+from kanbantool_mcp.models import Board, ChangelogEntry, Task
+from kanbantool_mcp.server import (
+    get_board,
+    get_task,
+    list_boards,
+    recent_changes,
+    search_tasks,
+)
+
+# The seeded "Welcome to Kanban Tool!" board id on the test account. Stable
+# across runs; if Kanban Tool ever re-seeds welcome boards with a different
+# id this is the one knob to update.
+_WELCOME_BOARD_ID = 1180501
+_WELCOME_BOARD_NAME = "Welcome to Kanban Tool!"
+
+
+@pytest.fixture
+def _inject_live_client(
+    monkeypatch: pytest.MonkeyPatch, live_client: KanbanToolClient
+) -> KanbanToolClient:
+    """Wire the live client into ``server._client`` so the MCP tools use it.
+
+    Mirrors the unit-test ``_inject_client`` fixture; lives here (not in the
+    integration ``conftest.py``) because it depends on the per-test
+    ``monkeypatch`` fixture and is only consumed by tests that drive the MCP
+    tool functions directly.
+    """
+    monkeypatch.setattr(server, "_client", live_client)
+    return live_client
+
+
+async def test_list_boards_returns_welcome_board(_inject_live_client: KanbanToolClient) -> None:
+    boards = await list_boards()
+
+    assert isinstance(boards, list)
+    assert len(boards) >= 1
+    assert all(isinstance(b, Board) for b in boards)
+
+    welcome = next((b for b in boards if b.name == _WELCOME_BOARD_NAME), None)
+    assert welcome is not None, (
+        f"expected a board named {_WELCOME_BOARD_NAME!r}; got {[b.name for b in boards]!r}"
+    )
+    assert welcome.id == _WELCOME_BOARD_ID
+
+
+async def test_get_board_returns_columns_and_card_template(
+    _inject_live_client: KanbanToolClient,
+) -> None:
+    board = await get_board(_WELCOME_BOARD_ID)
+
+    assert isinstance(board, Board)
+    assert board.id == _WELCOME_BOARD_ID
+    assert board.name == _WELCOME_BOARD_NAME
+    # The detail endpoint surfaces columns (wire: ``workflow_stages``) and
+    # ``card_template``; both are absent from the compact list endpoint.
+    assert len(board.columns) >= 1
+    assert isinstance(board.card_template, dict)
+    assert len(board.card_template) >= 1
+
+
+async def test_search_tasks_returns_non_archived_tutorial_tasks(
+    _inject_live_client: KanbanToolClient,
+) -> None:
+    # Earlier spike probes saw ``/tasks/search.json`` 500 on an empty account;
+    # with the seeded welcome board populated the call should succeed. If it
+    # still 500s, that's a real upstream finding worth flagging in CI output.
+    tasks = await search_tasks(query="archived:false", board_id=_WELCOME_BOARD_ID)
+
+    assert isinstance(tasks, list)
+    assert len(tasks) >= 1
+    assert all(isinstance(t, Task) for t in tasks)
+    assert all(t.board_id == _WELCOME_BOARD_ID for t in tasks)
+    # ``archived:false`` should exclude the two archived spike tasks (ids
+    # 77649691 / 77649693). Assert the filter behaved rather than the count.
+    assert all(t.archived_at is None for t in tasks)
+
+
+async def test_get_task_populates_renamed_wire_fields(
+    _inject_live_client: KanbanToolClient,
+) -> None:
+    # Pick a task id off the live board rather than hard-coding one — task ids
+    # on the welcome board aren't documented to be stable, and this exercises
+    # the discovery flow an LLM agent would actually use.
+    board = await get_board(_WELCOME_BOARD_ID)
+    search_hits = await search_tasks(query="archived:false", board_id=_WELCOME_BOARD_ID)
+    assert search_hits, "no non-archived tasks on the welcome board to fetch"
+    task_id = search_hits[0].id
+
+    task = await get_task(task_id)
+
+    assert isinstance(task, Task)
+    assert task.id == task_id
+    assert task.board_id == _WELCOME_BOARD_ID
+    # The renamed inbound alias: wire ``workflow_stage_id`` → model ``lane_id``.
+    assert task.lane_id is not None
+    assert task.lane_id in {c.id for c in board.columns}
+    # Counts/totals surface as their renamed model fields. They're typed
+    # ``int | None`` — assert the type, not a specific value, since the test
+    # account's tutorial tasks may or may not have comments/timers.
+    assert task.comments_count is None or isinstance(task.comments_count, int)
+    assert task.timers_total is None or isinstance(task.timers_total, int)
+    assert task.assigned_user_id is None or isinstance(task.assigned_user_id, int)
+    # Non-archived path: ``archived_at`` should be None and the derived
+    # ``is_archived`` flag should agree.
+    assert task.archived_at is None
+    assert task.is_archived is False
+    # ``block_reason`` is optional; just lock the type.
+    assert task.block_reason is None or isinstance(task.block_reason, str)
+
+
+async def test_recent_changes_populates_renamed_fields(
+    _inject_live_client: KanbanToolClient,
+) -> None:
+    entries = await recent_changes(board_id=_WELCOME_BOARD_ID)
+
+    assert isinstance(entries, list)
+    assert len(entries) >= 1
+    assert all(isinstance(e, ChangelogEntry) for e in entries)
+
+    first = entries[0]
+    # Lock the renamed-field surface — these are the fields most likely to
+    # silently drift if the API ever renames them upstream.
+    assert first.what is not None
+    assert isinstance(first.what, str)
+    assert first.user_id is None or isinstance(first.user_id, int)
+    assert first.changed_object_type is None or isinstance(first.changed_object_type, str)
+    assert first.description is None or isinstance(first.description, str)


### PR DESCRIPTION
## Summary

- New `.github/workflows/integration.yml` (`workflow_dispatch` only) runs read-tool tests end-to-end against a real Kanban Tool test account, gated on the pre-configured `KANBANTOOL_DOMAIN_TEST` / `KANBANTOOL_API_TOKEN_TEST` repo secrets.
- New `tests/integration/` directory with its own `conftest.py` that overrides the unit-test autouse env fixture so real credentials survive into `Config.from_env()` (and skips cleanly when they're absent locally).
- `pyproject.toml` gains `addopts = "--ignore=tests/integration"` so default `uv run pytest` stays offline; the workflow opts in via `pytest tests/integration/`.

Closes #18.

## Design choices

**Test isolation — directory separation, not markers.** A nested `tests/integration/` dir + `--ignore` is harder to mis-fire than `@pytest.mark.live`: a stray dev run or stripped-down CI invocation can't accidentally consume API quota, and the conftest layering gives a natural place to override the unit-test env fixture.

**Coverage — read tools only.** `list_boards`, `get_board`, `search_tasks`, `get_task`, `recent_changes`. Write tools would create real artifacts on the account every run, and the #62 spike already validated the write path; read coverage is what proves the renamed/aliased wire-field contract (`comments_count`, `timers_total`, `assigned_user_id`, `archived_at`, `block_reason`, changelog `what`/`user_id`/`changed_object_type`/`description`), which is the bit most likely to silently drift.

**Shape-not-value assertions.** The test account's task counts and content will shift over time as we exercise the integration. We assert types and presence of renamed fields, not exact counts or strings — `len(boards) >= 1`, not `== 1`.

**Workflow shape.** Single Python 3.13 job (no matrix — these are real API calls; matrix multiplies cost without coverage), `permissions: contents: read`, SHA-pinned actions per the existing `ci.yml` style. No concurrency group: manual trigger only, contention is rare.

## Notes for the reviewer / maintainer

- **The new workflow does NOT run on this PR's CI.** It's `workflow_dispatch` only. Once merged, dispatch via `gh workflow run integration.yml --repo VeryLongOrgNameSuchWow/kanbantool-mcp` (or the Actions UI). The existing `ci.yml` still runs on the PR as usual and provides offline coverage.
- The two archived spike tasks (ids `77649691` / `77649693`) on the welcome board are correctly excluded by the `archived:false` query — `test_search_tasks_returns_non_archived_tutorial_tasks` asserts `archived_at is None` on every result rather than locking a count.
- If `/tasks/search.json` still 500s on this account (it did on an empty account during earlier probes), `test_search_tasks_returns_non_archived_tutorial_tasks` will surface that as a real upstream finding worth filing.

## Test plan

- [x] `uv run pytest` — 119/119 passing locally, integration dir excluded.
- [x] `uv run pytest tests/integration/` — 5 tests skip cleanly when env vars are absent (local dev path).
- [x] `uv run ruff check .` clean.
- [x] `uv run ruff format --check .` clean.
- [x] `uv run ty check` clean.
- [ ] After merge: `gh workflow run integration.yml` — confirm 5/5 live tests pass against the seeded welcome board.