### PR TITLE
ci(release-please): switch to workflow_dispatch-only until org policy allows

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,9 +16,19 @@ name: release-please
 #
 # See https://github.com/googleapis/release-please-action and
 # ``RELEASING.md`` for the full flow.
+#
+# Currently set to ``workflow_dispatch`` only: the parent
+# ``VeryLongOrgNameSuchWow`` org enforces ``default_workflow_permissions:
+# read`` and blocks the "Allow GitHub Actions to create and approve pull
+# requests" toggle at the org level (the repo-level toggle in Settings →
+# Actions is greyed out). With those restrictions, release-please cannot
+# create the release PR — every ``push`` fire failed with
+# "GitHub Actions is not permitted to create or approve pull requests."
+# Re-enable the ``push`` trigger once the org policy allows write workflow
+# permissions (Org → Settings → Actions → "Workflow permissions"). Until
+# then, cut releases via ``RELEASING.md``'s manual flow.
 on:
-  push:
-    branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

The parent `VeryLongOrgNameSuchWow` org enforces `default_workflow_permissions: read` AND blocks the "Allow GitHub Actions to create and approve pull requests" toggle at the org level. The repo-level toggle in Settings → Actions appears greyed out; the API confirms `can_approve_pull_request_reviews: false`.

Every `push` fire of `release-please.yml` has been failing with:

```
release-please failed: GitHub Actions is not permitted to create or approve pull requests.
```

This PR switches the trigger to `workflow_dispatch` only — the workflow stays in-tree, ready to flip back to `push` once the org policy allows write workflow permissions.

## To re-enable later

In `Org → Settings → Actions → "Workflow permissions"`:
- Allow `Read and write permissions`
- Allow "Allow GitHub Actions to create and approve pull requests"

Then revert this PR (or change `on:` back to `push: branches: [main]`).

Until then, manual cuts via `RELEASING.md` work — that's how v0.2.0 shipped today (#89).

## Test plan

- [x] YAML well-formed
- [ ] CI matrix on this PR — green
- [ ] No more red `release-please` badges on subsequent main pushes

🤖 Generated with [Claude Code](https://claude.com/claude-code)