### PR TITLE
fix(server,models): align subtask tools with real API endpoints

### DIFF
--- a/src/kanbantool_mcp/models.py
+++ b/src/kanbantool_mcp/models.py
@@ -118,6 +118,11 @@ class Task(BaseModel):
     # returns — ``is_blocked`` is derived from "reason is set".
     block_reason: str | None = None
     subtasks_count: int | None = None
+    # Inline subtasks on the detail endpoint. Per the Kanban Tool API v3 docs
+    # there's no dedicated "list subtasks" endpoint — subtasks live on the
+    # parent task's detail payload. Empty default for the compact list shape
+    # (e.g. ``search_tasks`` results), where the API omits ``subtasks``.
+    subtasks: list[Subtask] = Field(default_factory=list)
     comments_count: int | None = None
     # Flat seconds. The wrapped ``{ "total": ..., "by_user": ... }`` shape is a
     # separate concern — exposed via a dedicated time-tracker tool later.
@@ -165,9 +170,11 @@ class Comment(BaseModel):
 class Subtask(BaseModel):
     """A subtask attached to a task.
 
-    Mirrors the GET/POST ``/tasks/{id}/subtasks.json`` payload. ``name`` is
-    the API-native field — kept verbatim rather than aliased to ``title`` so
-    there's no rename to maintain on either edge.
+    Surfaced inline on ``Task.subtasks`` whenever a task is fetched (the
+    Kanban Tool API v3 has no dedicated list-subtasks endpoint — see
+    https://kanbantool.com/developer/api-v3). ``POST /subtasks.json`` returns
+    the same shape. ``name`` is the API-native field — kept verbatim rather
+    than aliased to ``title`` so there's no rename to maintain on either edge.
     """
 
     model_config = ConfigDict(extra="ignore")
@@ -175,8 +182,12 @@ class Subtask(BaseModel):
     id: int
     name: str
     is_completed: bool | None = None
-    completed_at: str | None = None
     position: int | None = None
+    # Parent task id — surfaced on the wire after the create round-trip and
+    # useful for callers reasoning about a subtask in isolation.
+    task_id: int | None = None
+    # Single-assignee, mirroring ``Task.assigned_user_id``.
+    assigned_user_id: int | None = None
     # M3: consider wrapping ValidationError as KanbanToolHTTPError("malformed subtask payload").
 
 

--- a/src/kanbantool_mcp/server.py
+++ b/src/kanbantool_mcp/server.py
@@ -83,9 +83,12 @@ async def get_board(board_id: Annotated[int, Field(ge=1)]) -> Board:
 
 @mcp.tool
 async def get_task(task_id: int) -> Task:
-    """Fetch one task by id. Returns a Task with subtask/comment counts and total tracked time.
+    """Fetch one task by id. Returns a Task with subtask/comment counts,
+    total tracked time, and inline ``subtasks``.
 
-    Use ``list_subtasks`` to drill into nested collections.
+    Subtasks live on ``Task.subtasks`` directly — no extra round-trip needed
+    (use ``list_subtasks`` only when you want just the list and not the rest
+    of the task).
     Raises ``KanbanToolHTTPError(404)`` if the task is unknown or inaccessible."""
     data = await _get_client().request("GET", f"tasks/{task_id}")
     # M3: consider wrapping ValidationError as KanbanToolHTTPError("malformed task payload").
@@ -372,12 +375,12 @@ async def add_comment(task_id: int, text: str) -> Comment:
 async def list_subtasks(task_id: int) -> list[Subtask]:
     """List subtasks on a task — id, name, completion state, position.
 
-    Returns an empty list when the task has none. Use ``get_task`` first if
-    you only need the subtask count rather than the full list."""
-    data = await _get_client().request("GET", f"tasks/{task_id}/subtasks")
-    raw = data.get("subtasks", []) if isinstance(data, dict) else []
-    # M3: consider wrapping ValidationError as KanbanToolHTTPError("malformed subtasks payload").
-    return [Subtask.model_validate(s) for s in raw]
+    Subtasks are returned inline on ``Task.subtasks`` whenever you fetch a
+    task; this tool is sugar for callers that only want the list. Costs one
+    HTTP call (the same as ``get_task``) — the Kanban Tool API has no
+    dedicated list-subtasks endpoint."""
+    task = await get_task(task_id)
+    return task.subtasks
 
 
 @mcp.tool
@@ -386,8 +389,15 @@ async def add_subtask(task_id: int, title: str) -> Subtask:
 
     ``title`` is the human-readable label. Empty ``title`` typically raises
     ``KanbanToolValidationError`` from the API."""
-    body = {"subtask": {"name": title}}
-    data = await _get_client().request("POST", f"tasks/{task_id}/subtasks", json=body)
+    # Wire quirk: ``POST /subtasks.json`` takes a flat top-level body —
+    # ``{"name": ..., "task_id": ...}`` — NOT the Rails-style ``{"subtask": {...}}``
+    # envelope used by ``POST /tasks.json`` and friends. A spike against the
+    # live API confirmed that wrapping in an envelope makes the API drop the
+    # parent linkage (the response's ``task_id`` came back null and the
+    # subtask never appeared on the parent task). Don't copy ``create_task``'s
+    # shape here.
+    body = {"name": title, "task_id": task_id}
+    data = await _get_client().request("POST", "subtasks", json=body)
     # Trusting the bare-object response shape (mirrors get_task on main); no
     # defensive ``{"subtask": {...}}`` unwrap. M3 can revisit if the API ever
     # surprises us.

--- a/tests/integration/test_live_read_tools.py
+++ b/tests/integration/test_live_read_tools.py
@@ -19,11 +19,12 @@ any particular board name or id — see the ``populated_board_id`` fixture.
 from __future__ import annotations
 
 from kanbantool_mcp.client import KanbanToolClient
-from kanbantool_mcp.models import Board, ChangelogEntry, Task
+from kanbantool_mcp.models import Board, ChangelogEntry, Subtask, Task
 from kanbantool_mcp.server import (
     get_board,
     get_task,
     list_boards,
+    list_subtasks,
     recent_changes,
     search_tasks,
 )
@@ -116,3 +117,29 @@ async def test_recent_changes_populates_renamed_fields(
     assert first.user_id is None or isinstance(first.user_id, int)
     assert first.changed_object_type is None or isinstance(first.changed_object_type, str)
     assert first.description is None or isinstance(first.description, str)
+
+
+async def test_list_subtasks_and_inline_task_subtasks_agree(
+    _inject_live_client: KanbanToolClient, populated_board_id: int
+) -> None:
+    """The Kanban Tool API has no dedicated list-subtasks endpoint — subtasks
+    are inlined on ``GET /tasks/{id}.json``. Lock that contract: ``list_subtasks``
+    is sugar over ``get_task``, and both must surface the same shape.
+
+    Shape-not-value: we don't know if the picked task has subtasks (the welcome
+    board has none today), so we assert types and structural equivalence rather
+    than counts. This test would have caught the broken nested-endpoint path
+    pre-fix (the old code 404'd live)."""
+    search_hits = await search_tasks(query="archived:false", board_id=populated_board_id)
+    assert search_hits, "populated_board_id fixture promised non-archived tasks"
+    task_id = search_hits[0].id
+
+    subtasks = await list_subtasks(task_id)
+    assert isinstance(subtasks, list)
+    assert all(isinstance(s, Subtask) for s in subtasks)
+
+    # Inline path: ``Task.subtasks`` from ``get_task`` should be the same list.
+    task = await get_task(task_id)
+    assert isinstance(task.subtasks, list)
+    assert all(isinstance(s, Subtask) for s in task.subtasks)
+    assert [s.id for s in subtasks] == [s.id for s in task.subtasks]

--- a/tests/test_subtasks.py
+++ b/tests/test_subtasks.py
@@ -14,42 +14,91 @@ from kanbantool_mcp.exceptions import (
     KanbanToolPermissionError,
     KanbanToolValidationError,
 )
-from kanbantool_mcp.server import add_subtask, list_subtasks
+from kanbantool_mcp.models import Subtask, Task
+from kanbantool_mcp.server import add_subtask, get_task, list_subtasks
 
 from .conftest import BASE_URL
 
 TASK_ID = 42
-SUBTASKS_URL = f"{BASE_URL}tasks/{TASK_ID}/subtasks.json"
+# ``list_subtasks`` rides on top of ``get_task`` because the Kanban Tool API has
+# no dedicated list-subtasks endpoint — subtasks are inlined on the task detail.
+TASK_URL = f"{BASE_URL}tasks/{TASK_ID}.json"
+# ``add_subtask`` POSTs to the top-level ``/subtasks.json`` collection (NOT
+# nested under ``tasks/{id}/...``); the parent linkage is in the body.
+SUBTASKS_URL = f"{BASE_URL}subtasks.json"
 
 
 def _request_body(route: respx.Route) -> dict[str, object]:
     return json.loads(route.calls.last.request.content)
 
 
+def _task_payload(subtasks: list[dict[str, object]]) -> dict[str, object]:
+    """Minimal ``GET /tasks/{id}.json`` shape with an inline ``subtasks`` array."""
+    return {"id": TASK_ID, "name": "parent task", "subtasks": subtasks}
+
+
 # ---------------------------------------------------------------------------
-# list_subtasks
+# Task.subtasks model round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_task_subtasks_round_trips() -> None:
+    """``Task.subtasks`` validates an inline list of ``Subtask`` objects and
+    defaults to an empty list when the wire payload omits the field (compact
+    list shape on ``search_tasks``)."""
+    full = Task.model_validate(
+        {
+            "id": 1,
+            "name": "parent",
+            "subtasks": [
+                {
+                    "id": 11,
+                    "name": "step",
+                    "is_completed": False,
+                    "position": 1,
+                    "task_id": 1,
+                    "assigned_user_id": 99,
+                }
+            ],
+        }
+    )
+    assert len(full.subtasks) == 1
+    sub = full.subtasks[0]
+    assert isinstance(sub, Subtask)
+    assert sub.id == 11
+    assert sub.name == "step"
+    assert sub.task_id == 1
+    assert sub.assigned_user_id == 99
+
+    bare = Task.model_validate({"id": 2, "name": "compact"})
+    assert bare.subtasks == []
+
+
+# ---------------------------------------------------------------------------
+# list_subtasks (sugar over get_task)
 # ---------------------------------------------------------------------------
 
 
 async def test_list_subtasks_happy_path(_inject_client: KanbanToolClient) -> None:
-    """A two-element ``subtasks`` array — one fully populated, one minimal —
-    should round-trip into the typed model with optional fields defaulting to
-    ``None`` on the minimal entry."""
-    payload = {
-        "subtasks": [
+    """A two-element inline ``subtasks`` array — one fully populated, one
+    minimal — should round-trip into the typed model with optional fields
+    defaulting to ``None`` on the minimal entry."""
+    payload = _task_payload(
+        [
             {
                 "id": 1,
                 "name": "Write spec",
                 "is_completed": True,
-                "completed_at": "2026-04-29T10:00:00Z",
                 "position": 1,
+                "task_id": TASK_ID,
+                "assigned_user_id": 7,
                 "extra_unknown_field": "ignored",
             },
             {"id": 2, "name": "Review PR"},
         ]
-    }
+    )
     with respx.mock(assert_all_called=True) as router:
-        router.get(SUBTASKS_URL).mock(return_value=httpx.Response(200, json=payload))
+        router.get(TASK_URL).mock(return_value=httpx.Response(200, json=payload))
         result = await list_subtasks(TASK_ID)
 
     assert len(result) == 2
@@ -57,52 +106,52 @@ async def test_list_subtasks_happy_path(_inject_client: KanbanToolClient) -> Non
     assert first.id == 1
     assert first.name == "Write spec"
     assert first.is_completed is True
-    assert first.completed_at == "2026-04-29T10:00:00Z"
     assert first.position == 1
+    assert first.task_id == TASK_ID
+    assert first.assigned_user_id == 7
 
     assert second.id == 2
     assert second.name == "Review PR"
     assert second.is_completed is None
-    assert second.completed_at is None
     assert second.position is None
+    assert second.task_id is None
+    assert second.assigned_user_id is None
 
 
 async def test_list_subtasks_empty(_inject_client: KanbanToolClient) -> None:
     with respx.mock(assert_all_called=True) as router:
-        router.get(SUBTASKS_URL).mock(return_value=httpx.Response(200, json={"subtasks": []}))
+        router.get(TASK_URL).mock(return_value=httpx.Response(200, json=_task_payload([])))
         result = await list_subtasks(TASK_ID)
 
     assert result == []
 
 
-async def test_list_subtasks_missing_key(_inject_client: KanbanToolClient) -> None:
-    """Defensive parse: a dict without a ``subtasks`` key returns ``[]`` rather
-    than raising — mirrors ``list_boards`` so an unfamiliar wire shape doesn't
-    blow up the tool."""
+async def test_list_subtasks_missing_field(_inject_client: KanbanToolClient) -> None:
+    """A task payload that omits the ``subtasks`` key entirely (e.g. a forward-compat
+    shape change) should yield ``[]`` via the ``Task.subtasks`` default."""
+    payload = {"id": TASK_ID, "name": "no subtasks key"}
     with respx.mock(assert_all_called=True) as router:
-        router.get(SUBTASKS_URL).mock(return_value=httpx.Response(200, json={"unrelated": "shape"}))
+        router.get(TASK_URL).mock(return_value=httpx.Response(200, json=payload))
         result = await list_subtasks(TASK_ID)
 
     assert result == []
 
 
 async def test_list_subtasks_url_shape(_inject_client: KanbanToolClient) -> None:
-    """GET hits ``tasks/{id}/subtasks.json`` exactly — no double-suffix, no
-    trailing slash, no query string."""
+    """GET hits ``tasks/{id}.json`` exactly — the route through ``get_task``
+    means we must NOT hit any nested ``/subtasks`` path (no such endpoint)."""
     with respx.mock(assert_all_called=True) as router:
-        route = router.get(SUBTASKS_URL).mock(
-            return_value=httpx.Response(200, json={"subtasks": []})
-        )
+        route = router.get(TASK_URL).mock(return_value=httpx.Response(200, json=_task_payload([])))
         await list_subtasks(TASK_ID)
 
     request = route.calls.last.request
     assert request.method == "GET"
-    assert str(request.url) == SUBTASKS_URL
+    assert str(request.url) == TASK_URL
 
 
 async def test_list_subtasks_404_raises_http_error(_inject_client: KanbanToolClient) -> None:
     with respx.mock() as router:
-        router.get(SUBTASKS_URL).mock(return_value=httpx.Response(404, text="task not found"))
+        router.get(TASK_URL).mock(return_value=httpx.Response(404, text="task not found"))
         with pytest.raises(KanbanToolHTTPError) as exc_info:
             await list_subtasks(TASK_ID)
     assert exc_info.value.status_code == 404
@@ -112,9 +161,22 @@ async def test_list_subtasks_401_raises_permission_error(
     _inject_client: KanbanToolClient,
 ) -> None:
     with respx.mock() as router:
-        router.get(SUBTASKS_URL).mock(return_value=httpx.Response(401, text="unauthorized"))
+        router.get(TASK_URL).mock(return_value=httpx.Response(401, text="unauthorized"))
         with pytest.raises(KanbanToolPermissionError):
             await list_subtasks(TASK_ID)
+
+
+async def test_get_task_surfaces_inline_subtasks(_inject_client: KanbanToolClient) -> None:
+    """Sanity check that ``get_task`` parses the inline ``subtasks`` array —
+    proves ``list_subtasks`` and ``Task.subtasks`` agree on the same wire path."""
+    payload = _task_payload([{"id": 5, "name": "inline"}])
+    with respx.mock(assert_all_called=True) as router:
+        router.get(TASK_URL).mock(return_value=httpx.Response(200, json=payload))
+        task = await get_task(TASK_ID)
+
+    assert len(task.subtasks) == 1
+    assert task.subtasks[0].id == 5
+    assert task.subtasks[0].name == "inline"
 
 
 # ---------------------------------------------------------------------------
@@ -123,13 +185,17 @@ async def test_list_subtasks_401_raises_permission_error(
 
 
 async def test_add_subtask_happy_path(_inject_client: KanbanToolClient) -> None:
-    """Body must be the ``{"subtask": {"name": ...}}`` Rails envelope; response
-    parses straight into a ``Subtask`` (no defensive unwrap)."""
+    """Body must be the FLAT top-level ``{"name": ..., "task_id": ...}`` —
+    NOT the Rails-style ``{"subtask": {...}}`` envelope used by ``tasks``
+    POSTs. The live spike confirmed that the envelope shape makes the API
+    drop the parent linkage."""
     response_payload = {
         "id": 17,
         "name": "Draft tests",
         "is_completed": False,
         "position": 3,
+        "task_id": TASK_ID,
+        "assigned_user_id": 99,
     }
     with respx.mock(assert_all_called=True) as router:
         route = router.post(SUBTASKS_URL).mock(
@@ -141,9 +207,27 @@ async def test_add_subtask_happy_path(_inject_client: KanbanToolClient) -> None:
     assert subtask.name == "Draft tests"
     assert subtask.is_completed is False
     assert subtask.position == 3
+    assert subtask.task_id == TASK_ID
+    assert subtask.assigned_user_id == 99
 
     body = _request_body(route)
-    assert body == {"subtask": {"name": "Draft tests"}}
+    assert body == {"name": "Draft tests", "task_id": TASK_ID}
+
+
+async def test_add_subtask_body_has_no_envelope(_inject_client: KanbanToolClient) -> None:
+    """Regression guard: the top-level ``subtask`` envelope key must NOT appear.
+    Live API silently ignores ``task_id`` if the body is wrapped, breaking the
+    parent linkage — see the wire-quirk note on ``add_subtask``."""
+    with respx.mock(assert_all_called=True) as router:
+        route = router.post(SUBTASKS_URL).mock(
+            return_value=httpx.Response(201, json={"id": 1, "name": "x", "task_id": TASK_ID})
+        )
+        await add_subtask(task_id=TASK_ID, title="x")
+
+    body = _request_body(route)
+    assert "subtask" not in body
+    assert body["name"] == "x"
+    assert body["task_id"] == TASK_ID
 
 
 async def test_add_subtask_minimal_response(_inject_client: KanbanToolClient) -> None:
@@ -158,8 +242,9 @@ async def test_add_subtask_minimal_response(_inject_client: KanbanToolClient) ->
     assert subtask.id == 1
     assert subtask.name == "x"
     assert subtask.is_completed is None
-    assert subtask.completed_at is None
     assert subtask.position is None
+    assert subtask.task_id is None
+    assert subtask.assigned_user_id is None
 
 
 async def test_add_subtask_422_raises_validation_error(
@@ -179,7 +264,8 @@ async def test_add_subtask_422_raises_validation_error(
 
 
 async def test_add_subtask_url_shape(_inject_client: KanbanToolClient) -> None:
-    """POST hits ``tasks/{id}/subtasks.json`` exactly."""
+    """POST hits the top-level ``subtasks.json`` collection — NOT
+    ``tasks/{id}/subtasks.json`` (no such endpoint)."""
     with respx.mock(assert_all_called=True) as router:
         route = router.post(SUBTASKS_URL).mock(
             return_value=httpx.Response(201, json={"id": 1, "name": "x"})


### PR DESCRIPTION
## Summary

Closes #68. The `list_subtasks` and `add_subtask` tools were wired to endpoint paths that don't exist on the Kanban Tool API v3. Unit tests mocked the imagined shapes, so the drift was silent until the live integration suite exercised the real wire contract end-to-end.

## What was wrong

- **`list_subtasks`** hit `GET /tasks/{id}/subtasks.json`. That endpoint doesn't exist — every live call 404'd.
- **`add_subtask`** hit `POST /tasks/{id}/subtasks.json` with a Rails-style `{"subtask": {"name": ...}}` envelope. Closer to working than `list_subtasks`, but wrong on both the URL and the body shape.
- **`Subtask`** had a wire-fictional `completed_at` field and was missing `task_id` / `assigned_user_id`, which the live API does surface.

## What the API actually does

Per the v3 docs (https://kanbantool.com/developer/api-v3):

> There's no endpoint dedicated only to listing subtasks - you should fetch the task's details and access its `subtasks` field.

Confirmed live on the test account: `GET /tasks/{id}.json` includes a top-level `subtasks: [...]` array.

For writes, `POST /subtasks.json` (top-level collection) takes a **flat** body — `{"name": "...", "task_id": <int>}`. A live spike showed that wrapping in `{"subtask": {...}}` made the API silently drop the parent linkage: the response's `task_id` came back null and the subtask never appeared on the parent task. This contradicts the envelope convention used by `POST /tasks.json` and friends — the wire-quirk note on `add_subtask` calls it out so future maintainers don't blindly mirror `create_task`.

## Design decision (Option C)

`Task.subtasks` is the canonical access point — it's already free on every `get_task` round-trip. `list_subtasks` becomes a 2-line sugar wrapper for callers that only want the list:

```python
async def list_subtasks(task_id: int) -> list[Subtask]:
    task = await get_task(task_id)
    return task.subtasks
```

Same cost (one HTTP call), no second endpoint to maintain, no risk of the inline-vs-dedicated paths drifting.

## Changes

- **server.py**: rewire `list_subtasks` through `get_task`; fix `add_subtask` URL + body shape; document the wire-quirk note; tighten `get_task` docstring to point at `Task.subtasks` directly.
- **models.py**: add `Task.subtasks: list[Subtask] = Field(default_factory=list)` (default-empty for the compact `search_tasks` shape that omits it). Drop `Subtask.completed_at` (fictional); add `Subtask.task_id` and `Subtask.assigned_user_id` (real wire fields).
- **tests/test_subtasks.py**: rewrite mocks to match the real wire contract. New tests: `Task.subtasks` round-trip, wire-body envelope-absence guard, `get_task` ↔ inline-subtasks parity.
- **tests/integration/test_live_read_tools.py**: one new test proving `list_subtasks` and `Task.subtasks` agree on the live API. Shape-not-value assertions only. No live write coverage — `add_subtask` would create real artifacts on the test account every run; the offline envelope-guard test locks the wire body shape.

## Test plan

- [x] `uv run pytest` — 122/122 (was 119, +3 net new)
- [x] `uv run pytest tests/integration/` against `KANBANTOOL_DOMAIN=rynbou` — 6/6 (5 prior + the new one)
- [x] `uv run ruff check .` clean
- [x] `uv run ruff format --check .` clean
- [x] `uv run ty check` clean

## Notes for reviewer

- Forward reference: `Task.subtasks: list[Subtask]` is declared before `Subtask` in `models.py`. The module's `from __future__ import annotations` stringifies the annotation, and pydantic resolves it at validation time via the module namespace — verified with a sanity check before relying on it.
- I did not refactor `_patch_task` or any other unrelated helpers (out of scope per the brief). The `add_subtask` flat body deliberately doesn't reuse any envelope-builder — the convention diverges from `create_task` so DRY-ing them would be wrong.
- No new live write coverage by design. The wire-body shape is captured by the offline `test_add_subtask_body_has_no_envelope` regression guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)