### PR TITLE
docs: link examples/04 from index + bump README tool count to 18

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Kanban Tool holds the authoritative state of your boards, tasks, and workflow �
 
 ## Status
 
-**Alpha.** The 12-tool surface is settled and exercised against a real Kanban Tool account via the `Live Integration` workflow. Pre-1.0 means the surface may still evolve based on real-world feedback — pin a specific version if you need stability across upgrades.
+**Alpha.** The 18-tool surface is settled and exercised against a real Kanban Tool account via the `Live Integration` workflow. Pre-1.0 means the surface may still evolve based on real-world feedback — pin a specific version if you need stability across upgrades.
 
 ## Install
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -14,3 +14,6 @@ All examples assume an account at `rynbou.kanbantool.com` (i.e. `KANBANTOOL_DOMA
 - [`03-poll-recent-changes.md`](03-poll-recent-changes.md) — polling flow:
   using `recent_changes` to track board activity over time, and a note on why
   there are no webhooks.
+- [`04-user-discovery.md`](04-user-discovery.md) — assignment flow:
+  using `whoami` and `list_board_collaborators` to resolve user ids
+  before calling `update_task`.


### PR DESCRIPTION
## Summary

Two stale-doc fixes spotted while reviewing post-#100 state:

- **`examples/README.md`** was missing a link to `04-user-discovery.md` (the new file that landed in #100).
- **`README.md` Status** said "12-tool surface" — accurate at v0.1.0, but stale after v0.2.0 (+3 user-discovery) and v0.3.0 (+3 subtask CRUD). Now 18.

## Test plan
- [x] Pure docs — no source impact
- [ ] CI matrix — green
- [ ] Visual: examples/README.md renders the 04 link correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)