### PR TITLE
release: prepare v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0] - YYYY-MM-DD
+### Added
+
+### Changed
+
+### Fixed
+
+## [0.1.0] - 2026-05-01
 
 Initial release.
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 An MCP server that connects Claude Code (and other MCP clients) to a [Kanban Tool](https://kanbantool.com/) account.
 
 [![CI](https://github.com/VeryLongOrgNameSuchWow/kanbantool-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/VeryLongOrgNameSuchWow/kanbantool-mcp/actions/workflows/ci.yml)
-[![PyPI](https://img.shields.io/pypi/v/kanbantool-mcp.svg?label=pypi%20%28coming%20soon%29)](https://pypi.org/project/kanbantool-mcp/)
+[![PyPI](https://img.shields.io/pypi/v/kanbantool-mcp.svg)](https://pypi.org/project/kanbantool-mcp/)
 [![Python](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 
@@ -13,7 +13,7 @@ Kanban Tool holds the authoritative state of your boards, tasks, and workflow â€
 
 ## Status
 
-**Pre-alpha.** The tool surface is settled but unproven against real workloads, and the package is not yet on PyPI ([#19](https://github.com/VeryLongOrgNameSuchWow/kanbantool-mcp/issues/19)). Install from the git repo for now (see below). API breakage between commits is possible until v0.1.0 ships.
+**Alpha.** The 12-tool surface is settled and exercised against a real Kanban Tool account via the `Live Integration` workflow. Pre-1.0 means the surface may still evolve based on real-world feedback â€” pin a specific version if you need stability across upgrades.
 
 ## Install
 
@@ -49,7 +49,7 @@ Add to your MCP client's `mcp.json`:
 }
 ```
 
-### From PyPI (once v0.1.0 ships)
+### From PyPI
 
 ```json
 {

--- a/examples/02-create-and-comment.md
+++ b/examples/02-create-and-comment.md
@@ -28,7 +28,7 @@ annotated with reproduction steps. The assistant resolves the board, calls
     name="Fix login bug",
     board_id=4711,
     priority="high",
-    assignees=[12],
+    assigned_user_id=12,
   )
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kanbantool-mcp"
-version = "0.1.0.dev0"
+version = "0.1.0"
 description = "MCP server bridging Claude Code with the Kanban Tool API v3."
 readme = "README.md"
 requires-python = ">=3.11"
@@ -12,11 +12,16 @@ authors = [
 keywords = ["mcp", "kanbantool", "kanban", "claude", "llm"]
 classifiers = [
     "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Topic :: Communications",
+    "Topic :: Software Development :: Libraries",
+    "Typing :: Typed",
 ]
 dependencies = [
     "fastmcp>=2.0",
@@ -46,6 +51,11 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/kanbantool_mcp"]
+
+[tool.hatch.build.targets.sdist]
+# CLAUDE.md is internal Claude Code orientation for this repo — useful for
+# contributors via git, but not something a PyPI consumer should be inspecting.
+exclude = ["CLAUDE.md"]
 
 [tool.ruff]
 line-length = 100

--- a/src/kanbantool_mcp/__init__.py
+++ b/src/kanbantool_mcp/__init__.py
@@ -1,3 +1,3 @@
 """kanbantool-mcp: MCP server bridging Claude Code with the Kanban Tool API v3."""
 
-__version__ = "0.1.0.dev0"
+__version__ = "0.1.0"

--- a/uv.lock
+++ b/uv.lock
@@ -563,7 +563,7 @@ wheels = [
 
 [[package]]
 name = "kanbantool-mcp"
-version = "0.1.0.dev0"
+version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary

Cuts the version string, fills in the CHANGELOG date, polishes the README for a published package, fixes a stale example, and tightens the sdist contents.

Per the comprehensive v0.1.0 release-readiness review.

## Blockers fixed

- **Version bumped**: ``pyproject.toml`` and ``src/kanbantool_mcp/__init__.py`` go from ``0.1.0.dev0`` → ``0.1.0``. Build artifacts now produce ``kanbantool_mcp-0.1.0.{tar.gz,whl}`` correctly.
- **CLAUDE.md excluded from sdist** via Hatchling's ``[tool.hatch.build.targets.sdist] exclude``. Internal agent-orientation file; first-time PyPI consumers don't need it in a tarball. Wheel was already clean.
- **Stale example fixed**: ``examples/02-create-and-comment.md`` changed ``assignees=[12]`` → ``assigned_user_id=12``. The legacy form is silently ignored by the API.

## Pre-tag fixes

- **CHANGELOG.md**: ``YYYY-MM-DD`` → ``2026-05-01``; seeded empty ``[Unreleased]`` Added/Changed/Fixed stubs.
- **README PyPI badge**: drop the ``(coming soon)`` label suffix.
- **README Status**: tighten from "Pre-alpha … not yet on PyPI" to plain "Alpha".
- **README install heading**: drop "(once v0.1.0 ships)" parenthetical.
- **pyproject classifiers**: add ``Intended Audience :: Developers``, ``Operating System :: OS Independent``, ``Topic :: Communications``, ``Topic :: Software Development :: Libraries``, ``Typing :: Typed``.

## Test plan

- [x] ``uv run pytest`` — 122/122 ✓
- [x] ``uv run ruff check . && ruff format --check .`` clean
- [x] ``uv run ty check`` clean
- [x] ``uv build`` produces ``kanbantool_mcp-0.1.0.tar.gz`` + ``kanbantool_mcp-0.1.0-py3-none-any.whl``
- [x] Wheel src-only (no tests/CLAUDE.md/.github/examples)
- [x] sdist no longer contains CLAUDE.md
- [ ] CI matrix — green

## Post-merge

```
gh release create v0.1.0 --generate-notes --target main
```

Fires ``release.yml`` → OIDC-claims a PyPI token → upload → first publish converts the Pending Publisher to a real Publisher → ``softprops/action-gh-release`` creates the GitHub release with auto-generated notes.

Closes #19, #20, #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)