### PR TITLE
chore(server): drop stale create_task envelope-confirmation marker

### DIFF
--- a/src/kanbantool_mcp/server.py
+++ b/src/kanbantool_mcp/server.py
@@ -258,8 +258,10 @@ async def create_task(
     if tags is not None:
         payload["tags"] = tags
 
-    # M3: confirm against a real account that POST /tasks.json expects the
-    # ``{"task": {...}}`` Rails-style envelope (vs. flat top-level fields).
+    # ``tasks/`` endpoints take a Rails-style envelope: ``{"task": {...}}``.
+    # Confirmed via the #62 live-API spike — flat top-level fields are
+    # silently ignored. (Note: this convention does NOT carry over to
+    # subtasks; ``POST /subtasks.json`` is flat per ``add_subtask``.)
     body = {"task": payload}
     data = await _get_client().request("POST", "tasks", json=body)
     return _decode(Task, data, label="task")


### PR DESCRIPTION
## Summary

The `# M3: confirm against a real account that POST /tasks.json expects the {"task": {...}}` Rails-style envelope marker dates from M3 alignment work. The #62 spike (back in M2) confirmed live that `tasks/` POSTs require the Rails envelope; the marker was just stale.

Replace with a concise comment stating the contract and pointing out that the convention does **not** carry over to `subtasks/` (which take a flat body — see `add_subtask` and the live spike during the v0.2.0 work). Useful warning for future maintainers who'd otherwise reach for the same envelope shape.

## Test plan
- [x] `uv run pytest` — 147/147 ✓ (no behavior change)
- [x] `ruff check .` / `ruff format --check .` clean
- [x] `ty check` clean
- [ ] CI matrix — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)