### PR TITLE
feat(server): add whoami, get_user, list_board_collaborators tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,11 @@ Write tools (M2):
 - `add_subtask`
 - `list_subtasks`
 
+User discovery tools (post-M3):
+- `whoami` — current user (resolves "me" / "myself")
+- `get_user` — fetch one user by id
+- `list_board_collaborators` — board's user roster (no bulk list-users endpoint exists)
+
 ## Kanban Tool API quirks
 
 - Per-account base URL: `https://{KANBANTOOL_DOMAIN}.kanbantool.com/api/v3/`. There is no global host.

--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ Add to your MCP client's `mcp.json`:
 | `add_comment` | Post a comment on a task. | `task_id`, `text` |
 | `list_subtasks` | List subtasks attached to a task. | `task_id` |
 | `add_subtask` | Add a subtask to a task. | `task_id`, `title` |
+| `whoami` | Fetch the authenticated user's profile — id, role flags, locale. Use to resolve "me" / "myself" in user requests. | — |
+| `get_user` | Fetch one user by id. | `user_id` |
+| `list_board_collaborators` | List users with access to a board (the canonical user-discovery surface — the API has no bulk list-users endpoint). | `board_id` |
 
 (`ping` exists as a transport smoke test; not listed above.)
 

--- a/src/kanbantool_mcp/models.py
+++ b/src/kanbantool_mcp/models.py
@@ -66,6 +66,12 @@ class Board(BaseModel):
     # Detail-only collections; absent from list_boards' compact payload, hence defaults.
     columns: list[Column] = Field(default_factory=list, alias="workflow_stages")
     swimlanes: list[Swimlane] = Field(default_factory=list)
+    # The user-facing roster of board members. The API v3 has no bulk
+    # list-users endpoint, so this is the canonical way to discover user
+    # IDs for ``assigned_user_id`` on tasks. ``Collaborator`` is defined
+    # below; the forward reference resolves via ``from __future__ import
+    # annotations`` + pydantic's lazy resolution at validate time.
+    collaborators: list[Collaborator] = Field(default_factory=list)
     # ``card_template`` is the API's per-board "which card fields are shown"
     # config — a dict keyed by field name (``description``, ``priority``,
     # ``custom_field_1``, ...) whose values describe each field's enabled
@@ -298,3 +304,52 @@ class ChangelogEntry(BaseModel):
     # Action-specific payload (e.g. ``user_initials``, ``task_name``,
     # ``workflow_stage_name``). Shape varies by ``what``.
     data: dict[str, Any] | None = None
+
+
+class Collaborator(BaseModel):
+    """A user with access to a specific board.
+
+    Inline on ``Board.collaborators[]`` — the API v3 has no bulk-list-users
+    endpoint, so this is the canonical way to discover user IDs for
+    assignment workflows.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    id: int
+    name: str | None = None
+    initials: str | None = None
+    # ``True`` for users still allowed to act on the board, ``False`` for
+    # suspended / removed members. Useful when callers want to ignore stale
+    # entries that the wire still reports.
+    active: bool | None = None
+
+
+class User(BaseModel):
+    """An account-scoped user.
+
+    Returned from ``GET /users/{id}.json`` (and its ``/users/current.json``
+    redirect alias). Surfaces the LLM-meaningful subset of the wire shape;
+    heavy nested structures (``account``, ``customizations``, ``settings``,
+    ``groups``) are dropped via ``extra="ignore"`` and can be promoted to
+    typed sub-models when an MCP tool actually needs them.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    id: int
+    name: str | None = None
+    initials: str | None = None
+    # Role flags — a single user can hold any combination of these.
+    is_account_admin: bool | None = None
+    is_account_owner: bool | None = None
+    is_project_manager: bool | None = None
+    is_suspended: bool | None = None
+    # ISO 8601 strings — match the existing convention on Task/Board.
+    last_activity_on: str | None = None
+    last_login_at: str | None = None
+    created_at: str | None = None
+    # Account-level locale + timezone surfaced for LLMs that want to render
+    # times or messages in the user's local context.
+    timezone: str | None = None
+    locale: str | None = None

--- a/src/kanbantool_mcp/server.py
+++ b/src/kanbantool_mcp/server.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel, Field, ValidationError, validate_call
 from .client import KanbanToolClient
 from .config import Config
 from .exceptions import KanbanToolHTTPError
-from .models import Board, ChangelogEntry, Comment, Subtask, Task
+from .models import Board, ChangelogEntry, Collaborator, Comment, Subtask, Task, User
 
 # Mirrors ``client._BODY_EXCERPT_LIMIT`` so payload-shape errors surface a
 # truncated repr consistent with HTTP-error excerpts. Kept inline (rather than
@@ -88,6 +88,44 @@ async def list_boards() -> list[Board]:
     data = await _get_client().request("GET", "users/current")
     raw = data.get("boards", []) if isinstance(data, dict) else []
     return _decode_list(Board, raw, label="boards")
+
+
+@mcp.tool
+async def whoami() -> User:
+    """Fetch the authenticated user's profile.
+
+    Returns the ``User`` you're acting as — id, name, role flags, locale,
+    timezone. Use this to resolve "me" / "myself" references in user
+    requests (``assign to me`` → ``assigned_user_id`` from this response)
+    or to show the LLM whose perspective it's operating from."""
+    data = await _get_client().request("GET", "users/current")
+    return _decode(User, data, label="user")
+
+
+@mcp.tool
+@validate_call
+async def get_user(user_id: Annotated[int, Field(ge=1)]) -> User:
+    """Fetch one user by id. Useful after ``list_board_collaborators`` finds
+    a candidate by name — call this to confirm role flags and active state
+    before assigning. Raises ``KanbanToolHTTPError(404)`` for unknown ids."""
+    data = await _get_client().request("GET", f"users/{user_id}")
+    return _decode(User, data, label="user")
+
+
+@mcp.tool
+@validate_call
+async def list_board_collaborators(
+    board_id: Annotated[int, Field(ge=1)],
+) -> list[Collaborator]:
+    """List the users with access to ``board_id``.
+
+    The Kanban Tool API v3 has no bulk list-users endpoint, so this is the
+    canonical way to discover user IDs for ``assigned_user_id`` on tasks.
+    Costs one HTTP call (the same as ``get_board`` — collaborators come
+    inline on the detail payload). For richer per-user fields, follow up
+    with ``get_user(id)``."""
+    board = await get_board(board_id)
+    return board.collaborators
 
 
 @mcp.tool

--- a/tests/integration/test_live_read_tools.py
+++ b/tests/integration/test_live_read_tools.py
@@ -19,14 +19,17 @@ any particular board name or id — see the ``populated_board_id`` fixture.
 from __future__ import annotations
 
 from kanbantool_mcp.client import KanbanToolClient
-from kanbantool_mcp.models import Board, ChangelogEntry, Subtask, Task
+from kanbantool_mcp.models import Board, ChangelogEntry, Collaborator, Subtask, Task, User
 from kanbantool_mcp.server import (
     get_board,
     get_task,
+    get_user,
+    list_board_collaborators,
     list_boards,
     list_subtasks,
     recent_changes,
     search_tasks,
+    whoami,
 )
 
 
@@ -190,3 +193,50 @@ async def test_list_subtasks_and_inline_task_subtasks_agree(
     assert isinstance(task.subtasks, list)
     assert all(isinstance(s, Subtask) for s in task.subtasks)
     assert [s.id for s in subtasks] == [s.id for s in task.subtasks]
+
+
+async def test_whoami_returns_authenticated_user(
+    _inject_live_client: KanbanToolClient,
+) -> None:
+    """``whoami`` resolves through the ``/users/current.json`` 302-redirect
+    alias (see #57) and returns the typed User. Locks shape-only assertions
+    so the test stays valid as the account's profile drifts."""
+    me = await whoami()
+    assert isinstance(me, User)
+    assert me.id > 0
+    # ``name`` and ``initials`` are nullable per the model but should be
+    # populated for any real account. Type-only check tolerates either way.
+    assert me.name is None or isinstance(me.name, str)
+    assert me.initials is None or isinstance(me.initials, str)
+    # Role flags should at minimum be Boolean-or-None (never raise).
+    assert me.is_account_admin is None or isinstance(me.is_account_admin, bool)
+
+
+async def test_get_user_round_trips_against_whoami(
+    _inject_live_client: KanbanToolClient,
+) -> None:
+    """``whoami`` returns id; ``get_user(id)`` should return a User whose id
+    matches. Cheaper than locking specific account details."""
+    me = await whoami()
+    fetched = await get_user(me.id)
+    assert isinstance(fetched, User)
+    assert fetched.id == me.id
+
+
+async def test_list_board_collaborators_against_populated_board(
+    _inject_live_client: KanbanToolClient, populated_board_id: int
+) -> None:
+    """The board's ``collaborators[]`` is the canonical user-discovery
+    surface (no bulk list-users endpoint exists). Verifies the Board model
+    decodes the field and the wrapper tool propagates it."""
+    collaborators = await list_board_collaborators(populated_board_id)
+    assert isinstance(collaborators, list)
+    # Any account with at least one user (i.e. the authenticated one) on the
+    # board should report >= 1 collaborator. Type-only assertions for the
+    # rest tolerate locale / suspension state drift.
+    assert len(collaborators) >= 1
+    assert all(isinstance(c, Collaborator) for c in collaborators)
+    first = collaborators[0]
+    assert first.id > 0
+    assert first.name is None or isinstance(first.name, str)
+    assert first.active is None or isinstance(first.active, bool)

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -27,9 +27,9 @@ def _board_url(board_id: int) -> str:
 
 async def test_whoami_returns_typed_user(_inject_client: KanbanToolClient) -> None:
     payload = {
-        "id": 1383923,
-        "name": "riohno",
-        "initials": "R",
+        "id": 1,
+        "name": "Test User A",
+        "initials": "TA",
         "is_account_admin": True,
         "is_account_owner": False,
         "is_project_manager": True,
@@ -37,11 +37,11 @@ async def test_whoami_returns_typed_user(_inject_client: KanbanToolClient) -> No
         "last_activity_on": "2026-05-01",
         "last_login_at": "2026-05-01T08:00:00+00:00",
         "created_at": "2026-04-30T17:00:00+00:00",
-        "timezone": "Europe/Warsaw",
+        "timezone": "Etc/UTC",
         "locale": "en",
         # Heavy nested fields the API surfaces but the model drops via
         # ``extra="ignore"`` — keep one in the fixture so the test locks it.
-        "account": {"id": 99, "name": "VeryLong"},
+        "account": {"id": 99, "name": "TestAccount"},
         "settings": {"theme": "dark"},
     }
     with respx.mock(assert_all_called=True) as router:
@@ -49,11 +49,11 @@ async def test_whoami_returns_typed_user(_inject_client: KanbanToolClient) -> No
         result = await whoami()
 
     assert isinstance(result, User)
-    assert result.id == 1383923
-    assert result.name == "riohno"
+    assert result.id == 1
+    assert result.name == "Test User A"
     assert result.is_account_admin is True
     assert result.is_account_owner is False
-    assert result.timezone == "Europe/Warsaw"
+    assert result.timezone == "Etc/UTC"
     # ``extra="ignore"`` drops the unknown nested fields.
     dump = result.model_dump()
     assert "account" not in dump
@@ -89,19 +89,19 @@ async def test_whoami_malformed_payload_raises_http_error(
 
 async def test_get_user_returns_typed_user(_inject_client: KanbanToolClient) -> None:
     payload = {
-        "id": 1383921,
-        "name": "Magdalena Bartczak",
-        "initials": "MB",
+        "id": 2,
+        "name": "Test User B",
+        "initials": "TB",
         "is_account_admin": True,
         "is_account_owner": True,
     }
     with respx.mock(assert_all_called=True) as router:
-        router.get(_user_url(1383921)).mock(return_value=httpx.Response(200, json=payload))
-        result = await get_user(1383921)
+        router.get(_user_url(2)).mock(return_value=httpx.Response(200, json=payload))
+        result = await get_user(2)
 
     assert isinstance(result, User)
-    assert result.id == 1383921
-    assert result.name == "Magdalena Bartczak"
+    assert result.id == 2
+    assert result.name == "Test User B"
     assert result.is_account_owner is True
 
 

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -1,0 +1,204 @@
+"""Tests for the user-discovery tools: whoami, get_user, list_board_collaborators."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+
+from kanbantool_mcp.client import KanbanToolClient
+from kanbantool_mcp.exceptions import KanbanToolHTTPError, KanbanToolPermissionError
+from kanbantool_mcp.models import Collaborator, User
+from kanbantool_mcp.server import get_user, list_board_collaborators, whoami
+
+from .conftest import BASE_URL
+
+
+def _user_url(user_id: int | str) -> str:
+    return f"{BASE_URL}users/{user_id}.json"
+
+
+def _board_url(board_id: int) -> str:
+    return f"{BASE_URL}boards/{board_id}.json"
+
+
+# ---------- whoami ----------
+
+
+async def test_whoami_returns_typed_user(_inject_client: KanbanToolClient) -> None:
+    payload = {
+        "id": 1383923,
+        "name": "riohno",
+        "initials": "R",
+        "is_account_admin": True,
+        "is_account_owner": False,
+        "is_project_manager": True,
+        "is_suspended": False,
+        "last_activity_on": "2026-05-01",
+        "last_login_at": "2026-05-01T08:00:00+00:00",
+        "created_at": "2026-04-30T17:00:00+00:00",
+        "timezone": "Europe/Warsaw",
+        "locale": "en",
+        # Heavy nested fields the API surfaces but the model drops via
+        # ``extra="ignore"`` — keep one in the fixture so the test locks it.
+        "account": {"id": 99, "name": "VeryLong"},
+        "settings": {"theme": "dark"},
+    }
+    with respx.mock(assert_all_called=True) as router:
+        router.get(_user_url("current")).mock(return_value=httpx.Response(200, json=payload))
+        result = await whoami()
+
+    assert isinstance(result, User)
+    assert result.id == 1383923
+    assert result.name == "riohno"
+    assert result.is_account_admin is True
+    assert result.is_account_owner is False
+    assert result.timezone == "Europe/Warsaw"
+    # ``extra="ignore"`` drops the unknown nested fields.
+    dump = result.model_dump()
+    assert "account" not in dump
+    assert "settings" not in dump
+
+
+async def test_whoami_401_raises_permission_error(_inject_client: KanbanToolClient) -> None:
+    with respx.mock() as router:
+        router.get(_user_url("current")).mock(return_value=httpx.Response(401, text="unauthorized"))
+        with pytest.raises(KanbanToolPermissionError):
+            await whoami()
+
+
+async def test_whoami_malformed_payload_raises_http_error(
+    _inject_client: KanbanToolClient,
+) -> None:
+    """A 200 with a payload missing the required ``id`` field surfaces as
+    ``KanbanToolHTTPError(status_code=200)`` with a ``malformed``-tagged
+    excerpt — never a raw ``pydantic.ValidationError``."""
+    with respx.mock(assert_all_called=True) as router:
+        router.get(_user_url("current")).mock(
+            return_value=httpx.Response(200, json={"name": "no-id"})
+        )
+        with pytest.raises(KanbanToolHTTPError) as exc_info:
+            await whoami()
+
+    assert exc_info.value.status_code == 200
+    assert "malformed" in exc_info.value.body_excerpt
+
+
+# ---------- get_user ----------
+
+
+async def test_get_user_returns_typed_user(_inject_client: KanbanToolClient) -> None:
+    payload = {
+        "id": 1383921,
+        "name": "Magdalena Bartczak",
+        "initials": "MB",
+        "is_account_admin": True,
+        "is_account_owner": True,
+    }
+    with respx.mock(assert_all_called=True) as router:
+        router.get(_user_url(1383921)).mock(return_value=httpx.Response(200, json=payload))
+        result = await get_user(1383921)
+
+    assert isinstance(result, User)
+    assert result.id == 1383921
+    assert result.name == "Magdalena Bartczak"
+    assert result.is_account_owner is True
+
+
+async def test_get_user_404_raises_http_error(_inject_client: KanbanToolClient) -> None:
+    with respx.mock() as router:
+        router.get(_user_url(999)).mock(return_value=httpx.Response(404, text="not found"))
+        with pytest.raises(KanbanToolHTTPError) as exc_info:
+            await get_user(999)
+        assert exc_info.value.status_code == 404
+
+
+async def test_get_user_rejects_non_positive_id(_inject_client: KanbanToolClient) -> None:
+    """``validate_call`` enforces ``ge=1`` so we don't hit the API with a
+    bogus 0/-N that would produce a confusing 404."""
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        await get_user(0)
+
+
+# ---------- list_board_collaborators ----------
+
+
+async def test_list_board_collaborators_returns_typed_list(
+    _inject_client: KanbanToolClient,
+) -> None:
+    payload = {
+        "id": 42,
+        "name": "Engineering",
+        "workflow_stages": [],
+        "swimlanes": [],
+        "collaborators": [
+            {"id": 1, "name": "Alice", "initials": "A", "active": True},
+            {"id": 2, "name": "Bob", "initials": "B", "active": False},
+        ],
+    }
+    with respx.mock(assert_all_called=True) as router:
+        router.get(_board_url(42)).mock(return_value=httpx.Response(200, json=payload))
+        result = await list_board_collaborators(42)
+
+    assert len(result) == 2
+    assert all(isinstance(c, Collaborator) for c in result)
+    assert result[0].id == 1
+    assert result[0].name == "Alice"
+    assert result[0].active is True
+    assert result[1].active is False
+
+
+async def test_list_board_collaborators_empty_when_absent(
+    _inject_client: KanbanToolClient,
+) -> None:
+    """Boards may legitimately omit ``collaborators`` (compact list-style
+    payloads). Default to ``[]`` rather than failing validation."""
+    payload = {"id": 42, "name": "Engineering"}
+    with respx.mock(assert_all_called=True) as router:
+        router.get(_board_url(42)).mock(return_value=httpx.Response(200, json=payload))
+        result = await list_board_collaborators(42)
+
+    assert result == []
+
+
+async def test_list_board_collaborators_404_propagates(
+    _inject_client: KanbanToolClient,
+) -> None:
+    with respx.mock() as router:
+        router.get(_board_url(999)).mock(return_value=httpx.Response(404, text="not found"))
+        with pytest.raises(KanbanToolHTTPError):
+            await list_board_collaborators(999)
+
+
+# ---------- Board.collaborators round-trip ----------
+
+
+def test_board_collaborators_field_round_trip() -> None:
+    """The ``Board`` model exposes a typed ``collaborators`` list; verify
+    the round-trip preserves shape end-to-end."""
+    from kanbantool_mcp.models import Board
+
+    board = Board.model_validate(
+        {
+            "id": 1,
+            "name": "B",
+            "collaborators": [
+                {"id": 7, "name": "Eve", "initials": "E", "active": True},
+            ],
+        }
+    )
+    assert len(board.collaborators) == 1
+    assert isinstance(board.collaborators[0], Collaborator)
+    assert board.collaborators[0].id == 7
+    assert board.collaborators[0].name == "Eve"
+
+
+def test_board_collaborators_default_empty() -> None:
+    """When the API omits ``collaborators`` (e.g. compact list-style
+    payloads), the field defaults to ``[]``."""
+    from kanbantool_mcp.models import Board
+
+    board = Board.model_validate({"id": 1, "name": "B"})
+    assert board.collaborators == []


### PR DESCRIPTION
## Summary

Closes the user-discovery gap: the Kanban Tool API v3 has no bulk list-users endpoint, so assignment workflows had no way to surface candidate user IDs. This PR exposes the three primitives that fill that gap.

## New tools

- **`whoami() -> User`** — authenticated user's profile via `GET /users/current.json`. Resolves "me" / "myself" in agent prompts to the right `assigned_user_id`.
- **`get_user(user_id) -> User`** — by-id lookup. Useful as follow-up to `list_board_collaborators` when the agent needs role flags or active state before assigning.
- **`list_board_collaborators(board_id) -> list[Collaborator]`** — thin wrapper over `get_board` returning the inline `collaborators` roster. One HTTP call.

## New models

- **`User`** — id, name, initials, role flags, timezone/locale. Heavy nested fields (`account`, `settings`, `customizations`, `groups`) dropped via `extra="ignore"` and can be promoted to typed sub-models when an MCP tool needs them.
- **`Collaborator`** — id, name, initials, active. Inline on `Board.collaborators[]`; canonical user-discovery surface.

`Board.collaborators: list[Collaborator]` added (defaults to `[]` for compact list-style payloads that omit it).

## Surface change

Tool surface 12 → 15. README + CLAUDE.md inventories updated. The new tools all share the discovery / read-only theme; no write tools added.

## Test plan

- [x] `uv run pytest` — 136 → **147** ✓
- [x] Live integration suite — 7 → **10** ✓ against `rynbou` (incl. one bonus test for the additive #87 Task fields)
- [x] `uv run ruff check . && ruff format --check .` clean
- [x] `uv run ty check` clean
- [ ] CI matrix — green

## Coverage details

11 new unit tests in `tests/test_users.py`:
- whoami: happy-path, 401, malformed payload (locks the typed error surface from #85)
- get_user: happy-path, 404, `validate_call` rejection of non-positive id
- list_board_collaborators: typed-list happy-path, defaults-empty when API omits, 404 propagation
- `Board.collaborators` round-trip + default-empty

3 new live tests:
- `whoami` resolves through the 302 alias and returns `User`
- `get_user(whoami().id)` round-trips
- `list_board_collaborators` returns typed entries against the welcome board

🤖 Generated with [Claude Code](https://claude.com/claude-code)