### PR TITLE
ci(release): add workflow_dispatch trigger as manual-publish escape hatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,13 @@ name: Release
 on:
   push:
     tags: ["v*"]
+  # Manual dispatch as the escape hatch when a tag was created via
+  # ``GITHUB_TOKEN`` (e.g. by release-please-action), which by GitHub's
+  # anti-loop rule does NOT fire ``push: tags`` triggers. Dispatch with
+  # ``--ref v0.X.Y`` to build + publish for that tag. Long-term fix is to
+  # give release-please a PAT or GitHub App so its tag pushes count as
+  # user pushes.
+  workflow_dispatch:
 
 jobs:
   release:


### PR DESCRIPTION
## Summary

When release-please-action creates a tag, it pushes via `GITHUB_TOKEN` — and per GitHub's [anti-loop rule](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication), tags pushed by `GITHUB_TOKEN` do NOT fire `push:` triggers in other workflows. This bit us on v0.2.1: release-please-action created the GitHub release and tag at `b596827`, but `release.yml` never fired, so PyPI is still at v0.2.0.

This PR adds `workflow_dispatch:` to `release.yml` so we can manually fire it for any tag:

```bash
gh workflow run release.yml --ref v0.X.Y
```

## Long-term

Filing a follow-up to give release-please-action a PAT or GitHub App token so its tag pushes count as user pushes and trigger `release.yml` naturally — no manual dispatch required.

## Test plan

- [x] YAML well-formed
- [ ] CI matrix on this PR — green
- [ ] After merge: dispatch `release.yml` against `v0.2.1` and confirm PyPI publish + GitHub release assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)