### PR TITLE
docs: add CONTRIBUTING.md plus issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Something isn't working as documented
+title: ""
+labels: ["type:bug"]
+---
+
+## What happened
+
+<!-- One paragraph: what you tried, what happened, why it surprised you. -->
+
+## Reproduction
+
+<!-- Minimum steps. Include the exact MCP tool call (or curl) and the
+     response you got. DO NOT paste your KANBANTOOL_API_TOKEN — redact
+     to "<TOKEN>". Domain (subdomain prefix) is fine. -->
+
+```
+KANBANTOOL_DOMAIN=<your-subdomain>
+KANBANTOOL_API_TOKEN=<TOKEN>
+```
+
+```
+> tool_name(arg=value)
+```
+
+## Expected
+
+<!-- What did you expect to happen instead? -->
+
+## Environment
+
+- `kanbantool-mcp` version: <!-- `uvx kanbantool-mcp --version` or check the wheel METADATA -->
+- Python version: <!-- `python --version` -->
+- OS: <!-- macOS / Linux distro / Windows -->
+- MCP client: <!-- Claude Code / Cursor / other -->
+
+## Anything else

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/VeryLongOrgNameSuchWow/kanbantool-mcp/security/advisories/new
+    about: Don't open a public issue. Report privately via GitHub security advisories.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,37 @@
+---
+name: Feature request
+about: Surface a Kanban Tool API capability the MCP doesn't yet expose
+title: ""
+labels: ["type:enhancement"]
+---
+
+## What you want to do
+
+<!-- What's the LLM-agent workflow you're trying to enable? -->
+
+<!-- Example: "Have Claude triage incoming bug tickets by tagging them
+     with the right card type." -->
+
+## What's missing
+
+<!-- Which existing tool falls short, or which API capability isn't
+     surfaced at all? -->
+
+<!-- Concrete API endpoint reference helps:
+     https://kanbantool.com/developer/api-v3 -->
+
+## Proposed shape
+
+<!-- Optional but appreciated: what should the tool signature look like?
+     What's the input / output? Keep ergonomics LLM-friendly — single
+     responsibility, terse args, predictable response. -->
+
+```python
+new_tool(arg1: int, arg2: str) -> Result
+```
+
+## Alternatives considered
+
+<!-- Did you try doing this with existing tools? Why didn't it work? -->
+
+## Anything else

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,28 @@
+<!-- PR title MUST follow Conventional Commits (release-please reads it):
+     <type>[scope][!]: <short description>
+     e.g.  feat(server): add list_users tool
+           fix: handle 422 with empty body
+           docs(readme): tighten install snippet -->
+
+## Summary
+
+<!-- One paragraph: what changes and why. -->
+
+## What's in / what's out
+
+<!-- Optional. Use if scope was non-obvious or you deferred related work. -->
+
+## Test plan
+
+- [ ] `uv run pytest`
+- [ ] `uv run ruff check . && uv run ruff format --check .`
+- [ ] `uv run ty check`
+- [ ] (if you touched a tool's wire contract) Live integration tests exercise the new path
+- [ ] CI matrix on this PR — green
+
+## Closes / refs
+
+<!-- "Closes #N" footers in the squash-merge body auto-close issues at
+     release time. Use them. -->
+
+Closes #

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,122 @@
+# Contributing
+
+Thanks for considering a contribution to `kanbantool-mcp`. The project
+is small, opinionated, and pre-1.0 — read this once before you open a
+PR and we'll get along fine.
+
+## Getting started
+
+```bash
+git clone git@github.com:VeryLongOrgNameSuchWow/kanbantool-mcp.git
+cd kanbantool-mcp
+uv sync --dev          # installs runtime + dev dependencies
+uv run pytest          # 122+ tests, offline, < 2s
+uv run ruff check .    # lint
+uv run ruff format --check .
+uv run ty check        # type check
+```
+
+Python 3.11+ required. The CI matrix runs 3.11 / 3.12 / 3.13.
+
+## Filing issues
+
+Use the issue templates — bug report or feature request. The bug
+template asks for repro steps, expected vs. actual, and the
+`KANBANTOOL_DOMAIN`/`KANBANTOOL_API_TOKEN` shape (please **don't**
+paste tokens; redact). Feature requests should explain the LLM-agent
+use case the tool would enable, not just "expose endpoint X."
+
+## Pull requests
+
+We use [GitHub Flow](https://docs.github.com/en/get-started/using-github/github-flow):
+feature branch → PR → squash-merge to `main`. No `develop` / `release/*`
+branches.
+
+### Conventional commits
+
+Squash-merge commit titles MUST follow
+[Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+<type>[optional scope][!]: <short description>
+```
+
+| Type | Use for |
+|------|---------|
+| `feat` | New tool, new model field, new MCP-visible behaviour |
+| `fix` | Bug fix (incl. error-surface inconsistencies) |
+| `docs` | README, CHANGELOG, CONTRIBUTING, RELEASING, examples |
+| `chore` | Dependency bumps, repo housekeeping |
+| `ci` | CI workflow changes |
+| `test` | Test-only changes |
+| `refactor` | Rename / move without behaviour change |
+| `perf` | Performance improvement without API change |
+
+Add `!` (e.g. `feat!: ...`) or a `BREAKING CHANGE:` footer for
+backwards-incompatible changes — release-please uses these to bump
+the major version.
+
+`Closes #N` footers in the squash-merge body auto-close the issue at
+release time (parsed from the CHANGELOG entry by the release
+workflow).
+
+### What a good PR looks like
+
+- One logical change per PR. Don't bundle unrelated cleanup.
+- Tests that exercise the change. Offline tests must stay offline
+  (mock with `respx`); see `tests/conftest.py` for shared fixtures.
+- If you touch a tool's wire contract (URL, body shape, response
+  parsing), add or update a live integration test under
+  `tests/integration/`. Live tests are excluded from the default
+  `pytest` run and only execute via the manual `Live Integration`
+  workflow.
+- Docstrings for `@mcp.tool` functions are the prompt the LLM sees.
+  Keep them terse, action-oriented, and accurate. Don't explain
+  *what* the code does — explain *when* an agent should reach for
+  this tool and what a good argument looks like.
+
+### CI
+
+Every PR must pass:
+
+- `test (3.11 / 3.12 / 3.13)` — full offline suite.
+- `dry-run` (only fires on PRs touching packaging-relevant files) —
+  builds wheel + sdist, smoke-tests the wheel installs.
+
+The live integration suite is **not** required for PR — by design.
+It only runs manually via the `Live Integration` workflow against a
+real Kanban Tool account.
+
+### Reviews
+
+Two-step: I'll look at the change for correctness + simplicity; if
+you've added a tool or touched the wire surface, I'll also dispatch
+the live integration suite before merging.
+
+## Code style
+
+- `ruff` is the formatter and the linter. `ruff format` for the
+  former, `ruff check` for the latter. Settings live in
+  `pyproject.toml`.
+- `ty` is the type-checker. Settings live in `pyproject.toml`.
+- Pydantic models use `ConfigDict(extra="ignore")` for forward-compat
+  with API additions. When a wire field uses a different name than
+  the model attribute, use `Field(alias="<wire>")` plus
+  `populate_by_name=True`.
+- Errors flow through the typed ladder in `src/kanbantool_mcp/exceptions.py`
+  — `KanbanToolError` → `KanbanToolPermissionError`,
+  `KanbanToolHTTPError` → `KanbanToolValidationError`,
+  `KanbanToolTransportError`. New tools should raise these, not
+  `ValueError` / `RuntimeError`.
+
+## Releasing
+
+You don't cut releases — release-please does. Land conventional
+commits on `main`, the bot opens (or refreshes) a "chore(main):
+release X.Y.Z" PR. Merging it auto-tags + auto-publishes to PyPI.
+See `RELEASING.md` for the full flow.
+
+## Security
+
+If you find a security issue, **don't** open a public issue or PR.
+Use GitHub private security advisories — link in `SECURITY.md`.


### PR DESCRIPTION
## Summary

Adds the standard FOSS hygiene files we've been running without:

- **`CONTRIBUTING.md`** — getting-started, conventional-commit requirement (load-bearing for release-please), what a good PR looks like, CI gates, live-integration-suite distinction.
- **`.github/ISSUE_TEMPLATE/`** — bug-report + feature-request templates with `config.yml` disabling blank issues and routing security reports to private advisories.
- **`.github/pull_request_template.md`** — leads with the conventional-commit reminder so contributors don't get caught out by release-please silently dropping their commit from the changelog.

No source impact; pure docs and repo metadata.

## Test plan

- [x] `uv run pytest` — 122/122 ✓
- [x] `ruff check .` / `ruff format --check .` clean
- [x] `ty check` clean
- [ ] CI matrix — green
- [ ] Visual: open the new issue templates in the GitHub UI to confirm the form renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)