### PR TITLE
ci(release-please): re-enable push trigger now that org policy allows

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,17 +17,12 @@ name: release-please
 # See https://github.com/googleapis/release-please-action and
 # ``RELEASING.md`` for the full flow.
 #
-# Currently set to ``workflow_dispatch`` only: the parent
-# ``VeryLongOrgNameSuchWow`` org enforces ``default_workflow_permissions:
-# read`` and blocks the "Allow GitHub Actions to create and approve pull
-# requests" toggle at the org level (the repo-level toggle in Settings →
-# Actions is greyed out). With those restrictions, release-please cannot
-# create the release PR — every ``push`` fire failed with
-# "GitHub Actions is not permitted to create or approve pull requests."
-# Re-enable the ``push`` trigger once the org policy allows write workflow
-# permissions (Org → Settings → Actions → "Workflow permissions"). Until
-# then, cut releases via ``RELEASING.md``'s manual flow.
+# Triggers: ``push: branches: [main]`` is the production flow; the
+# ``workflow_dispatch:`` is kept available for manual reruns when debugging
+# release-please's parsing or when the auto-trigger needs a one-off bypass.
 on:
+  push:
+    branches: [main]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

The org-level "Allow GitHub Actions to create and approve pull requests" toggle is now on (verified: `can_approve_pull_request_reviews: true`). The workflow's explicit `permissions: contents: write, pull-requests: write` block overrides the still-default `default_workflow_permissions: read` and release-please can create PRs again.

Verified by manually dispatching `release-please.yml` on main: it opened PR #93 (v0.2.1 release PR) cleanly in 12s.

This PR restores the production trigger `push: branches: [main]` while keeping `workflow_dispatch:` available for manual reruns when debugging.

## Test plan

- [x] Manual dispatch confirmed release-please now succeeds
- [ ] CI on this PR — green
- [ ] After merge: a release-please push-trigger run fires automatically and either no-ops (if PR #93 still tracks the right state) or refreshes #93's body

🤖 Generated with [Claude Code](https://claude.com/claude-code)