### PR TITLE
feat(server,models): surface custom_field_1..15 (M4 #103)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,9 @@ User discovery tools (post-M3):
 - `get_user` — fetch one user by id
 - `list_board_collaborators` — board's user roster (no bulk list-users endpoint exists)
 
+M4 — Completeness:
+- `list_custom_field_definitions` — per-board metadata for the 15 `custom_field_*` slots (label, type, enabled state); pair with `Task.custom_fields[custom_field_N]` for values
+
 ## Kanban Tool API quirks
 
 - Per-account base URL: `https://{KANBANTOOL_DOMAIN}.kanbantool.com/api/v3/`. There is no global host.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Kanban Tool holds the authoritative state of your boards, tasks, and workflow �
 
 ## Status
 
-**Alpha.** The 18-tool surface is settled and exercised against a real Kanban Tool account via the `Live Integration` workflow. Pre-1.0 means the surface may still evolve based on real-world feedback — pin a specific version if you need stability across upgrades.
+**Alpha.** The 19-tool surface is settled and exercised against a real Kanban Tool account via the `Live Integration` workflow. Pre-1.0 means the surface may still evolve based on real-world feedback — pin a specific version if you need stability across upgrades.
 
 ## Install
 
@@ -88,6 +88,7 @@ Add to your MCP client's `mcp.json`:
 | `whoami` | Fetch the authenticated user's profile — id, role flags, locale. Use to resolve "me" / "myself" in user requests. | — |
 | `get_user` | Fetch one user by id. | `user_id` |
 | `list_board_collaborators` | List users with access to a board (the canonical user-discovery surface — the API has no bulk list-users endpoint). | `board_id` |
+| `list_custom_field_definitions` | List the per-board metadata for the 15 ``custom_field_*`` slots (label, type, enabled state). Use to interpret the values surfaced on `Task.custom_fields`. | `board_id` |
 
 (`ping` exists as a transport smoke test; not listed above.)
 

--- a/src/kanbantool_mcp/models.py
+++ b/src/kanbantool_mcp/models.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field, computed_field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, computed_field, field_validator, model_validator
 
 
 class Column(BaseModel):
@@ -198,10 +198,20 @@ class Task(BaseModel):
     external_id: str | None = None
     # Caller-supplied URL for cross-system linking.
     external_link: str | None = None
-    # v0.2.0+: ``custom_field_1..15`` (15 numbered fields, dict-shaped wrapper
-    # design call still pending) and ``changelogs``/``time_trackers`` (heavy
-    # nested data — exposed via dedicated tools rather than inlined here)
-    # remain dropped via ``extra="ignore"`` for now. Tracked under #38.
+
+    # --- Custom fields -------------------------------------------------------
+    # The wire payload exposes ``custom_field_1`` .. ``custom_field_15`` as 15
+    # top-level keys. Their per-board *meaning* (label, type, enabled state)
+    # lives in ``Board.card_template[custom_field_N]`` — fetch that via
+    # ``list_custom_field_definitions(board_id)`` to know what each slot
+    # holds. Collapse the 15 keys into one dict-typed surface here so
+    # callers don't have to enumerate them; the ``_collect_custom_fields``
+    # validator does the lift before the rest of the model parses.
+    custom_fields: dict[str, Any] = Field(default_factory=dict)
+
+    # v0.2.0+: ``changelogs`` / ``time_trackers`` (heavy nested data —
+    # exposed via dedicated tools rather than inlined here) remain dropped
+    # via ``extra="ignore"`` for now. Tracked under #38.
 
     # The Kanban Tool API serialises empty collections as JSON ``null`` rather
     # than ``[]`` for several of these additive fields (live spike confirmed
@@ -222,6 +232,28 @@ class Task(BaseModel):
     @classmethod
     def _none_to_empty_list(cls, value: Any) -> Any:
         return [] if value is None else value
+
+    # The wire spreads custom field values across ``custom_field_1`` ..
+    # ``custom_field_15`` top-level keys. Lift them into ``self.custom_fields``
+    # before the rest of the model parses so callers see a single dict instead
+    # of 15 individual attributes. ``extra="ignore"`` then drops the
+    # now-pulled-out raw keys silently.
+    @model_validator(mode="before")
+    @classmethod
+    def _collect_custom_fields(cls, data: Any) -> Any:
+        if not isinstance(data, dict):
+            return data
+        # Only lift if the caller hasn't already supplied a ``custom_fields``
+        # dict directly (e.g. in tests that round-trip ``model_dump`` output).
+        if "custom_fields" in data:
+            return data
+        custom = {k: data[k] for k in data if k.startswith("custom_field_")}
+        if not custom:
+            return data
+        # Build a new dict — don't mutate the caller's input.
+        rest = {k: v for k, v in data.items() if not k.startswith("custom_field_")}
+        rest["custom_fields"] = custom
+        return rest
 
     # ``@computed_field`` is required so pydantic v2 includes the derived
     # boolean in ``model_dump()`` and ``model_json_schema()`` — a bare
@@ -357,3 +389,35 @@ class User(BaseModel):
     # times or messages in the user's local context.
     timezone: str | None = None
     locale: str | None = None
+
+
+class CustomFieldDefinition(BaseModel):
+    """Per-board metadata for one of the ``custom_field_1..15`` slots.
+
+    Sourced from ``Board.card_template[custom_field_N]`` and surfaced via
+    the ``list_custom_field_definitions`` MCP tool. Use this to interpret
+    the raw values on ``Task.custom_fields`` — the slot number alone tells
+    you nothing about what's in it on a given board.
+    """
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    # Slot number (1..15). The value is added by the tool when assembling
+    # the result list — the wire payload doesn't carry it explicitly because
+    # the slot is encoded in the parent dict's key.
+    slot: int
+    # Human-readable label set by the board owner (e.g. "Customer", "ETA").
+    label: str | None = None
+    # Field type — observed values: ``"text"``. Other types likely include
+    # ``"number"``, ``"date"``, ``"dropdown"`` per the Kanban Tool UI; treat
+    # this as a hint string rather than a closed enum.
+    type_: str | None = Field(default=None, alias="type", serialization_alias="type")
+    # ``True`` when the field is shown on this board's UI / available for
+    # writes. ``False`` slots are usually dormant — values may exist on
+    # individual tasks but the LLM should generally skip them.
+    enabled: bool | None = None
+    # Comma-separated values for dropdown-typed fields; empty for free-text.
+    options: str | None = None
+    # UI position on the card detail panel — useful when you want to
+    # surface fields in the order the user sees them.
+    position: int | None = None

--- a/src/kanbantool_mcp/server.py
+++ b/src/kanbantool_mcp/server.py
@@ -11,7 +11,16 @@ from pydantic import BaseModel, Field, ValidationError, validate_call
 from .client import KanbanToolClient
 from .config import Config
 from .exceptions import KanbanToolHTTPError
-from .models import Board, ChangelogEntry, Collaborator, Comment, Subtask, Task, User
+from .models import (
+    Board,
+    ChangelogEntry,
+    Collaborator,
+    Comment,
+    CustomFieldDefinition,
+    Subtask,
+    Task,
+    User,
+)
 
 # Mirrors ``client._BODY_EXCERPT_LIMIT`` so payload-shape errors surface a
 # truncated repr consistent with HTTP-error excerpts. Kept inline (rather than
@@ -126,6 +135,50 @@ async def list_board_collaborators(
     with ``get_user(id)``."""
     board = await get_board(board_id)
     return board.collaborators
+
+
+@mcp.tool
+@validate_call
+async def list_custom_field_definitions(
+    board_id: Annotated[int, Field(ge=1)],
+) -> list[CustomFieldDefinition]:
+    """List the per-board metadata for the 15 custom-field slots.
+
+    Each task has up to 15 ``custom_field_N`` values surfaced as
+    ``Task.custom_fields["custom_field_N"]``. The slot number alone tells
+    you nothing about what's IN it on a given board — call this tool once
+    per board to learn the labels, types, and enabled state, then
+    interpret task values accordingly.
+
+    Returns the 15 definitions in slot order (1..15) regardless of which
+    are ``enabled``. Slots with ``enabled=False`` are usually dormant on
+    that board's UI even if individual tasks happen to carry values."""
+    # Sourced from ``Board.card_template[custom_field_N]`` — same one
+    # HTTP call as ``get_board`` (the metadata is inline on the detail
+    # payload). The tool is sugar that filters to the custom-field slots
+    # and adds the explicit slot number for caller convenience.
+    board = await get_board(board_id)
+    template = board.card_template or {}
+    definitions: list[CustomFieldDefinition] = []
+    for key, defn in template.items():
+        if not key.startswith("custom_field_"):
+            continue
+        if not isinstance(defn, dict):
+            # Defensive against unexpected card_template shapes; skip
+            # silently rather than fail the whole call.
+            continue
+        try:
+            slot = int(key[len("custom_field_") :])
+        except ValueError:
+            continue
+        # The wire entry has ``label``/``type``/``enabled``/``options``/
+        # ``position`` already; we add the ``slot`` since the dict key is
+        # the only place it lived.
+        definitions.append(
+            _decode(CustomFieldDefinition, {**defn, "slot": slot}, label="custom field")
+        )
+    definitions.sort(key=lambda d: d.slot)
+    return definitions
 
 
 @mcp.tool

--- a/tests/integration/test_live_read_tools.py
+++ b/tests/integration/test_live_read_tools.py
@@ -19,13 +19,22 @@ any particular board name or id — see the ``populated_board_id`` fixture.
 from __future__ import annotations
 
 from kanbantool_mcp.client import KanbanToolClient
-from kanbantool_mcp.models import Board, ChangelogEntry, Collaborator, Subtask, Task, User
+from kanbantool_mcp.models import (
+    Board,
+    ChangelogEntry,
+    Collaborator,
+    CustomFieldDefinition,
+    Subtask,
+    Task,
+    User,
+)
 from kanbantool_mcp.server import (
     get_board,
     get_task,
     get_user,
     list_board_collaborators,
     list_boards,
+    list_custom_field_definitions,
     list_subtasks,
     recent_changes,
     search_tasks,
@@ -240,3 +249,43 @@ async def test_list_board_collaborators_against_populated_board(
     assert first.id > 0
     assert first.name is None or isinstance(first.name, str)
     assert first.active is None or isinstance(first.active, bool)
+
+
+async def test_list_custom_field_definitions_against_populated_board(
+    _inject_live_client: KanbanToolClient, populated_board_id: int
+) -> None:
+    """Lock the wire-shape contract for the per-board custom-field metadata
+    surface. Kanban Tool boards always have 15 slots whether they're
+    enabled or not — the trial seed fixture has them all disabled, but the
+    structural assertions below tolerate either state."""
+    definitions = await list_custom_field_definitions(populated_board_id)
+
+    assert isinstance(definitions, list)
+    # All known Kanban Tool plans expose 15 numbered slots, even on the free
+    # trial. If this ever changes upstream, expect this to be a real signal.
+    assert len(definitions) == 15
+    assert all(isinstance(d, CustomFieldDefinition) for d in definitions)
+    assert [d.slot for d in definitions] == list(range(1, 16))
+    first = definitions[0]
+    # Type-only locks for the rest: labels are user-customisable, types vary
+    # per board, etc. ``enabled`` is always Boolean-or-None.
+    assert first.label is None or isinstance(first.label, str)
+    assert first.type_ is None or isinstance(first.type_, str)
+    assert first.enabled is None or isinstance(first.enabled, bool)
+
+
+async def test_get_task_collects_custom_field_values(
+    _inject_live_client: KanbanToolClient, populated_board_id: int
+) -> None:
+    """The Task before-validator pulls ``custom_field_1..15`` into a single
+    ``custom_fields`` dict. Verify the lift happens against a real task —
+    on the welcome board they're all ``None``, but the keys must be there."""
+    search_hits = await search_tasks(query="archived:false", board_id=populated_board_id)
+    assert search_hits, "populated_board_id fixture promised non-archived tasks"
+    task_id = search_hits[0].id
+    task = await get_task(task_id)
+
+    # On any board with all 15 slots emitted (every Kanban Tool board, per
+    # the metadata test above), the dict should have all 15 keys present.
+    assert isinstance(task.custom_fields, dict)
+    assert set(task.custom_fields.keys()) == {f"custom_field_{i}" for i in range(1, 16)}

--- a/tests/test_custom_fields.py
+++ b/tests/test_custom_fields.py
@@ -1,0 +1,259 @@
+"""Tests for the custom-field surface on Task + the
+``list_custom_field_definitions`` discovery tool."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+import respx
+
+from kanbantool_mcp.client import KanbanToolClient
+from kanbantool_mcp.exceptions import KanbanToolHTTPError
+from kanbantool_mcp.models import CustomFieldDefinition, Task
+from kanbantool_mcp.server import list_custom_field_definitions
+
+from .conftest import BASE_URL
+
+BOARD_ID = 4711
+BOARD_URL = f"{BASE_URL}boards/{BOARD_ID}.json"
+
+
+def _board_payload(card_template: dict[str, Any]) -> dict[str, Any]:
+    """Minimal ``GET /boards/{id}.json`` shape with a tunable card_template."""
+    return {
+        "id": BOARD_ID,
+        "name": "Engineering",
+        "card_template": card_template,
+    }
+
+
+def _custom_field_template(
+    slot: int,
+    *,
+    label: str | None = None,
+    type_: str = "text",
+    enabled: bool = False,
+    options: str = "",
+    position: int | None = None,
+) -> dict[str, Any]:
+    """Minimal card_template entry shape — the wire form lives in
+    ``Board.card_template`` and the tool reshapes it into
+    ``CustomFieldDefinition``."""
+    return {
+        "label": label or f"Custom field #{slot}",
+        "type": type_,
+        "enabled": enabled,
+        "options": options,
+        "position": position if position is not None else 12 + slot,
+        "width": "25",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Task.custom_fields collection (model_validator)
+# ---------------------------------------------------------------------------
+
+
+def test_task_collects_numbered_custom_fields_into_dict() -> None:
+    """The wire payload spreads ``custom_field_1..15`` as 15 top-level keys.
+    The before-validator lifts them into ``Task.custom_fields`` so callers
+    don't have to enumerate the slots."""
+    task = Task.model_validate(
+        {
+            "id": 1,
+            "name": "with customs",
+            "custom_field_1": "Acme Corp",
+            "custom_field_2": None,
+            "custom_field_3": 42,
+            "custom_field_15": "2026-05-15",
+        }
+    )
+    assert task.custom_fields == {
+        "custom_field_1": "Acme Corp",
+        "custom_field_2": None,
+        "custom_field_3": 42,
+        "custom_field_15": "2026-05-15",
+    }
+
+
+def test_task_custom_fields_default_empty_dict() -> None:
+    """A task payload with NO ``custom_field_*`` keys (e.g. compact
+    ``search_tasks`` shape) yields an empty dict — never ``None``."""
+    task = Task.model_validate({"id": 2, "name": "compact"})
+    assert task.custom_fields == {}
+
+
+def test_task_custom_fields_round_trip_via_model_dump() -> None:
+    """``model_dump`` round-trip: a Task built from already-collapsed
+    ``custom_fields`` dict shouldn't re-process the lift validator (it
+    short-circuits when ``custom_fields`` is already present)."""
+    task = Task.model_validate(
+        {
+            "id": 1,
+            "name": "round-trip",
+            "custom_fields": {"custom_field_1": "preserved"},
+        }
+    )
+    assert task.custom_fields == {"custom_field_1": "preserved"}
+
+
+def test_task_extra_unknown_fields_still_dropped() -> None:
+    """The ``extra="ignore"`` policy stays in force for non-custom-field
+    keys — only the numbered slots are pulled into the dict."""
+    task = Task.model_validate(
+        {
+            "id": 1,
+            "name": "n",
+            "custom_field_1": "kept",
+            "speculative_future_field": "dropped",
+            "another_unknown": [1, 2, 3],
+        }
+    )
+    assert task.custom_fields == {"custom_field_1": "kept"}
+    dump = task.model_dump()
+    assert "speculative_future_field" not in dump
+    assert "another_unknown" not in dump
+
+
+# ---------------------------------------------------------------------------
+# list_custom_field_definitions
+# ---------------------------------------------------------------------------
+
+
+async def test_list_custom_field_definitions_extracts_slots(
+    _inject_client: KanbanToolClient,
+) -> None:
+    """The tool walks ``Board.card_template`` and emits a
+    ``CustomFieldDefinition`` for each ``custom_field_N`` slot found."""
+    template = {
+        "description": {"enabled": True, "position": 1},  # NOT a custom field
+        "priority": {"enabled": True, "position": 2},  # NOT a custom field
+        "custom_field_1": _custom_field_template(1, label="Customer", enabled=True),
+        "custom_field_2": _custom_field_template(2, label="ETA", type_="date"),
+    }
+    with respx.mock(assert_all_called=True) as router:
+        router.get(BOARD_URL).mock(return_value=httpx.Response(200, json=_board_payload(template)))
+        result = await list_custom_field_definitions(BOARD_ID)
+
+    assert len(result) == 2
+    assert all(isinstance(d, CustomFieldDefinition) for d in result)
+    first, second = result
+    assert first.slot == 1
+    assert first.label == "Customer"
+    assert first.enabled is True
+    assert first.type_ == "text"
+    assert second.slot == 2
+    assert second.label == "ETA"
+    assert second.type_ == "date"
+
+
+async def test_list_custom_field_definitions_returns_in_slot_order(
+    _inject_client: KanbanToolClient,
+) -> None:
+    """Definitions come back sorted by slot regardless of dict iteration
+    order on the wire."""
+    template = {
+        "custom_field_15": _custom_field_template(15),
+        "custom_field_2": _custom_field_template(2),
+        "custom_field_10": _custom_field_template(10),
+    }
+    with respx.mock(assert_all_called=True) as router:
+        router.get(BOARD_URL).mock(return_value=httpx.Response(200, json=_board_payload(template)))
+        result = await list_custom_field_definitions(BOARD_ID)
+
+    assert [d.slot for d in result] == [2, 10, 15]
+
+
+async def test_list_custom_field_definitions_empty_when_no_custom_fields(
+    _inject_client: KanbanToolClient,
+) -> None:
+    """A board whose card_template has no ``custom_field_*`` entries (or
+    is itself absent) yields an empty list rather than failing."""
+    template_no_customs = {
+        "description": {"enabled": True, "position": 1},
+        "priority": {"enabled": True, "position": 2},
+    }
+    with respx.mock(assert_all_called=True) as router:
+        router.get(BOARD_URL).mock(
+            return_value=httpx.Response(200, json=_board_payload(template_no_customs))
+        )
+        result = await list_custom_field_definitions(BOARD_ID)
+
+    assert result == []
+
+
+async def test_list_custom_field_definitions_handles_missing_card_template(
+    _inject_client: KanbanToolClient,
+) -> None:
+    """Compact list-style ``Board`` payloads omit ``card_template``
+    entirely. The tool tolerates that — empty list."""
+    with respx.mock(assert_all_called=True) as router:
+        router.get(BOARD_URL).mock(
+            return_value=httpx.Response(200, json={"id": BOARD_ID, "name": "compact"})
+        )
+        result = await list_custom_field_definitions(BOARD_ID)
+
+    assert result == []
+
+
+async def test_list_custom_field_definitions_skips_non_dict_entries(
+    _inject_client: KanbanToolClient,
+) -> None:
+    """Defensive against an unexpected card_template entry shape — if a
+    custom_field slot is somehow not a dict, skip it silently rather than
+    fail the whole call."""
+    template = {
+        "custom_field_1": _custom_field_template(1, label="ok"),
+        "custom_field_2": "not-a-dict-somehow",
+        "custom_field_3": _custom_field_template(3, label="also-ok"),
+    }
+    with respx.mock(assert_all_called=True) as router:
+        router.get(BOARD_URL).mock(return_value=httpx.Response(200, json=_board_payload(template)))
+        result = await list_custom_field_definitions(BOARD_ID)
+
+    assert [d.slot for d in result] == [1, 3]
+
+
+async def test_list_custom_field_definitions_rejects_non_positive_board_id(
+    _inject_client: KanbanToolClient,
+) -> None:
+    """``validate_call`` enforces ``ge=1`` so we don't waste an API round
+    trip on a clearly-invalid id."""
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        await list_custom_field_definitions(0)
+
+
+async def test_list_custom_field_definitions_404_propagates(
+    _inject_client: KanbanToolClient,
+) -> None:
+    """An unknown board id produces a typed ``KanbanToolHTTPError(404)``
+    via ``get_board``'s existing error path."""
+    with respx.mock() as router:
+        router.get(BOARD_URL).mock(return_value=httpx.Response(404, text="not found"))
+        with pytest.raises(KanbanToolHTTPError) as exc_info:
+            await list_custom_field_definitions(BOARD_ID)
+        assert exc_info.value.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# CustomFieldDefinition model — alias serialisation
+# ---------------------------------------------------------------------------
+
+
+def test_custom_field_definition_type_alias_serialises_as_type() -> None:
+    """``type_`` is a Python attribute (avoiding the builtin shadow); the
+    serialisation alias keeps the wire / MCP-schema name as ``type``."""
+    defn = CustomFieldDefinition.model_validate(
+        {"slot": 1, "label": "Customer", "type": "text", "enabled": True}
+    )
+    assert defn.type_ == "text"
+    # Default model_dump preserves the original Python attribute name.
+    by_attr = defn.model_dump()
+    assert "type_" in by_attr
+    # Aliased dump uses the wire name, matching what the API expects on writes.
+    by_alias = defn.model_dump(by_alias=True)
+    assert "type" in by_alias


### PR DESCRIPTION
## Summary

Closes the design call laid out in #103. The Kanban Tool API exposes each task's 15 numbered custom fields as `custom_field_1` .. `custom_field_15` top-level keys, with per-board metadata on `Board.card_template[custom_field_N]`. We were dropping both via `extra="ignore"`.

Implements **Option C** from #103: a dict on Task plus a separate discovery tool.

## What changed

- **`Task.custom_fields: dict[str, Any]`** — populated via a new `model_validator(mode="before")` that lifts the 15 numbered keys into the dict before the rest of the model parses. Default-empty dict for compact list-style payloads (e.g. `search_tasks` results).
- **`CustomFieldDefinition` model** — typed wrapper around the `card_template` entry: `slot`, `label`, `type` (aliased to `type_` Python attr), `enabled`, `options`, `position`.
- **`list_custom_field_definitions(board_id) -> list[CustomFieldDefinition]`** — sugar over `get_board` (one HTTP call) that filters `card_template` to the custom-field slots, adds the slot number, returns sorted by slot.

## Surface

Tool surface 18 → 19. README + CLAUDE.md inventories updated.

## Live spike confirms

Against the rynbou welcome board:
- 15 numbered slots returned, all `enabled=False` on the trial seed
- `Task.custom_fields` collects all 15 keys (`None` values on the welcome task)
- `CustomFieldDefinition` round-trips `label`, `type`, `enabled`, `options`, `position`

## Tests

- +12 unit tests in `tests/test_custom_fields.py`: model lift behaviour, extra-fields drop, tool extraction, slot ordering, defensive shape guards, `validate_call` rejection of non-positive id, 404 propagation.
- +2 live integration tests: 15-slot count lock + `Task.custom_fields` key set against rynbou.
- Offline 167 → 179. Live 10 → 12.

## Out of scope

- **Write tools** for custom fields (set / unset / typed validation by slot type) — the API write path needs a separate spike. The current tool surface is read-only on custom fields; writes happen via `update_task` at the field level (untested for custom fields). File a separate issue if needed.
- **#104 time tracking** — deferred. Endpoints 404 on the trial plan; needs a paid account or docs-only implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Refs #103.