### PR TITLE
feat(models): surface additive Task fields from the v3 wire payload

### DIFF
--- a/src/kanbantool_mcp/models.py
+++ b/src/kanbantool_mcp/models.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field, computed_field
+from pydantic import BaseModel, ConfigDict, Field, computed_field, field_validator
 
 
 class Column(BaseModel):
@@ -129,11 +129,93 @@ class Task(BaseModel):
     timers_total: int | None = None
     created_at: str | None = None
     updated_at: str | None = None
-    # v0.2.0: additive fields confirmed in the live-API spike — ``size_estimate``,
-    # ``card_color``, ``search_tags``, ``collaborators``, ``card_type_id``,
-    # ``custom_field_1..15``, ``recurring_schedule``, ``reminders_schedule``,
-    # ``linked_tasks``, ``task_dependencies``. Tracked under the High-Value
-    # tier of #38; the 15 numbered custom fields need a dict-shaped design call.
+
+    # --- Sizing & estimation -------------------------------------------------
+    # Story-point / abstract size as set on the card.
+    size_estimate: int | None = None
+    # Free-form description accompanying ``size_estimate``.
+    size_estimate_description: str | None = None
+    # Estimated effort in seconds (distinct from ``timers_total``, which is
+    # recorded actuals).
+    time_estimate: int | None = None
+
+    # --- Search / discoverability -------------------------------------------
+    # Free-form list of search-helper strings; distinct from ``tags`` (which is
+    # the comma-separated user-facing label string). Live spike confirmed the
+    # wire shape is a list of strings.
+    search_tags: list[str] = Field(default_factory=list)
+
+    # --- Visual markers ------------------------------------------------------
+    # Named card colour, e.g. ``"red"`` (separate from ``color`` which is a
+    # hex/CSS string on some accounts).
+    card_color: str | None = None
+    # API-provided RGB rendering of ``card_color``, useful when a UI wants to
+    # avoid maintaining its own colour-name → swatch lookup.
+    card_color_in_rgb: str | None = None
+    # True when the card-colour foreground should be inverted for contrast.
+    card_color_invert: bool | None = None
+    # Per-account card-type id (board-config concept; the LLM mostly treats
+    # this as opaque).
+    card_type_id: int | None = None
+
+    # --- Schedule fields -----------------------------------------------------
+    # raw API shape passed through; typed wrapper deferred to v0.x.x
+    recurring_schedule: dict[str, Any] | None = None
+    # raw API shape passed through; typed wrapper deferred to v0.x.x
+    reminders_schedule: dict[str, Any] | None = None
+
+    # --- Relationships -------------------------------------------------------
+    # raw entries — typed sub-model can come when an MCP tool actually needs it
+    linked_tasks: list[dict[str, Any]] = Field(default_factory=list)
+    # Status string summarising the linked-task relationship state.
+    linked_tasks_status: str | None = None
+    # raw entries — typed sub-model can come when an MCP tool actually needs it
+    task_dependencies: list[dict[str, Any]] = Field(default_factory=list)
+    # raw entries — typed sub-model can come when an MCP tool actually needs it
+    collaborators: list[dict[str, Any]] = Field(default_factory=list)
+
+    # --- Attachments ---------------------------------------------------------
+    # raw entries — typed sub-model can come when an MCP tool actually needs it
+    attachments: list[dict[str, Any]] = Field(default_factory=list)
+    attachments_count: int | None = None
+
+    # --- Provenance & state --------------------------------------------------
+    # User id of the task's creator.
+    created_by_id: int | None = None
+    # ISO 8601 timestamp of the task's last column/swimlane move.
+    moved_at: str | None = None
+    # ISO 8601 timestamp the task is snoozed/postponed until.
+    postponed_until: str | None = None
+    # Companion to ``subtasks_count`` — number of subtasks already completed.
+    subtasks_completed_count: int | None = None
+    # Caller-supplied identifier for cross-system linking.
+    external_id: str | None = None
+    # Caller-supplied URL for cross-system linking.
+    external_link: str | None = None
+    # v0.2.0+: ``custom_field_1..15`` (15 numbered fields, dict-shaped wrapper
+    # design call still pending) and ``changelogs``/``time_trackers`` (heavy
+    # nested data — exposed via dedicated tools rather than inlined here)
+    # remain dropped via ``extra="ignore"`` for now. Tracked under #38.
+
+    # The Kanban Tool API serialises empty collections as JSON ``null`` rather
+    # than ``[]`` for several of these additive fields (live spike confirmed
+    # for ``linked_tasks``; the other detail-only collections behave the same
+    # way). Coerce ``None`` → ``[]`` at validation time so callers see a
+    # consistent list-typed surface and don't have to defensive-check for
+    # ``None``. Applies to all the additive collection fields; the existing
+    # ``subtasks`` field is a typed sub-model list and is omitted from this
+    # list so the original parsing behaviour stays untouched.
+    @field_validator(
+        "linked_tasks",
+        "task_dependencies",
+        "collaborators",
+        "attachments",
+        "search_tags",
+        mode="before",
+    )
+    @classmethod
+    def _none_to_empty_list(cls, value: Any) -> Any:
+        return [] if value is None else value
 
     # ``@computed_field`` is required so pydantic v2 includes the derived
     # boolean in ``model_dump()`` and ``model_json_schema()`` — a bare

--- a/tests/integration/test_live_read_tools.py
+++ b/tests/integration/test_live_read_tools.py
@@ -100,6 +100,53 @@ async def test_get_task_populates_renamed_wire_fields(
     assert task.block_reason is None or isinstance(task.block_reason, str)
 
 
+async def test_get_task_surfaces_additive_v3_fields(
+    _inject_live_client: KanbanToolClient, populated_board_id: int
+) -> None:
+    """Type-only assertions that the additive #38 / #59 fields are reachable
+    through the model. We don't lock values — the test account's data
+    drifts — but the v3 wire payload should advertise these keys, so the
+    typed attributes must exist on the resulting ``Task`` and respect their
+    declared types where present."""
+    search_hits = await search_tasks(query="archived:false", board_id=populated_board_id)
+    assert search_hits, "populated_board_id fixture promised non-archived tasks"
+    task_id = search_hits[0].id
+
+    task = await get_task(task_id)
+
+    # Sizing & estimation
+    assert task.size_estimate is None or isinstance(task.size_estimate, int)
+    assert task.size_estimate_description is None or isinstance(task.size_estimate_description, str)
+    assert task.time_estimate is None or isinstance(task.time_estimate, int)
+    # Search / discoverability — list of strings on the wire; ``None`` is
+    # coerced to ``[]`` so callers see a stable list type.
+    assert isinstance(task.search_tags, list)
+    assert all(isinstance(tag, str) for tag in task.search_tags)
+    # Visual markers
+    assert task.card_color is None or isinstance(task.card_color, str)
+    assert task.card_color_in_rgb is None or isinstance(task.card_color_in_rgb, str)
+    assert task.card_color_invert is None or isinstance(task.card_color_invert, bool)
+    assert task.card_type_id is None or isinstance(task.card_type_id, int)
+    # Schedule fields (raw dicts)
+    assert task.recurring_schedule is None or isinstance(task.recurring_schedule, dict)
+    assert task.reminders_schedule is None or isinstance(task.reminders_schedule, dict)
+    # Relationships — collection fields default to ``[]``, never ``None``.
+    assert isinstance(task.linked_tasks, list)
+    assert task.linked_tasks_status is None or isinstance(task.linked_tasks_status, str)
+    assert isinstance(task.task_dependencies, list)
+    assert isinstance(task.collaborators, list)
+    # Attachments
+    assert isinstance(task.attachments, list)
+    assert task.attachments_count is None or isinstance(task.attachments_count, int)
+    # Provenance & state
+    assert task.created_by_id is None or isinstance(task.created_by_id, int)
+    assert task.moved_at is None or isinstance(task.moved_at, str)
+    assert task.postponed_until is None or isinstance(task.postponed_until, str)
+    assert task.subtasks_completed_count is None or isinstance(task.subtasks_completed_count, int)
+    assert task.external_id is None or isinstance(task.external_id, str)
+    assert task.external_link is None or isinstance(task.external_link, str)
+
+
 async def test_recent_changes_populates_renamed_fields(
     _inject_live_client: KanbanToolClient, populated_board_id: int
 ) -> None:

--- a/tests/test_get_task.py
+++ b/tests/test_get_task.py
@@ -189,3 +189,128 @@ def test_task_model_json_schema_advertises_computed_flags() -> None:
     schema = Task.model_json_schema(mode="serialization")
     assert "is_archived" in schema["properties"]
     assert "is_blocked" in schema["properties"]
+
+
+# --- Additive fields surfaced from the v3 wire payload (#38 / #59) ----------
+#
+# These three tests lock the additive-field contract: every new field
+# round-trips when present, defaults to None / [] when absent, and the
+# explicitly-deferred fields (custom_field_*, changelogs) stay dropped via
+# ``extra="ignore"``.
+
+
+def test_task_round_trips_additive_fields() -> None:
+    """Every additive field surfaced in #38 / #59 must round-trip via
+    ``Task.model_validate(...).model_dump()``."""
+    payload = {
+        "id": 1,
+        "name": "Loaded",
+        # Sizing & estimation
+        "size_estimate": 5,
+        "size_estimate_description": "five points",
+        "time_estimate": 7200,
+        # Search / discoverability
+        "search_tags": ["alpha", "beta"],
+        # Visual markers
+        "card_color": "red",
+        "card_color_in_rgb": "#ff0000",
+        "card_color_invert": True,
+        "card_type_id": 9,
+        # Schedule fields (raw dicts)
+        "recurring_schedule": {"every": "week", "weekday": "mon"},
+        "reminders_schedule": {"offsets": [60, 1440]},
+        # Relationships
+        "linked_tasks": [{"id": 11, "name": "linked-a"}],
+        "linked_tasks_status": "blocked",
+        "task_dependencies": [{"id": 22, "type": "blocks"}],
+        "collaborators": [{"user_id": 33}, {"user_id": 44}],
+        # Attachments
+        "attachments": [{"id": 55, "filename": "spec.pdf"}],
+        "attachments_count": 1,
+        # Provenance & state
+        "created_by_id": 100,
+        "moved_at": "2026-04-30T09:00:00Z",
+        "postponed_until": "2026-05-10T00:00:00Z",
+        "subtasks_completed_count": 2,
+        "external_id": "JIRA-42",
+        "external_link": "https://example.test/JIRA-42",
+    }
+    task = Task.model_validate(payload)
+    dumped = task.model_dump()
+
+    for key, value in payload.items():
+        assert dumped[key] == value, f"{key} did not round-trip"
+
+
+def test_task_additive_fields_default_when_absent() -> None:
+    """A minimal payload defaults every new field — ``None`` for scalars,
+    empty list for collection fields."""
+    task = Task.model_validate({"id": 1, "name": "Bare"})
+
+    # Scalar defaults
+    assert task.size_estimate is None
+    assert task.size_estimate_description is None
+    assert task.time_estimate is None
+    assert task.card_color is None
+    assert task.card_color_in_rgb is None
+    assert task.card_color_invert is None
+    assert task.card_type_id is None
+    assert task.recurring_schedule is None
+    assert task.reminders_schedule is None
+    assert task.linked_tasks_status is None
+    assert task.attachments_count is None
+    assert task.created_by_id is None
+    assert task.moved_at is None
+    assert task.postponed_until is None
+    assert task.subtasks_completed_count is None
+    assert task.external_id is None
+    assert task.external_link is None
+
+    # Collection defaults
+    assert task.search_tags == []
+    assert task.linked_tasks == []
+    assert task.task_dependencies == []
+    assert task.collaborators == []
+    assert task.attachments == []
+
+
+def test_task_collection_fields_coerce_null_to_empty_list() -> None:
+    """The Kanban Tool v3 API serialises empty collections as JSON ``null``
+    for several detail-only fields (live spike confirmed for ``linked_tasks``).
+    The model must coerce ``None`` → ``[]`` so callers see a consistent
+    list-typed surface."""
+    task = Task.model_validate(
+        {
+            "id": 1,
+            "name": "Null collections",
+            "linked_tasks": None,
+            "task_dependencies": None,
+            "collaborators": None,
+            "attachments": None,
+            "search_tags": None,
+        }
+    )
+    assert task.linked_tasks == []
+    assert task.task_dependencies == []
+    assert task.collaborators == []
+    assert task.attachments == []
+    assert task.search_tags == []
+
+
+def test_task_still_drops_deferred_fields() -> None:
+    """``custom_field_*`` and ``changelogs`` are explicitly deferred — they
+    must remain dropped via ``extra="ignore"`` so the additive change stays
+    pure (no accidental surface for fields we haven't designed)."""
+    task = Task.model_validate(
+        {
+            "id": 1,
+            "name": "Deferred",
+            "custom_field_1": "should not surface",
+            "custom_field_15": "also dropped",
+            "changelogs": [{"id": 999, "what": "noisy"}],
+        }
+    )
+    dumped = task.model_dump()
+    assert "custom_field_1" not in dumped
+    assert "custom_field_15" not in dumped
+    assert "changelogs" not in dumped


### PR DESCRIPTION
## Summary

Surfaces the high-value subset of `Task` fields the Kanban Tool v3 API returns but the model was silently dropping via `extra="ignore"`. Pure additive change — no renames, no removals, no breaking surface.

### What's added

- **Sizing & estimation**: `size_estimate`, `size_estimate_description`, `time_estimate`.
- **Search / discoverability**: `search_tags` (list of strings — live spike confirmed it is NOT a single comma-separated string like `tags`).
- **Visual markers**: `card_color`, `card_color_in_rgb`, `card_color_invert`, `card_type_id`.
- **Schedules** (raw dict pass-through; typed wrappers deferred): `recurring_schedule`, `reminders_schedule`.
- **Relationships** (raw entries; typed sub-models deferred): `linked_tasks`, `linked_tasks_status`, `task_dependencies`, `collaborators`.
- **Attachments**: `attachments` (raw entries) + `attachments_count`.
- **Provenance & state**: `created_by_id`, `moved_at`, `postponed_until`, `subtasks_completed_count`, `external_id`, `external_link`.

### What's deferred (still dropped via `extra="ignore"`)

- `custom_field_1..15` — 15 numbered fields; needs a dict-shaped wrapper design call.
- `changelogs` (inline) — heavy nested data; the dedicated `recent_changes` MCP tool already covers the board-level changelog.
- `time_trackers` (inline) — heavy; time tracking belongs behind a dedicated tool.
- Internal counters / versions / niche fields (`timers_*_count`, `timers_total_updated_at`, `version`, `board_version`, `deleted_at`, `linked_from`, `subtask_search_tags`).

### Notable wire-shape findings from the live spike

1. `search_tags` is a **list of strings** on the wire (the spec assumed `str`); the model now reflects that.
2. The v3 API serialises empty collections as JSON `null` rather than `[]` for several detail-only fields (confirmed for `linked_tasks`). A `mode="before"` validator coerces `None` → `[]` so callers see a stable list-typed surface.

## Test plan

- [x] Offline unit tests: 126 passed (was 122 baseline + 4 new).
- [x] Live integration tests: 7 passed (was 6 + 1 new) against the `rynbou` test account.
- [x] `uv run ruff check .` clean.
- [x] `uv run ruff format --check .` clean.
- [x] `uv run ty check` clean.

Closes #38
Closes #59