### PR TITLE
ci(integration): fail fast when repo secrets are missing

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -22,6 +22,17 @@ jobs:
           enable-cache: true
       - run: uv python install 3.13
       - run: uv sync --dev
+      # Without this guard, missing/empty repo secrets would resolve to "" and
+      # the conftest skip-on-missing path would mark every test SKIPPED, which
+      # the workflow then reports as success — green check that means
+      # "nothing ran." Fail loudly instead.
+      - name: Verify live secrets are bound
+        env:
+          KANBANTOOL_DOMAIN_TEST: ${{ secrets.KANBANTOOL_DOMAIN_TEST }}
+          KANBANTOOL_API_TOKEN_TEST: ${{ secrets.KANBANTOOL_API_TOKEN_TEST }}
+        run: |
+          : "${KANBANTOOL_DOMAIN_TEST:?KANBANTOOL_DOMAIN_TEST repo secret is not set}"
+          : "${KANBANTOOL_API_TOKEN_TEST:?KANBANTOOL_API_TOKEN_TEST repo secret is not set}"
       # Only the read tools are exercised live — write tools would create real
       # artifacts on the test account every run, and the #62 spike already
       # validated the write path. Read coverage proves the wire contract for


### PR DESCRIPTION
## Summary
- Adds a one-step preflight to `integration.yml` that fails the job if either `KANBANTOOL_DOMAIN_TEST` or `KANBANTOOL_API_TOKEN_TEST` resolves to empty.
- Prevents the silent "all-skipped green" failure mode where the workflow looks healthy but exercised nothing.
- The conftest's skip-on-missing behavior is unchanged — it remains correct for local runs (no env = skip, not fail).

Closes #65

## Test plan
- [x] `uv run pytest` — offline suite still 119/119 (no test-file changes)
- [x] `uv run ruff check . && ruff format --check .` — clean
- [x] `uv run ty check` — clean
- [ ] CI matrix on this PR — green
- [ ] Post-merge: `gh workflow run integration.yml` confirms the workflow still runs end-to-end with secrets bound (manual smoke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)