### PR TITLE
fix(server,models): align read tools with live API wire shapes

### DIFF
--- a/src/kanbantool_mcp/models.py
+++ b/src/kanbantool_mcp/models.py
@@ -25,7 +25,11 @@ class Column(BaseModel):
     model_config = ConfigDict(extra="ignore", populate_by_name=True, serialize_by_alias=True)
 
     id: int
-    name: str
+    # Live API returns ``null`` for the synthetic root stage that parents the
+    # real columns (the one whose ``parent_id is None`` and ``lane_type is None``).
+    # Keep the field nullable so the full tree validates; consumers filter
+    # leaves via ``parent_id`` if they want only display columns.
+    name: str | None = None
     position: int | None = None
     parent_id: int | None = None
     wip_limit: int | None = None

--- a/src/kanbantool_mcp/server.py
+++ b/src/kanbantool_mcp/server.py
@@ -101,9 +101,8 @@ async def recent_changes(board_id: int, since: datetime | None = None) -> list[C
     Poll sparingly: 30-120s cadence, not per-keystroke."""
     params = {"since": since.isoformat()} if since is not None else None
     data = await _get_client().request("GET", f"boards/{board_id}/changelog", params=params)
-    raw = data.get("changelog", []) if isinstance(data, dict) else []
     # M3: consider wrapping ValidationError as KanbanToolHTTPError("malformed changelog payload").
-    return [ChangelogEntry.model_validate(entry) for entry in raw]
+    return [ChangelogEntry.model_validate(entry) for entry in data]
 
 
 # Hard ceiling on a single page. Defends against an LLM hallucinating a huge
@@ -151,7 +150,10 @@ async def search_tasks(
         params["board_id"] = board_id
 
     data = await _get_client().request("GET", "tasks/search", params=params)
-    raw = data.get("tasks", []) if isinstance(data, dict) else []
+    # When ``limit``/``page`` are supplied (always, here), the API wraps
+    # results in ``{"results": [...], "pagination": {...}}``. Without those
+    # params it returns a bare list — but we always paginate.
+    raw = data.get("results", []) if isinstance(data, dict) else []
     # M3: consider wrapping ValidationError as KanbanToolHTTPError("malformed search payload").
     return [Task.model_validate(t) for t in raw]
 

--- a/tests/test_recent_changes.py
+++ b/tests/test_recent_changes.py
@@ -20,28 +20,26 @@ def _changelog_url(board_id: int) -> str:
 
 
 async def test_recent_changes_happy_path(_inject_client: KanbanToolClient) -> None:
-    payload = {
-        "changelog": [
-            {
-                "id": 1001,
-                "created_at": "2026-04-30T10:15:00Z",
-                "what": "created",
-                "user_id": 7,
-                "changed_object_type": "Task",
-                "changed_object_id": 555,
-                "description": "Ada Lovelace created Write spec",
-                "data": {"user_initials": "AL", "task_name": "Write spec"},
-                "extra_unknown_field": "ignored",
-            },
-            {
-                "id": 1000,
-                "created_at": "2026-04-30T09:00:00Z",
-                "what": "moved",
-                "changed_object_type": "Task",
-                "changed_object_id": 555,
-            },
-        ]
-    }
+    payload = [
+        {
+            "id": 1001,
+            "created_at": "2026-04-30T10:15:00Z",
+            "what": "created",
+            "user_id": 7,
+            "changed_object_type": "Task",
+            "changed_object_id": 555,
+            "description": "Ada Lovelace created Write spec",
+            "data": {"user_initials": "AL", "task_name": "Write spec"},
+            "extra_unknown_field": "ignored",
+        },
+        {
+            "id": 1000,
+            "created_at": "2026-04-30T09:00:00Z",
+            "what": "moved",
+            "changed_object_type": "Task",
+            "changed_object_id": 555,
+        },
+    ]
     with respx.mock(assert_all_called=True) as router:
         router.get(_changelog_url(42)).mock(return_value=httpx.Response(200, json=payload))
         result = await recent_changes(42)
@@ -69,9 +67,7 @@ async def test_recent_changes_passes_since_as_query_param(
 ) -> None:
     since = datetime(2026, 4, 30, 8, 0, 0, tzinfo=UTC)
     with respx.mock(assert_all_called=True) as router:
-        route = router.get(_changelog_url(42)).mock(
-            return_value=httpx.Response(200, json={"changelog": []})
-        )
+        route = router.get(_changelog_url(42)).mock(return_value=httpx.Response(200, json=[]))
         await recent_changes(42, since=since)
 
     request = route.calls.last.request
@@ -82,9 +78,7 @@ async def test_recent_changes_omits_since_when_none(
     _inject_client: KanbanToolClient,
 ) -> None:
     with respx.mock(assert_all_called=True) as router:
-        route = router.get(_changelog_url(42)).mock(
-            return_value=httpx.Response(200, json={"changelog": []})
-        )
+        route = router.get(_changelog_url(42)).mock(return_value=httpx.Response(200, json=[]))
         await recent_changes(42)
 
     request = route.calls.last.request
@@ -95,9 +89,7 @@ async def test_recent_changes_omits_since_when_none(
 
 async def test_recent_changes_empty(_inject_client: KanbanToolClient) -> None:
     with respx.mock(assert_all_called=True) as router:
-        router.get(_changelog_url(42)).mock(
-            return_value=httpx.Response(200, json={"changelog": []})
-        )
+        router.get(_changelog_url(42)).mock(return_value=httpx.Response(200, json=[]))
         result = await recent_changes(42)
 
     assert result == []
@@ -128,9 +120,7 @@ async def test_recent_changes_via_fastmcp_entrypoint_accepts_iso_string(
     pass ``since`` as plain ISO text."""
     iso = "2026-04-30T08:00:00+00:00"
     with respx.mock(assert_all_called=True) as router:
-        route = router.get(_changelog_url(42)).mock(
-            return_value=httpx.Response(200, json={"changelog": []})
-        )
+        route = router.get(_changelog_url(42)).mock(return_value=httpx.Response(200, json=[]))
         tool = await mcp.get_tool("recent_changes")
         assert tool is not None
         await tool.run({"board_id": 42, "since": iso})

--- a/tests/test_search_tasks.py
+++ b/tests/test_search_tasks.py
@@ -14,10 +14,17 @@ from .conftest import BASE_URL
 
 SEARCH_URL = f"{BASE_URL}tasks/search.json"
 
+# Tests that don't care about returned tasks just need a well-formed empty
+# envelope — the tool always paginates so the response is always wrapped.
+_EMPTY_RESPONSE = {
+    "results": [],
+    "pagination": {"results_count": 0, "page": 1, "pages_count": 0},
+}
+
 
 async def test_search_tasks_happy_path(_inject_client: KanbanToolClient) -> None:
     payload = {
-        "tasks": [
+        "results": [
             {
                 "id": 1,
                 "name": "Ship release",
@@ -35,7 +42,8 @@ async def test_search_tasks_happy_path(_inject_client: KanbanToolClient) -> None
                 "board_id": 7,
                 "priority": 1,
             },
-        ]
+        ],
+        "pagination": {"results_count": 2, "page": 1, "pages_count": 1},
     }
     with respx.mock(assert_all_called=True) as router:
         router.get(SEARCH_URL).mock(return_value=httpx.Response(200, json=payload))
@@ -63,7 +71,7 @@ async def test_search_tasks_dsl_passthrough_unmodified(
     no extra quoting, no operator splitting."""
     raw_query = '@alice priority:high tags:"bug,urgent"'
     with respx.mock(assert_all_called=True) as router:
-        route = router.get(SEARCH_URL).mock(return_value=httpx.Response(200, json={"tasks": []}))
+        route = router.get(SEARCH_URL).mock(return_value=httpx.Response(200, json=_EMPTY_RESPONSE))
         await search_tasks(query=raw_query)
 
     request = route.calls.last.request
@@ -74,7 +82,7 @@ async def test_search_tasks_omits_board_id_when_none(
     _inject_client: KanbanToolClient,
 ) -> None:
     with respx.mock(assert_all_called=True) as router:
-        route = router.get(SEARCH_URL).mock(return_value=httpx.Response(200, json={"tasks": []}))
+        route = router.get(SEARCH_URL).mock(return_value=httpx.Response(200, json=_EMPTY_RESPONSE))
         await search_tasks(query="name:foo")
 
     request = route.calls.last.request
@@ -85,7 +93,7 @@ async def test_search_tasks_forwards_board_id_when_provided(
     _inject_client: KanbanToolClient,
 ) -> None:
     with respx.mock(assert_all_called=True) as router:
-        route = router.get(SEARCH_URL).mock(return_value=httpx.Response(200, json={"tasks": []}))
+        route = router.get(SEARCH_URL).mock(return_value=httpx.Response(200, json=_EMPTY_RESPONSE))
         await search_tasks(query="name:foo", board_id=42)
 
     request = route.calls.last.request
@@ -94,7 +102,7 @@ async def test_search_tasks_forwards_board_id_when_provided(
 
 async def test_search_tasks_empty_results(_inject_client: KanbanToolClient) -> None:
     with respx.mock(assert_all_called=True) as router:
-        router.get(SEARCH_URL).mock(return_value=httpx.Response(200, json={"tasks": []}))
+        router.get(SEARCH_URL).mock(return_value=httpx.Response(200, json=_EMPTY_RESPONSE))
         results = await search_tasks(query="name:nothing-matches")
 
     assert results == []
@@ -102,7 +110,7 @@ async def test_search_tasks_empty_results(_inject_client: KanbanToolClient) -> N
 
 async def test_search_tasks_pagination_forwarded(_inject_client: KanbanToolClient) -> None:
     with respx.mock(assert_all_called=True) as router:
-        route = router.get(SEARCH_URL).mock(return_value=httpx.Response(200, json={"tasks": []}))
+        route = router.get(SEARCH_URL).mock(return_value=httpx.Response(200, json=_EMPTY_RESPONSE))
         await search_tasks(query="name:foo", limit=10, page=2)
 
     params = route.calls.last.request.url.params
@@ -113,7 +121,7 @@ async def test_search_tasks_pagination_forwarded(_inject_client: KanbanToolClien
 async def test_search_tasks_limit_is_clamped_to_50(_inject_client: KanbanToolClient) -> None:
     """Hallucinated huge limits must be capped before they hit the API."""
     with respx.mock(assert_all_called=True) as router:
-        route = router.get(SEARCH_URL).mock(return_value=httpx.Response(200, json={"tasks": []}))
+        route = router.get(SEARCH_URL).mock(return_value=httpx.Response(200, json=_EMPTY_RESPONSE))
         await search_tasks(query="name:foo", limit=200)
 
     assert route.calls.last.request.url.params["limit"] == "50"
@@ -143,14 +151,15 @@ async def test_search_tasks_drops_unknown_task_fields(
     """Confirms ``extra="ignore"`` round-trip — unknown task fields are
     silently dropped rather than failing validation."""
     payload = {
-        "tasks": [
+        "results": [
             {
                 "id": 99,
                 "name": "Round trip",
                 "speculative_future_field": {"nested": True},
                 "another_unknown": [1, 2, 3],
             }
-        ]
+        ],
+        "pagination": {"results_count": 1, "page": 1, "pages_count": 1},
     }
     with respx.mock(assert_all_called=True) as router:
         router.get(SEARCH_URL).mock(return_value=httpx.Response(200, json=payload))


### PR DESCRIPTION
## Summary

Three critical-tier wire-contract bugs surfaced when running the live integration suite (#18) end-to-end against a populated test account. All silent in the offline suite — unit tests mocked the shapes the code expected, not the shapes the API actually returns. Same class of issue as #61/#63.

| Fix | Site | What was wrong |
|---|---|---|
| `search_tasks` envelope key | `server.py:150` | Expected `{"tasks": [...]}`, API returns `{"results": [...], "pagination": {...}}` whenever `limit`/`page` are supplied (always). Defensive `else []` masked it → every live search silently returned `[]`. |
| `recent_changes` envelope | `server.py:103` | Expected `{"changelog": [...]}`, API returns a bare list. Same masking pattern → every live change-poll silently returned `[]`. |
| `Column.name` nullable | `models.py:28` | Typed `str`, but the live API returns `null` for the synthetic root stage that parents the real columns. `get_board` validation crashed on any real board. |

## Why it didn't surface earlier

The offline suite mocked `{"tasks": [...]}` and `{"changelog": [...]}` to match what the code expected, not what the API returns. The defensive `isinstance(data, dict) else []` fallbacks turned the silent-empty-list path into the apparent "empty result" the unit tests asserted. We only saw it when running the integration tests live for the first time.

## What's NOT in this PR

- `list_subtasks` 404s against the live endpoint path (`tasks/{id}/subtasks.json`) — separate scope, will need API docs research and possibly a redesign. Filing as a separate issue.
- Dropping the welcome-board hardcoding in the integration suite — separate PR (depends on this one merging so the live tests actually pass).

## Test plan
- [x] `uv run pytest` — 119/119 passing
- [x] `uv run pytest tests/integration/` against rynbou account — 5/5 passing (was effectively 0/5 pre-fix: 3 would have crashed, 2 would have silently passed with empty results)
- [x] `uv run ruff check .` / `ruff format --check .` clean
- [x] `uv run ty check` clean
- [ ] CI matrix — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)