### PR TITLE
fix(release): escape brackets in CHANGELOG-section awk regex

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,11 +52,15 @@ jobs:
         run: |
           version="${GITHUB_REF#refs/tags/v}"
           # Extract the section under ``## [VERSION] - YYYY-MM-DD`` up to the
-          # next ``## [`` heading.
-          awk -v ver="[$version]" '
-            $0 ~ "^## " ver { inside=1; next }
-            $0 ~ "^## \\[" { inside=0 }
-            inside { print }
+          # next ``## [`` heading. The brackets are escaped in awk source so
+          # the regex engine treats them as literals; passing ``[VERSION]``
+          # via a shell variable would be parsed as a character class (the
+          # v0.2.0 release shipped with the buggy form and silently produced
+          # an empty section).
+          awk -v version="$version" '
+            $0 ~ "^## \\[" version "\\]"  { inside=1; next }
+            /^## \[/                       { inside=0 }
+            inside                         { print }
           ' CHANGELOG.md > /tmp/release-section.md
           if [ ! -s /tmp/release-section.md ]; then
             echo "::notice::No CHANGELOG section found for [$version]; skipping issue close."


### PR DESCRIPTION
## Summary

The auto-close-issues step in `release.yml` extracted the version's CHANGELOG section using `awk -v ver="[$version]"`. Concatenated into the regex, `[VERSION]` was parsed as a **character class** matching any char in `{0, 2, ., 0}` — not a literal bracket-enclosed version. The `## [0.2.0] - 2026-05-01` heading starts with `[` which isn't in the class, so the start-of-section regex never matched.

Visible symptom: `::notice::No CHANGELOG section found for [0.2.0]; skipping issue close.` in the v0.2.0 release-workflow log.

## Fix

Pass `version` raw to awk and build the regex inside the awk source with explicitly-escaped brackets:

```awk
$0 ~ "^## \\[" version "\\]"  { inside=1; next }
```

The `\\[` / `\\]` are awk string-level escapes that produce `\[` / `\]` in the runtime regex — literal-bracket matches in ERE.

## Verification

Tested locally against the current CHANGELOG.md:

- `version=0.2.0` extracts the v0.2.0 section (~60 lines).
- `version=0.1.0` extracts the v0.1.0 section (~60 lines).
- Neither bleeds into the other (the literal `2` in `0.2.0` correctly excludes `## [0.1.0]`, and vice versa).

Closes #90

## Test plan

- [x] Manual awk test against current CHANGELOG ✓
- [ ] CI matrix — green
- [ ] Real validation: next release with a `Closes #N` footer in its CHANGELOG section auto-closes on tag push

🤖 Generated with [Claude Code](https://claude.com/claude-code)