### PR TITLE
ci(release): wire publish job to the 'pypi' GitHub Environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,11 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    # Bind to the ``pypi`` environment so the protection rules around it (tag
+    # policy, optional required reviewers) gate the publish step. The PyPI
+    # trusted-publisher entry must be configured for environment ``pypi``;
+    # see ``Environment name`` on https://pypi.org/manage/account/publishing/.
+    environment: pypi
     permissions:
       id-token: write
       contents: write


### PR DESCRIPTION
## Summary

Adds ``environment: pypi`` to the release job in ``release.yml``. The ``pypi`` environment was created via API alongside this PR with a deployment branch policy that only permits ``v*`` tags. Result: only the act of pushing a ``v*`` tag (i.e. cutting a release) can trigger publishing, and any future required-reviewer rule attached to the environment will gate the upload step automatically.

## What's done

- ``release.yml`` now sets ``environment: pypi`` on the publish job.
- GitHub Environment ``pypi`` exists on the repo with deployment branch policy ``type: tag, name: v*``.

## What's NOT in this PR (still pending, partially out-of-band)

- **PyPI trusted-publisher entry** — must be configured at https://pypi.org/manage/account/publishing/ with ``Environment name: pypi`` so the OIDC attestation in the publish step matches. Out-of-band action by the maintainer; project owner is doing it now.
- **Required reviewers** on the ``pypi`` environment — adding/removing reviewers is an access-control change and stays out of scope for autonomous PRs. Maintainer can attach themselves under the environment's protection rules.

## Test plan

- [x] ``uv run pytest`` — 122/122 ✓ (no source impact)
- [x] ``uv run ruff check . && ruff format --check .`` clean
- [ ] CI matrix on this PR — green (the release workflow itself only fires on tag push, not PR)
- [ ] First successful run will be the v0.1.0 cut (#20)

🤖 Generated with [Claude Code](https://claude.com/claude-code)