### PR TITLE
refactor(client): widen request() return type from dict[str, Any] to Any

### DIFF
--- a/src/kanbantool_mcp/client.py
+++ b/src/kanbantool_mcp/client.py
@@ -124,8 +124,13 @@ class KanbanToolClient:
     async def aclose(self) -> None:
         await self._http.aclose()
 
-    async def request(self, method: str, path: str, **kwargs: Any) -> dict[str, Any]:
+    async def request(self, method: str, path: str, **kwargs: Any) -> Any:
         """Send an HTTP request to the Kanban Tool API and return the parsed JSON response.
+
+        Return type is ``Any`` because the Kanban Tool API surfaces both
+        envelope-shaped dicts (``GET /tasks/search.json`` → ``{"results": [...]}``)
+        and bare lists (``GET /boards/{id}/changelog.json`` → ``[...]``). Callers
+        narrow via ``model_validate`` on the items they actually expect.
 
         Pass query parameters via the `params=` keyword, not embedded in `path` —
         the `.json` suffix logic doesn't account for query strings. Authorization


### PR DESCRIPTION
## Summary

The Kanban Tool API surfaces both envelope-shaped dicts and bare lists:

- ``GET /tasks/search.json`` → ``{"results": [...], "pagination": {...}}``
- ``GET /boards/{id}/changelog.json`` → ``[...]`` (bare list)
- ``GET /users/current.json`` → ``{"boards": [...], ...}``

``dict[str, Any]`` was a lie for the bare-list endpoints — ``recent_changes`` iterates the response directly assuming it's a list. ``ty`` didn't flag it (iteration is valid on dicts too) but the hint mis-described what callers can rely on.

Widen to ``Any``. Callers already narrow via ``model_validate``, which is the real type discipline. Docstring sentence added so the next maintainer doesn't try to "fix" it back to ``dict[str, Any]``.

Closes #71

## Test plan
- [x] ``uv run pytest`` — 122/122 ✓
- [x] ``uv run ruff check . && ruff format --check .`` clean
- [x] ``uv run ty check`` clean
- [ ] CI matrix — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)