### PR TITLE
test(integration): drop welcome-board hardcoding for dynamic discovery

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -17,8 +17,10 @@ from collections.abc import AsyncIterator
 
 import pytest
 
+from kanbantool_mcp import server
 from kanbantool_mcp.client import KanbanToolClient
 from kanbantool_mcp.config import Config
+from kanbantool_mcp.server import list_boards, search_tasks
 
 
 @pytest.fixture(autouse=True)
@@ -43,3 +45,31 @@ async def live_client() -> AsyncIterator[KanbanToolClient]:
         yield c
     finally:
         await c.aclose()
+
+
+@pytest.fixture
+def _inject_live_client(
+    monkeypatch: pytest.MonkeyPatch, live_client: KanbanToolClient
+) -> KanbanToolClient:
+    """Wire the live client into ``server._client`` so the MCP tools use it."""
+    monkeypatch.setattr(server, "_client", live_client)
+    return live_client
+
+
+@pytest.fixture
+async def populated_board_id(_inject_live_client: KanbanToolClient) -> int:
+    """Discover any board on the test account that has at least one non-archived task.
+
+    The integration suite validates wire-contract shapes, not the contents of
+    a specific board, so we don't pin a particular id. Skip if the account has
+    no usable board — the maintainer needs to seed one before these tests can run.
+    """
+    boards = await list_boards()
+    for board in boards:
+        tasks = await search_tasks(query="archived:false", board_id=board.id)
+        if tasks:
+            return board.id
+    pytest.skip(
+        "no board with non-archived tasks on the test account; "
+        "seed at least one board with one task before running live tests."
+    )

--- a/tests/integration/test_live_read_tools.py
+++ b/tests/integration/test_live_read_tools.py
@@ -1,26 +1,23 @@
 """Live integration tests for the read tools.
 
 These hit a real Kanban Tool test account. They are excluded from the default
-``pytest`` run (see ``pyproject.toml``'s ``testpaths``) and only execute under
+``pytest`` run (see ``pyproject.toml``'s ``addopts``) and only execute under
 the ``Live Integration`` workflow on demand.
 
-Coverage scope: the five read tools end-to-end against the seeded "Welcome"
-board on the test account. We deliberately do NOT exercise the write tools
-live — they would create real artifacts on the account every run and the
-spike in #62 already confirmed the write path. Read coverage proves the wire
-contract for our renamed/aliased fields, which is the bit most likely to
-silently drift.
+Coverage scope: the five read tools end-to-end against any populated board on
+the test account. We deliberately do NOT exercise the write tools live — they
+would create real artifacts on the account every run and the spike in #62
+already confirmed the write path. Read coverage proves the wire contract for
+our renamed/aliased fields, which is the bit most likely to silently drift.
 
 Assertions are SHAPE-not-VALUE: the test account's task counts and content
 will shift over time as we exercise the integration. Locking exact numbers
-would make the suite brittle without adding signal.
+would make the suite brittle without adding signal. The tests do not assume
+any particular board name or id — see the ``populated_board_id`` fixture.
 """
 
 from __future__ import annotations
 
-import pytest
-
-from kanbantool_mcp import server
 from kanbantool_mcp.client import KanbanToolClient
 from kanbantool_mcp.models import Board, ChangelogEntry, Task
 from kanbantool_mcp.server import (
@@ -31,50 +28,22 @@ from kanbantool_mcp.server import (
     search_tasks,
 )
 
-# The seeded "Welcome to Kanban Tool!" board id on the test account. Stable
-# across runs; if Kanban Tool ever re-seeds welcome boards with a different
-# id this is the one knob to update.
-_WELCOME_BOARD_ID = 1180501
-_WELCOME_BOARD_NAME = "Welcome to Kanban Tool!"
 
-
-@pytest.fixture
-def _inject_live_client(
-    monkeypatch: pytest.MonkeyPatch, live_client: KanbanToolClient
-) -> KanbanToolClient:
-    """Wire the live client into ``server._client`` so the MCP tools use it.
-
-    Mirrors the unit-test ``_inject_client`` fixture; lives here (not in the
-    integration ``conftest.py``) because it depends on the per-test
-    ``monkeypatch`` fixture and is only consumed by tests that drive the MCP
-    tool functions directly.
-    """
-    monkeypatch.setattr(server, "_client", live_client)
-    return live_client
-
-
-async def test_list_boards_returns_welcome_board(_inject_live_client: KanbanToolClient) -> None:
+async def test_list_boards_returns_account_boards(_inject_live_client: KanbanToolClient) -> None:
     boards = await list_boards()
 
     assert isinstance(boards, list)
     assert len(boards) >= 1
     assert all(isinstance(b, Board) for b in boards)
 
-    welcome = next((b for b in boards if b.name == _WELCOME_BOARD_NAME), None)
-    assert welcome is not None, (
-        f"expected a board named {_WELCOME_BOARD_NAME!r}; got {[b.name for b in boards]!r}"
-    )
-    assert welcome.id == _WELCOME_BOARD_ID
-
 
 async def test_get_board_returns_columns_and_card_template(
-    _inject_live_client: KanbanToolClient,
+    _inject_live_client: KanbanToolClient, populated_board_id: int
 ) -> None:
-    board = await get_board(_WELCOME_BOARD_ID)
+    board = await get_board(populated_board_id)
 
     assert isinstance(board, Board)
-    assert board.id == _WELCOME_BOARD_ID
-    assert board.name == _WELCOME_BOARD_NAME
+    assert board.id == populated_board_id
     # The detail endpoint surfaces columns (wire: ``workflow_stages``) and
     # ``card_template``; both are absent from the compact list endpoint.
     assert len(board.columns) >= 1
@@ -82,45 +51,43 @@ async def test_get_board_returns_columns_and_card_template(
     assert len(board.card_template) >= 1
 
 
-async def test_search_tasks_returns_non_archived_tutorial_tasks(
-    _inject_live_client: KanbanToolClient,
+async def test_search_tasks_filters_archived(
+    _inject_live_client: KanbanToolClient, populated_board_id: int
 ) -> None:
     # Earlier spike probes saw ``/tasks/search.json`` 500 on an empty account;
-    # with the seeded welcome board populated the call should succeed. If it
-    # still 500s, that's a real upstream finding worth flagging in CI output.
-    tasks = await search_tasks(query="archived:false", board_id=_WELCOME_BOARD_ID)
+    # against a populated board the call should succeed. If it still 500s,
+    # that's a real upstream finding worth flagging in CI output.
+    tasks = await search_tasks(query="archived:false", board_id=populated_board_id)
 
     assert isinstance(tasks, list)
     assert len(tasks) >= 1
     assert all(isinstance(t, Task) for t in tasks)
-    assert all(t.board_id == _WELCOME_BOARD_ID for t in tasks)
-    # ``archived:false`` should exclude the two archived spike tasks (ids
-    # 77649691 / 77649693). Assert the filter behaved rather than the count.
+    assert all(t.board_id == populated_board_id for t in tasks)
+    # ``archived:false`` should mean the filter behaved.
     assert all(t.archived_at is None for t in tasks)
 
 
 async def test_get_task_populates_renamed_wire_fields(
-    _inject_live_client: KanbanToolClient,
+    _inject_live_client: KanbanToolClient, populated_board_id: int
 ) -> None:
     # Pick a task id off the live board rather than hard-coding one — task ids
-    # on the welcome board aren't documented to be stable, and this exercises
-    # the discovery flow an LLM agent would actually use.
-    board = await get_board(_WELCOME_BOARD_ID)
-    search_hits = await search_tasks(query="archived:false", board_id=_WELCOME_BOARD_ID)
-    assert search_hits, "no non-archived tasks on the welcome board to fetch"
+    # aren't documented to be stable, and this exercises the discovery flow an
+    # LLM agent would actually use.
+    board = await get_board(populated_board_id)
+    search_hits = await search_tasks(query="archived:false", board_id=populated_board_id)
+    assert search_hits, "populated_board_id fixture promised non-archived tasks"
     task_id = search_hits[0].id
 
     task = await get_task(task_id)
 
     assert isinstance(task, Task)
     assert task.id == task_id
-    assert task.board_id == _WELCOME_BOARD_ID
+    assert task.board_id == populated_board_id
     # The renamed inbound alias: wire ``workflow_stage_id`` → model ``lane_id``.
     assert task.lane_id is not None
     assert task.lane_id in {c.id for c in board.columns}
     # Counts/totals surface as their renamed model fields. They're typed
-    # ``int | None`` — assert the type, not a specific value, since the test
-    # account's tutorial tasks may or may not have comments/timers.
+    # ``int | None`` — assert the type, not a specific value.
     assert task.comments_count is None or isinstance(task.comments_count, int)
     assert task.timers_total is None or isinstance(task.timers_total, int)
     assert task.assigned_user_id is None or isinstance(task.assigned_user_id, int)
@@ -133,9 +100,9 @@ async def test_get_task_populates_renamed_wire_fields(
 
 
 async def test_recent_changes_populates_renamed_fields(
-    _inject_live_client: KanbanToolClient,
+    _inject_live_client: KanbanToolClient, populated_board_id: int
 ) -> None:
-    entries = await recent_changes(board_id=_WELCOME_BOARD_ID)
+    entries = await recent_changes(board_id=populated_board_id)
 
     assert isinstance(entries, list)
     assert len(entries) >= 1


### PR DESCRIPTION
## Summary

The integration suite previously pinned ``_WELCOME_BOARD_ID = 1180501`` and ``_WELCOME_BOARD_NAME = "Welcome to Kanban Tool!"`` — both account-specific. The welcome board is generated at trial-account provisioning, gets a different id on each account, and may be renamed/deleted by the user. Re-tagging would be required on every test-account migration.

These tests validate **wire-contract shapes**, not specific board content. Replaces the constants with a session fixture (``populated_board_id``) that:

1. Enumerates ``list_boards()``.
2. Picks any board with at least one non-archived task (so ``search_tasks`` / ``get_task`` / ``recent_changes`` have data to iterate).
3. Skips with a clear seed-the-account message if none exist.

Also drops the ``board.name == "Welcome to Kanban Tool!"`` assertion — locale-/content-dependent and adds no contract signal beyond ``isinstance(b, Board)``.

## Refactor notes
- ``_inject_live_client`` moves up from ``test_live_read_tools.py`` to ``tests/integration/conftest.py`` so ``populated_board_id`` can depend on it cleanly.
- Net effect on the suite: same 5 read-tool tests, less account coupling. Pass against any populated test account, not just rynbou's.

## Test plan
- [x] ``uv run pytest`` — 119/119 offline ✓
- [x] ``uv run pytest tests/integration/`` against rynbou — 5/5 live ✓
- [x] ``uv run ruff check . && ruff format --check .`` clean
- [x] ``uv run ty check`` clean
- [ ] CI matrix on this PR — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)