### PR TITLE
chore(packaging): single-source the package version via Hatchling dynamic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,9 @@
 [project]
 name = "kanbantool-mcp"
-version = "0.1.0"
+# Version is read from ``src/kanbantool_mcp/__init__.py`` at build time —
+# see ``[tool.hatch.version]`` below. Single source: ``__version__`` is the
+# only string that needs bumping for a release.
+dynamic = ["version"]
 description = "MCP server bridging Claude Code with the Kanban Tool API v3."
 readme = "README.md"
 requires-python = ">=3.11"
@@ -48,6 +51,12 @@ dev = [
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.hatch.version]
+# Single source of truth for the package version. Update ``__version__`` in
+# ``__init__.py`` to bump; ``project.version`` resolves dynamically at build
+# time. See https://hatch.pypa.io/latest/version/.
+path = "src/kanbantool_mcp/__init__.py"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/kanbantool_mcp"]

--- a/uv.lock
+++ b/uv.lock
@@ -563,7 +563,6 @@ wheels = [
 
 [[package]]
 name = "kanbantool-mcp"
-version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary

``__version__`` lived in two places — ``pyproject.toml`` and ``src/kanbantool_mcp/__init__.py`` — and they drifted during the v0.1.0 cut: PR #76 had to bump both. Tomorrow we'd forget one.

Switch to Hatchling's dynamic-version reader:

```toml
[project]
dynamic = ["version"]

[tool.hatch.version]
path = "src/kanbantool_mcp/__init__.py"
```

The ``__version__`` string in ``__init__.py`` is the only place that needs editing for a release.

## Verification

- ``uv build`` still produces ``kanbantool_mcp-0.1.0.{tar.gz,whl}``.
- Wheel METADATA shows ``Version: 0.1.0``.
- ``uv run pytest`` 122/122; ``ruff check``, ``ruff format --check``, ``ty check`` all clean.

Refs the v0.1.0 retro discussion (improvement #1 of 3).

## Test plan
- [x] ``uv run pytest`` — 122/122 ✓
- [x] ``uv build`` produces correct artifacts
- [x] Lint + type-check clean
- [ ] CI matrix — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)