### PR TITLE
ci(release): scope release-asset glob to artifacts only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,4 +23,11 @@ jobs:
       - uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3.0.0
         with:
           generate_release_notes: true
-          files: dist/*
+          # Explicit glob — ``dist/*`` would also pick up ``dist/.gitignore``
+          # that ``uv build`` writes (a one-line ``*`` to keep ``dist/`` out
+          # of source). v0.1.0 shipped that file as a release asset; this
+          # change scopes attestations + artifacts only.
+          files: |
+            dist/*.whl
+            dist/*.tar.gz
+            dist/*.publish.attestation


### PR DESCRIPTION
## Summary

``dist/*`` in ``release.yml`` globbed too widely. ``uv build`` writes a one-line ``dist/.gitignore`` (literally ``*``) to keep build output out of source control. The v0.1.0 release picked it up and shipped ``default.gitignore`` as a release asset.

Tighten the glob to the three filename shapes we actually want to publish:

```yaml
files: |
  dist/*.whl
  dist/*.tar.gz
  dist/*.publish.attestation
```

Closes #77

## Test plan

This workflow only fires on tag push, so it can't be exercised by PR CI. Verification path:
- [x] ``release.yml`` is the only file changed; YAML is well-formed
- [ ] CI matrix on this PR — green (offline tests + lint, unaffected)
- [ ] Validated on next release cut (v0.1.1+)

## Cosmetic note

The v0.1.0 release on GitHub still has the rogue asset attached. Not deleting it retroactively — release immutability matters more than the cosmetic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)