### PR TITLE
feat(server): subtask CRUD completion — update / delete / reorder

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,9 @@ Write tools (M2):
 - `add_comment`
 - `add_subtask`
 - `list_subtasks`
+- `update_subtask`
+- `delete_subtask`
+- `reorder_subtasks`
 
 User discovery tools (post-M3):
 - `whoami` — current user (resolves "me" / "myself")

--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ Add to your MCP client's `mcp.json`:
 | `add_comment` | Post a comment on a task. | `task_id`, `text` |
 | `list_subtasks` | List subtasks attached to a task. | `task_id` |
 | `add_subtask` | Add a subtask to a task. | `task_id`, `title` |
+| `update_subtask` | Partial update of an existing subtask — mark complete, rename, change assignee. `None` kwargs are omitted. | `subtask_id`, `name?`, `is_completed?`, `assigned_user_id?` |
+| `delete_subtask` | Soft-delete a subtask. Returns the deleted subtask with `deleted_at` populated. | `subtask_id` |
+| `reorder_subtasks` | Reorder all subtasks under a task. `ids` must include the full set in the desired order. | `task_id`, `ids: list[int]` |
 | `whoami` | Fetch the authenticated user's profile — id, role flags, locale. Use to resolve "me" / "myself" in user requests. | — |
 | `get_user` | Fetch one user by id. | `user_id` |
 | `list_board_collaborators` | List users with access to a board (the canonical user-discovery surface — the API has no bulk list-users endpoint). | `board_id` |

--- a/examples/04-user-discovery.md
+++ b/examples/04-user-discovery.md
@@ -1,0 +1,142 @@
+# Example 4: User discovery — assignment workflows
+
+Two short flows showing how Claude figures out *who* to assign tasks
+to. The Kanban Tool API v3 has no bulk list-users endpoint, so user
+ids surface through `whoami` (the current authenticated user) and
+`list_board_collaborators` (the roster on a specific board).
+`get_user` follows up with role flags and active state.
+
+> JSON snippets are illustrative — shapes match `User` /
+> `Collaborator` / `Task`, ids and names are made up.
+
+---
+
+## Flow A — "assign this to me"
+
+**User:** Set me as the assignee on task 50240.
+
+**Assistant:** I need my own user id first.
+
+```text
+> whoami()
+```
+
+```json
+{
+  "id": 42,
+  "name": "Reviewer",
+  "initials": "R",
+  "is_account_admin": true,
+  "is_account_owner": false,
+  "is_project_manager": true,
+  "is_suspended": false,
+  "timezone": "Europe/Warsaw",
+  "locale": "en"
+}
+```
+
+```text
+> update_task(task_id=50240, assigned_user_id=42)
+```
+
+```json
+{
+  "id": 50240,
+  "name": "Fix login bug",
+  "board_id": 4711,
+  "lane_id": 90001,
+  "assigned_user_id": 42,
+  "is_archived": false,
+  "updated_at": "2026-05-01T13:42:11Z"
+}
+```
+
+**Assistant:** Done — task `50240` is now assigned to you (id 42).
+
+---
+
+## Flow B — "assign to a teammate by name"
+
+**User:** Assign the auth migration task to Alice.
+
+**Assistant:** I'll list the Engineering board's collaborators to find
+Alice's user id, then update the task.
+
+```text
+> list_board_collaborators(board_id=4711)
+```
+
+```json
+[
+  {"id": 42,  "name": "Reviewer",       "initials": "R",  "active": true},
+  {"id": 88,  "name": "Alice Hansen",   "initials": "AH", "active": true},
+  {"id": 91,  "name": "Bob Chen",       "initials": "BC", "active": true},
+  {"id": 14,  "name": "Carol Stoyanov", "initials": "CS", "active": false}
+]
+```
+
+**Assistant:** Alice is id `88`, active. Let me confirm her role before
+assigning — `get_user` returns the full profile.
+
+```text
+> get_user(user_id=88)
+```
+
+```json
+{
+  "id": 88,
+  "name": "Alice Hansen",
+  "initials": "AH",
+  "is_account_admin": false,
+  "is_account_owner": false,
+  "is_project_manager": true,
+  "is_suspended": false,
+  "timezone": "Europe/Berlin",
+  "locale": "en"
+}
+```
+
+```text
+> search_tasks(query="name:\"auth migration\"", board_id=4711)
+```
+
+```json
+[
+  {"id": 50412, "name": "Auth migration kickoff", "board_id": 4711, "lane_id": 90002}
+]
+```
+
+```text
+> update_task(task_id=50412, assigned_user_id=88)
+```
+
+```json
+{
+  "id": 50412,
+  "name": "Auth migration kickoff",
+  "board_id": 4711,
+  "lane_id": 90002,
+  "assigned_user_id": 88,
+  "updated_at": "2026-05-01T13:43:55Z"
+}
+```
+
+**Assistant:** Done — assigned "Auth migration kickoff" (`50412`) to
+Alice Hansen (`88`). She's an active project manager on the
+Engineering board.
+
+---
+
+## Why this surface exists
+
+- The API has **no bulk list-users endpoint**. Listing all users in
+  the account isn't possible; user ids come through the boards a user
+  has access to.
+- `list_board_collaborators(board_id)` is the canonical lookup. It's
+  sugar over `get_board` (the roster comes inline on the detail
+  payload), so the cost is one HTTP call.
+- `whoami()` short-circuits the "me / myself" reference — no need to
+  search for the authenticated user in the collaborator list.
+- `get_user(id)` is the per-user follow-up when role flags or active
+  state matter (e.g. don't assign to a suspended user; don't auto-
+  promote without checking `is_account_admin`).

--- a/src/kanbantool_mcp/models.py
+++ b/src/kanbantool_mcp/models.py
@@ -276,6 +276,10 @@ class Subtask(BaseModel):
     task_id: int | None = None
     # Single-assignee, mirroring ``Task.assigned_user_id``.
     assigned_user_id: int | None = None
+    # Soft-delete timestamp — populated on the response from
+    # ``DELETE /subtasks/{id}.json`` (the API never hard-deletes, so the
+    # record stays around with this set). ``None`` on every live subtask.
+    deleted_at: str | None = None
 
 
 class ChangelogEntry(BaseModel):

--- a/src/kanbantool_mcp/server.py
+++ b/src/kanbantool_mcp/server.py
@@ -454,10 +454,78 @@ async def add_subtask(task_id: int, title: str) -> Subtask:
     # shape here.
     body = {"name": title, "task_id": task_id}
     data = await _get_client().request("POST", "subtasks", json=body)
-    # Trusting the bare-object response shape (mirrors get_task on main); no
-    # defensive ``{"subtask": {...}}`` unwrap. M3 can revisit if the API ever
-    # surprises us.
     return _decode(Subtask, data, label="subtask")
+
+
+@mcp.tool
+@validate_call
+async def update_subtask(
+    subtask_id: Annotated[int, Field(ge=1)],
+    *,
+    name: str | None = None,
+    is_completed: bool | None = None,
+    assigned_user_id: int | None = None,
+) -> Subtask:
+    """Partial update of an existing subtask. Returns the updated ``Subtask``.
+
+    Only kwargs the caller passes are sent — ``None`` means *omit*, not
+    *clear*. Use this to mark complete (``is_completed=True``), rename
+    (``name="..."``), or change the assignee (``assigned_user_id=42``).
+    The ``position`` field is read-only on this endpoint; use
+    ``reorder_subtasks`` to change ordering."""
+    # Same flat-body convention as ``add_subtask`` — ``PATCH /subtasks/{id}.json``
+    # does NOT take a ``{"subtask": {...}}`` envelope. Confirmed via live spike.
+    payload: dict[str, Any] = {}
+    if name is not None:
+        payload["name"] = name
+    if is_completed is not None:
+        payload["is_completed"] = is_completed
+    if assigned_user_id is not None:
+        payload["assigned_user_id"] = assigned_user_id
+    if not payload:
+        raise ValueError(
+            "update_subtask called with no fields to update; "
+            "pass at least one of name / is_completed / assigned_user_id."
+        )
+    data = await _get_client().request("PATCH", f"subtasks/{subtask_id}", json=payload)
+    return _decode(Subtask, data, label="subtask")
+
+
+@mcp.tool
+@validate_call
+async def delete_subtask(subtask_id: Annotated[int, Field(ge=1)]) -> Subtask:
+    """Delete a subtask (soft-delete). Returns the deleted ``Subtask`` with
+    ``deleted_at`` populated.
+
+    The Kanban Tool API soft-deletes — the subtask record is retained
+    server-side with a ``deleted_at`` timestamp and stops appearing on the
+    parent task's ``subtasks`` array. This operation is not strictly
+    irreversible from an audit perspective, but the MCP-visible effect is
+    "the subtask is gone."""
+    data = await _get_client().request("DELETE", f"subtasks/{subtask_id}")
+    return _decode(Subtask, data, label="subtask")
+
+
+@mcp.tool
+@validate_call
+async def reorder_subtasks(
+    task_id: Annotated[int, Field(ge=1)],
+    ids: list[int],
+) -> list[Subtask]:
+    """Reorder subtasks under a task. Returns the subtasks in the new order.
+
+    ``ids`` must be the full set of subtask ids on ``task_id`` in the
+    desired order. Passing a partial set, or ids belonging to a different
+    task, raises ``KanbanToolValidationError`` from the API."""
+    if not ids:
+        raise ValueError("reorder_subtasks requires at least one subtask id.")
+    # Wire shape: ``PUT /subtasks/reorder.json`` takes ``{"task_id": int,
+    # "ids": "comma,separated,string"}`` — the API expects a literal string
+    # joined with commas, not a JSON array. Tool surface keeps the LLM-friendly
+    # ``list[int]`` and joins on the way out.
+    body = {"task_id": task_id, "ids": ",".join(str(i) for i in ids)}
+    data = await _get_client().request("PUT", "subtasks/reorder", json=body)
+    return _decode_list(Subtask, data, label="subtasks")
 
 
 def run() -> None:

--- a/src/kanbantool_mcp/server.py
+++ b/src/kanbantool_mcp/server.py
@@ -519,6 +519,11 @@ async def reorder_subtasks(
     task, raises ``KanbanToolValidationError`` from the API."""
     if not ids:
         raise ValueError("reorder_subtasks requires at least one subtask id.")
+    if len(set(ids)) != len(ids):
+        # The API would 422 on duplicate ids; refusing client-side mirrors
+        # the empty-list ``ValueError`` and surfaces the intent ("did you
+        # mean to repeat that id?") instead of a typed-validation round-trip.
+        raise ValueError(f"reorder_subtasks ``ids`` must be unique; got duplicates in {ids!r}.")
     # Wire shape: ``PUT /subtasks/reorder.json`` takes ``{"task_id": int,
     # "ids": "comma,separated,string"}`` — the API expects a literal string
     # joined with commas, not a JSON array. Tool surface keeps the LLM-friendly

--- a/tests/test_subtasks.py
+++ b/tests/test_subtasks.py
@@ -444,7 +444,8 @@ async def test_delete_subtask_returns_soft_deleted_subtask(
     _inject_client: KanbanToolClient,
 ) -> None:
     """The API soft-deletes — DELETE returns the modified ``Subtask`` with
-    ``deleted_at`` populated. Lock that contract."""
+    ``deleted_at`` populated. Lock that contract end-to-end through the
+    typed model."""
     response_body = {
         "id": 7,
         "name": "old",
@@ -458,10 +459,16 @@ async def test_delete_subtask_returns_soft_deleted_subtask(
 
     assert isinstance(result, Subtask)
     assert result.id == 7
-    # ``deleted_at`` is present on the wire; the model drops it via
-    # ``extra="ignore"``, so its absence on the typed object is fine. The
-    # important contract is that the call returns a typed Subtask, not raw
-    # pydantic ValidationError, on the soft-delete path.
+    # ``deleted_at`` is the soft-delete signal; the typed model surfaces it
+    # so callers can confirm the operation actually took (vs. a no-op).
+    assert result.deleted_at == "2026-05-01T15:00:00.000+02:00"
+
+
+async def test_subtask_deleted_at_default_is_none() -> None:
+    """A live (non-deleted) ``Subtask`` has ``deleted_at`` defaulting to
+    ``None`` — it's only populated on the soft-delete path."""
+    sub = Subtask.model_validate({"id": 1, "name": "live"})
+    assert sub.deleted_at is None
 
 
 async def test_delete_subtask_url_shape(_inject_client: KanbanToolClient) -> None:
@@ -550,6 +557,15 @@ async def test_reorder_subtasks_empty_list_raises_value_error(
     """Empty ``ids`` is a programmer error; the API would either no-op or 422."""
     with pytest.raises(ValueError, match="at least one"):
         await reorder_subtasks(task_id=TASK_ID, ids=[])
+
+
+async def test_reorder_subtasks_rejects_duplicate_ids(
+    _inject_client: KanbanToolClient,
+) -> None:
+    """Duplicates would 422 server-side; refuse client-side with the same
+    intent-revealing ``ValueError`` style as the empty-list guard."""
+    with pytest.raises(ValueError, match="must be unique"):
+        await reorder_subtasks(task_id=TASK_ID, ids=[1, 1, 2])
 
 
 async def test_reorder_subtasks_rejects_non_positive_task_id(

--- a/tests/test_subtasks.py
+++ b/tests/test_subtasks.py
@@ -1,4 +1,4 @@
-"""Tests for the list_subtasks and add_subtask MCP tools."""
+"""Tests for the list/add/update/delete/reorder subtask MCP tools."""
 
 from __future__ import annotations
 
@@ -15,7 +15,14 @@ from kanbantool_mcp.exceptions import (
     KanbanToolValidationError,
 )
 from kanbantool_mcp.models import Subtask, Task
-from kanbantool_mcp.server import add_subtask, get_task, list_subtasks
+from kanbantool_mcp.server import (
+    add_subtask,
+    delete_subtask,
+    get_task,
+    list_subtasks,
+    reorder_subtasks,
+    update_subtask,
+)
 
 from .conftest import BASE_URL
 
@@ -307,5 +314,276 @@ async def test_add_subtask_malformed_response_raises_http_error(
         with pytest.raises(KanbanToolHTTPError) as exc_info:
             await add_subtask(task_id=TASK_ID, title="x")
 
+    assert exc_info.value.status_code == 200
+    assert "malformed" in exc_info.value.body_excerpt
+
+
+# ---------------------------------------------------------------------------
+# update_subtask
+# ---------------------------------------------------------------------------
+
+
+def _subtask_url(subtask_id: int) -> str:
+    return f"{BASE_URL}subtasks/{subtask_id}.json"
+
+
+_REORDER_URL = f"{BASE_URL}subtasks/reorder.json"
+
+
+async def test_update_subtask_marks_completed(_inject_client: KanbanToolClient) -> None:
+    """Setting ``is_completed=True`` sends the flat-body PATCH and returns
+    the updated typed ``Subtask``."""
+    response_body = {
+        "id": 7,
+        "name": "Set up CI",
+        "task_id": TASK_ID,
+        "is_completed": True,
+        "position": 1,
+    }
+    with respx.mock(assert_all_called=True) as router:
+        route = router.patch(_subtask_url(7)).mock(
+            return_value=httpx.Response(200, json=response_body)
+        )
+        result = await update_subtask(subtask_id=7, is_completed=True)
+
+    assert isinstance(result, Subtask)
+    assert result.id == 7
+    assert result.is_completed is True
+    body = _request_body(route)
+    assert body == {"is_completed": True}
+
+
+async def test_update_subtask_multiple_fields(_inject_client: KanbanToolClient) -> None:
+    """Multiple updates land in one PATCH; ``None`` kwargs are omitted."""
+    response_body = {
+        "id": 7,
+        "name": "Renamed",
+        "task_id": TASK_ID,
+        "is_completed": False,
+        "assigned_user_id": 12,
+    }
+    with respx.mock(assert_all_called=True) as router:
+        route = router.patch(_subtask_url(7)).mock(
+            return_value=httpx.Response(200, json=response_body)
+        )
+        await update_subtask(
+            subtask_id=7,
+            name="Renamed",
+            assigned_user_id=12,
+            # is_completed left None → omitted
+        )
+
+    body = _request_body(route)
+    assert body == {"name": "Renamed", "assigned_user_id": 12}
+    assert "is_completed" not in body
+
+
+async def test_update_subtask_body_has_no_envelope(_inject_client: KanbanToolClient) -> None:
+    """Wire-shape regression guard: ``PATCH /subtasks/{id}.json`` must take a
+    flat body. The ``{"subtask": {...}}`` Rails envelope used by ``tasks/``
+    POSTs would silently fail (per the spike that drove ``add_subtask``)."""
+    with respx.mock(assert_all_called=True) as router:
+        route = router.patch(_subtask_url(7)).mock(
+            return_value=httpx.Response(200, json={"id": 7, "name": "x"})
+        )
+        await update_subtask(subtask_id=7, name="x")
+
+    body = _request_body(route)
+    assert "subtask" not in body
+    assert "name" in body
+
+
+async def test_update_subtask_no_fields_raises_value_error(
+    _inject_client: KanbanToolClient,
+) -> None:
+    """Calling ``update_subtask`` with no kwargs is a programmer error —
+    nothing to send. Refuse before hitting the API."""
+    with pytest.raises(ValueError, match="no fields to update"):
+        await update_subtask(subtask_id=7)
+
+
+async def test_update_subtask_rejects_non_positive_id(
+    _inject_client: KanbanToolClient,
+) -> None:
+    """``validate_call`` enforces ``ge=1`` so a bogus 0/-N never reaches the
+    API as a confusing 404."""
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        await update_subtask(subtask_id=0, name="x")
+
+
+async def test_update_subtask_404_raises_http_error(_inject_client: KanbanToolClient) -> None:
+    with respx.mock() as router:
+        router.patch(_subtask_url(999)).mock(return_value=httpx.Response(404, text="not found"))
+        with pytest.raises(KanbanToolHTTPError) as exc_info:
+            await update_subtask(subtask_id=999, name="x")
+        assert exc_info.value.status_code == 404
+
+
+async def test_update_subtask_malformed_response_raises_http_error(
+    _inject_client: KanbanToolClient,
+) -> None:
+    """A 200 with a payload missing the required ``id`` field surfaces as
+    ``KanbanToolHTTPError(status_code=200)`` with a ``malformed``-tagged
+    excerpt — never a raw ``pydantic.ValidationError``."""
+    with respx.mock() as router:
+        router.patch(_subtask_url(7)).mock(return_value=httpx.Response(200, json={"name": "no-id"}))
+        with pytest.raises(KanbanToolHTTPError) as exc_info:
+            await update_subtask(subtask_id=7, name="x")
+    assert exc_info.value.status_code == 200
+    assert "malformed" in exc_info.value.body_excerpt
+
+
+# ---------------------------------------------------------------------------
+# delete_subtask
+# ---------------------------------------------------------------------------
+
+
+async def test_delete_subtask_returns_soft_deleted_subtask(
+    _inject_client: KanbanToolClient,
+) -> None:
+    """The API soft-deletes — DELETE returns the modified ``Subtask`` with
+    ``deleted_at`` populated. Lock that contract."""
+    response_body = {
+        "id": 7,
+        "name": "old",
+        "task_id": TASK_ID,
+        "is_completed": False,
+        "deleted_at": "2026-05-01T15:00:00.000+02:00",
+    }
+    with respx.mock(assert_all_called=True) as router:
+        router.delete(_subtask_url(7)).mock(return_value=httpx.Response(200, json=response_body))
+        result = await delete_subtask(subtask_id=7)
+
+    assert isinstance(result, Subtask)
+    assert result.id == 7
+    # ``deleted_at`` is present on the wire; the model drops it via
+    # ``extra="ignore"``, so its absence on the typed object is fine. The
+    # important contract is that the call returns a typed Subtask, not raw
+    # pydantic ValidationError, on the soft-delete path.
+
+
+async def test_delete_subtask_url_shape(_inject_client: KanbanToolClient) -> None:
+    """DELETE hits the top-level ``subtasks/{id}.json`` collection."""
+    with respx.mock(assert_all_called=True) as router:
+        route = router.delete(_subtask_url(7)).mock(
+            return_value=httpx.Response(200, json={"id": 7, "name": "x"})
+        )
+        await delete_subtask(subtask_id=7)
+
+    request = route.calls.last.request
+    assert request.method == "DELETE"
+    assert str(request.url) == _subtask_url(7)
+
+
+async def test_delete_subtask_rejects_non_positive_id(
+    _inject_client: KanbanToolClient,
+) -> None:
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        await delete_subtask(subtask_id=0)
+
+
+async def test_delete_subtask_404_raises_http_error(_inject_client: KanbanToolClient) -> None:
+    with respx.mock() as router:
+        router.delete(_subtask_url(999)).mock(return_value=httpx.Response(404, text="not found"))
+        with pytest.raises(KanbanToolHTTPError) as exc_info:
+            await delete_subtask(subtask_id=999)
+        assert exc_info.value.status_code == 404
+
+
+async def test_delete_subtask_malformed_response_raises_http_error(
+    _inject_client: KanbanToolClient,
+) -> None:
+    with respx.mock() as router:
+        router.delete(_subtask_url(7)).mock(
+            return_value=httpx.Response(200, json={"name": "no-id"})
+        )
+        with pytest.raises(KanbanToolHTTPError) as exc_info:
+            await delete_subtask(subtask_id=7)
+    assert exc_info.value.status_code == 200
+    assert "malformed" in exc_info.value.body_excerpt
+
+
+# ---------------------------------------------------------------------------
+# reorder_subtasks
+# ---------------------------------------------------------------------------
+
+
+async def test_reorder_subtasks_happy_path(_inject_client: KanbanToolClient) -> None:
+    """PUT /subtasks/reorder.json takes ``{task_id, ids: "comma,joined"}`` and
+    returns a typed ``list[Subtask]`` in the new order."""
+    response_body = [
+        {"id": 9, "name": "second-now-first", "task_id": TASK_ID, "position": 1},
+        {"id": 7, "name": "first-now-second", "task_id": TASK_ID, "position": 2},
+    ]
+    with respx.mock(assert_all_called=True) as router:
+        route = router.put(_REORDER_URL).mock(return_value=httpx.Response(200, json=response_body))
+        result = await reorder_subtasks(task_id=TASK_ID, ids=[9, 7])
+
+    assert len(result) == 2
+    assert all(isinstance(s, Subtask) for s in result)
+    assert [s.id for s in result] == [9, 7]
+    body = _request_body(route)
+    assert body == {"task_id": TASK_ID, "ids": "9,7"}
+
+
+async def test_reorder_subtasks_joins_ids_as_comma_separated_string(
+    _inject_client: KanbanToolClient,
+) -> None:
+    """API quirk: ``ids`` is a string of comma-separated integer IDs, NOT a
+    JSON array. Lock the conversion."""
+    with respx.mock(assert_all_called=True) as router:
+        route = router.put(_REORDER_URL).mock(return_value=httpx.Response(200, json=[]))
+        await reorder_subtasks(task_id=TASK_ID, ids=[1, 2, 3, 4])
+
+    body = _request_body(route)
+    assert body["ids"] == "1,2,3,4"
+    assert isinstance(body["ids"], str)
+
+
+async def test_reorder_subtasks_empty_list_raises_value_error(
+    _inject_client: KanbanToolClient,
+) -> None:
+    """Empty ``ids`` is a programmer error; the API would either no-op or 422."""
+    with pytest.raises(ValueError, match="at least one"):
+        await reorder_subtasks(task_id=TASK_ID, ids=[])
+
+
+async def test_reorder_subtasks_rejects_non_positive_task_id(
+    _inject_client: KanbanToolClient,
+) -> None:
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        await reorder_subtasks(task_id=0, ids=[1])
+
+
+async def test_reorder_subtasks_422_raises_validation_error(
+    _inject_client: KanbanToolClient,
+) -> None:
+    """API rejects (e.g. partial id list, ids belonging to another task)
+    surface as the typed ``KanbanToolValidationError``."""
+    error_body = {"errors": {"ids": ["are incomplete"]}}
+    with respx.mock() as router:
+        router.put(_REORDER_URL).mock(return_value=httpx.Response(422, json=error_body))
+        with pytest.raises(KanbanToolValidationError) as exc_info:
+            await reorder_subtasks(task_id=TASK_ID, ids=[1])
+
+    assert exc_info.value.status_code == 422
+    assert exc_info.value.field_errors == {"ids": ["are incomplete"]}
+
+
+async def test_reorder_subtasks_malformed_response_raises_http_error(
+    _inject_client: KanbanToolClient,
+) -> None:
+    """A 200 with a list whose entries are missing required ``id`` surfaces
+    as ``KanbanToolHTTPError(status_code=200)`` — never raw pydantic."""
+    with respx.mock() as router:
+        router.put(_REORDER_URL).mock(return_value=httpx.Response(200, json=[{"name": "no-id"}]))
+        with pytest.raises(KanbanToolHTTPError) as exc_info:
+            await reorder_subtasks(task_id=TASK_ID, ids=[1])
     assert exc_info.value.status_code == 200
     assert "malformed" in exc_info.value.body_excerpt


### PR DESCRIPTION
## Summary

Brings the subtask surface to feature-parity with the rest of the MCP. Three endpoints the Kanban Tool API documents but we hadn't exposed; live spike against the rynbou test account locked the wire shapes before coding.

## New tools

- **`update_subtask(subtask_id, *, name=None, is_completed=None, assigned_user_id=None) -> Subtask`** — partial update via `PATCH /subtasks/{id}.json`. `None` kwargs omitted. Refuses with `ValueError` if no fields are passed (no-op API call would be a programmer mistake).
- **`delete_subtask(subtask_id) -> Subtask`** — soft-delete via `DELETE /subtasks/{id}.json`. Returns the modified subtask with `deleted_at` populated.
- **`reorder_subtasks(task_id, ids: list[int]) -> list[Subtask]`** — `PUT /subtasks/reorder.json` with the full set of ids in the desired order. Wire-shape quirk: API takes `ids` as a comma-separated *string*, not a JSON array. Tool keeps the LLM-friendly `list[int]` and joins on the way out.

## Wire-shape consistency

All three follow the same flat-body convention as `add_subtask`. `PATCH` / `DELETE` / `PUT` to the top-level `/subtasks/...` endpoints take their fields at the top level, NOT wrapped in a Rails-style `{"subtask": {...}}` envelope (which silently drops parent linkage on POST per the original `add_subtask` spike — confirmed for the other verbs in this PR's spike).

## Surface change

Tool surface 15 → 18. README + CLAUDE.md inventories updated.

## Tests

+18 unit tests covering happy paths, body-shape regression guards (no envelope, comma-joined ids), 422 / 404 / malformed-payload paths, `validate_call` non-positive-id rejection, and `ValueError` surfaces on programmer-error inputs. Suite goes 147 → 165.

## Test plan
- [x] `uv run pytest` — 165/165 ✓
- [x] `ruff check .` / `ruff format --check .` clean
- [x] `ty check` clean
- [x] Live spike confirmed PATCH / DELETE / PUT wire shapes against rynbou (cleanup ✓)
- [ ] CI matrix on this PR — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)