### PR TITLE
feat(server,models): add time-tracker tools (M4 #104)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,10 @@ User discovery tools (post-M3):
 
 M4 — Completeness:
 - `list_custom_field_definitions` — per-board metadata for the 15 `custom_field_*` slots (label, type, enabled state); pair with `Task.custom_fields[custom_field_N]` for values
+- `start_timer` — start a per-user time tracker on a task (POST `/time_trackers.json` with `board_id`+`task_id`)
+- `stop_timer` — stop a timer (PUT, `ended_at` defaults to "now")
+- `delete_timer` — hard-delete a timer
+- `list_my_timers` — current user's time trackers across all tasks
 
 ## Kanban Tool API quirks
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Kanban Tool holds the authoritative state of your boards, tasks, and workflow �
 
 ## Status
 
-**Alpha.** The 19-tool surface is settled and exercised against a real Kanban Tool account via the `Live Integration` workflow. Pre-1.0 means the surface may still evolve based on real-world feedback — pin a specific version if you need stability across upgrades.
+**Alpha.** The 23-tool surface is settled and exercised against a real Kanban Tool account via the `Live Integration` workflow. Pre-1.0 means the surface may still evolve based on real-world feedback — pin a specific version if you need stability across upgrades.
 
 ## Install
 
@@ -89,6 +89,10 @@ Add to your MCP client's `mcp.json`:
 | `get_user` | Fetch one user by id. | `user_id` |
 | `list_board_collaborators` | List users with access to a board (the canonical user-discovery surface — the API has no bulk list-users endpoint). | `board_id` |
 | `list_custom_field_definitions` | List the per-board metadata for the 15 ``custom_field_*`` slots (label, type, enabled state). Use to interpret the values surfaced on `Task.custom_fields`. | `board_id` |
+| `start_timer` | Start a per-user time tracker on a task. | `task_id`, `board_id` |
+| `stop_timer` | Stop a running time tracker. ``ended_at`` defaults to "now" if omitted. | `timer_id`, `ended_at?` |
+| `delete_timer` | Delete a time tracker (hard-delete). Returns `None`. | `timer_id` |
+| `list_my_timers` | List the authenticated user's time trackers across all tasks. | — |
 
 (`ping` exists as a transport smoke test; not listed above.)
 

--- a/src/kanbantool_mcp/client.py
+++ b/src/kanbantool_mcp/client.py
@@ -152,6 +152,14 @@ class KanbanToolClient:
 
         _raise_for_status(response, method, normalized)
 
+        # DELETE endpoints conventionally return ``204 No Content`` (or 200
+        # with an empty body) — there's nothing to JSON-decode. Returning
+        # ``None`` lets callers like ``delete_timer`` propagate cleanly
+        # without forcing them to bypass this method. Other verbs that
+        # legitimately return empty bodies hit the same path.
+        if response.status_code == 204 or not response.content:
+            return None
+
         try:
             return response.json()
         except json.JSONDecodeError:

--- a/src/kanbantool_mcp/models.py
+++ b/src/kanbantool_mcp/models.py
@@ -130,9 +130,14 @@ class Task(BaseModel):
     # (e.g. ``search_tasks`` results), where the API omits ``subtasks``.
     subtasks: list[Subtask] = Field(default_factory=list)
     comments_count: int | None = None
-    # Flat seconds. The wrapped ``{ "total": ..., "by_user": ... }`` shape is a
-    # separate concern — exposed via a dedicated time-tracker tool later.
+    # Flat seconds — the running total across all users' completed timers
+    # on this task. ``time_trackers`` below is the per-timer detail.
     timers_total: int | None = None
+    # Inline per-user timer entries on the task detail endpoint. Each entry
+    # is one user's timer (running or finished) on this task. ``TimeTracker``
+    # is forward-referenced; the definition lives after ``User`` near the
+    # bottom of the file.
+    time_trackers: list[TimeTracker] = Field(default_factory=list)
     created_at: str | None = None
     updated_at: str | None = None
 
@@ -421,3 +426,56 @@ class CustomFieldDefinition(BaseModel):
     # UI position on the card detail panel — useful when you want to
     # surface fields in the order the user sees them.
     position: int | None = None
+
+
+class TimeTracker(BaseModel):
+    """A single user's elapsed-time record on a task.
+
+    Time tracking in Kanban Tool is per-user, per-task — each ``TimeTracker``
+    is one user's running or finished timer. The aggregate counters on
+    ``Task`` (``timers_total``, ``timers_active_count``, etc.) summarise
+    across users.
+
+    Live-spike-confirmed wire shape: API returns the timer fields plus a
+    nested ``task`` object (priority/name/etc.) that we drop via
+    ``extra="ignore"`` — the timer's own ``task_id`` is sufficient.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    id: int
+    # User the timer belongs to (timers are per-user, per-task).
+    user_id: int | None = None
+    board_id: int | None = None
+    task_id: int | None = None
+    # ISO 8601 timestamps. ``ended_at is None`` means the timer is still
+    # running; the typed ``is_running`` flag below derives this.
+    started_at: str | None = None
+    ended_at: str | None = None
+    # ``True`` for timers exposed in the user's normal timer list (vs.
+    # archived/postponed entries).
+    listed: bool | None = None
+    # Sprint id the timer was started inside; matches ``task_id`` when no
+    # sprint is active.
+    sprint_id: int | None = None
+    # Elapsed seconds since the most recent resume — distinct from the task
+    # aggregate ``timers_total``.
+    seconds_from_resumed_sprint: int | None = None
+    # Per-user ordering on the timer list UI; rarely meaningful to the LLM.
+    position: int | None = None
+    # ISO timestamps for the highlight + enlist UI features.
+    highlighted_at: str | None = None
+    enlist_at: str | None = None
+    # Audit timestamps.
+    created_at: str | None = None
+    updated_at: str | None = None
+
+    # ``@computed_field`` here so pydantic v2 includes the derived flag in
+    # ``model_dump()`` / ``model_json_schema()`` (a bare ``@property`` is
+    # invisible to the serialiser, which means FastMCP wouldn't surface it
+    # to the LLM).
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def is_running(self) -> bool:
+        """True iff the timer is still active (no ``ended_at`` set)."""
+        return self.ended_at is None

--- a/src/kanbantool_mcp/server.py
+++ b/src/kanbantool_mcp/server.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Annotated, Any, Literal, TypeVar
 
 from fastmcp import FastMCP
@@ -19,6 +19,7 @@ from .models import (
     CustomFieldDefinition,
     Subtask,
     Task,
+    TimeTracker,
     User,
 )
 
@@ -584,6 +585,86 @@ async def reorder_subtasks(
     body = {"task_id": task_id, "ids": ",".join(str(i) for i in ids)}
     data = await _get_client().request("PUT", "subtasks/reorder", json=body)
     return _decode_list(Subtask, data, label="subtasks")
+
+
+@mcp.tool
+@validate_call
+async def start_timer(
+    task_id: Annotated[int, Field(ge=1)],
+    board_id: Annotated[int, Field(ge=1)],
+) -> TimeTracker:
+    """Start a new time tracker on a task for the authenticated user.
+
+    Returns the created ``TimeTracker``. Both ``task_id`` AND ``board_id``
+    are required by the API — passing only one returns 404. The new timer
+    starts in the running state (``ended_at`` is ``None``); call
+    ``stop_timer`` when work pauses or ends.
+
+    Note: timers are per-user — starting one creates a record for the
+    authenticated user only. Use ``whoami`` if you need to know whose
+    timer it is."""
+    body = {"board_id": board_id, "task_id": task_id}
+    data = await _get_client().request("POST", "time_trackers", json=body)
+    return _decode(TimeTracker, data, label="time tracker")
+
+
+@mcp.tool
+@validate_call
+async def stop_timer(
+    timer_id: Annotated[int, Field(ge=1)],
+    ended_at: str | None = None,
+) -> TimeTracker:
+    """Stop a running time tracker. Returns the stopped ``TimeTracker``.
+
+    ``ended_at`` is an ISO 8601 timestamp; defaults to the current UTC
+    time if not provided. Stopping an already-stopped timer is harmless —
+    the API just updates the ``ended_at`` to the new value.
+
+    Wire shape: ``PUT /time_trackers/{id}.json`` with a flat
+    ``{"ended_at": ...}`` body. Same flat-body convention as the
+    subtask endpoints — no ``{"time_tracker": {...}}`` envelope."""
+    if ended_at is None:
+        # Default to "now" so the LLM doesn't have to thread datetime
+        # values through every stop call. ISO format with millisecond
+        # precision + Z suffix matches what the API echoes on responses.
+        ended_at = datetime.now(UTC).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+    data = await _get_client().request(
+        "PUT",
+        f"time_trackers/{timer_id}",
+        json={"ended_at": ended_at},
+    )
+    return _decode(TimeTracker, data, label="time tracker")
+
+
+@mcp.tool
+@validate_call
+async def delete_timer(timer_id: Annotated[int, Field(ge=1)]) -> None:
+    """Delete a time tracker entirely (e.g. cancel a mistakenly-started
+    one). Unlike subtasks, timer deletion is hard — the record is gone,
+    not soft-flagged.
+
+    Returns ``None`` because the API responds with an empty body to
+    ``DELETE /time_trackers/{id}.json``. The caller should treat the
+    timer id as invalidated after this call."""
+    # The API returns ``204 No Content`` (or sometimes empty 200) — there
+    # is no body to decode. Just propagate any HTTP error and otherwise
+    # return None.
+    await _get_client().request("DELETE", f"time_trackers/{timer_id}")
+
+
+@mcp.tool
+async def list_my_timers() -> list[TimeTracker]:
+    """List the authenticated user's time trackers across all tasks.
+
+    Returns one ``TimeTracker`` per active or finished timer the current
+    user owns; the wire data lives on the ``time_trackers`` field of the
+    ``/users/current.json`` response (no dedicated list endpoint).
+
+    Use ``Task.time_trackers`` instead when you only want one task's
+    timers across all users."""
+    data = await _get_client().request("GET", "users/current")
+    raw = data.get("time_trackers", []) if isinstance(data, dict) else []
+    return _decode_list(TimeTracker, raw, label="time trackers")
 
 
 def run() -> None:

--- a/tests/integration/test_live_read_tools.py
+++ b/tests/integration/test_live_read_tools.py
@@ -26,6 +26,7 @@ from kanbantool_mcp.models import (
     CustomFieldDefinition,
     Subtask,
     Task,
+    TimeTracker,
     User,
 )
 from kanbantool_mcp.server import (
@@ -35,6 +36,7 @@ from kanbantool_mcp.server import (
     list_board_collaborators,
     list_boards,
     list_custom_field_definitions,
+    list_my_timers,
     list_subtasks,
     recent_changes,
     search_tasks,
@@ -289,3 +291,26 @@ async def test_get_task_collects_custom_field_values(
     # the metadata test above), the dict should have all 15 keys present.
     assert isinstance(task.custom_fields, dict)
     assert set(task.custom_fields.keys()) == {f"custom_field_{i}" for i in range(1, 16)}
+
+
+async def test_list_my_timers_returns_typed_list(
+    _inject_live_client: KanbanToolClient,
+) -> None:
+    """Read-only live coverage for the time-tracker surface. Write tools
+    (start_timer/stop_timer/delete_timer) are unit-tested only — running
+    them in CI would create real timer artifacts on the test account
+    every run. The full create→stop→delete cycle was spike-verified
+    locally during implementation and is covered by the offline unit suite."""
+    timers = await list_my_timers()
+
+    assert isinstance(timers, list)
+    # The user might genuinely have zero timers right now (rynbou's account
+    # is mostly clean), so we don't assert a count. Type-only locks.
+    assert all(isinstance(t, TimeTracker) for t in timers)
+    for t in timers:
+        # Critical fields the model surfaces; the rest are optional.
+        assert t.id > 0
+        assert t.user_id is None or isinstance(t.user_id, int)
+        # ``is_running`` is the computed-field flag; should be Boolean,
+        # never None (derived from ``ended_at``).
+        assert isinstance(t.is_running, bool)

--- a/tests/test_time_trackers.py
+++ b/tests/test_time_trackers.py
@@ -1,0 +1,374 @@
+"""Tests for the time-tracker tools: start_timer, stop_timer, delete_timer,
+list_my_timers."""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+import httpx
+import pytest
+import respx
+
+from kanbantool_mcp.client import KanbanToolClient
+from kanbantool_mcp.exceptions import KanbanToolHTTPError, KanbanToolPermissionError
+from kanbantool_mcp.models import TimeTracker
+from kanbantool_mcp.server import (
+    delete_timer,
+    list_my_timers,
+    start_timer,
+    stop_timer,
+)
+
+from .conftest import BASE_URL
+
+TIMERS_URL = f"{BASE_URL}time_trackers.json"
+USERS_CURRENT_URL = f"{BASE_URL}users/current.json"
+
+
+def _timer_url(timer_id: int) -> str:
+    return f"{BASE_URL}time_trackers/{timer_id}.json"
+
+
+def _request_body(route: respx.Route) -> dict[str, Any]:
+    return json.loads(route.calls.last.request.content)
+
+
+def _timer_payload(
+    *,
+    id: int = 1,
+    user_id: int = 7,
+    board_id: int = 4711,
+    task_id: int = 50000,
+    started_at: str = "2026-05-01T18:00:00.000+02:00",
+    ended_at: str | None = None,
+    extras: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Realistic-shaped TimeTracker wire payload — matches what the live
+    spike returned. The nested ``task`` is included to verify the
+    extra="ignore" drop."""
+    payload: dict[str, Any] = {
+        "id": id,
+        "user_id": user_id,
+        "board_id": board_id,
+        "task_id": task_id,
+        "started_at": started_at,
+        "ended_at": ended_at,
+        "listed": True,
+        "sprint_id": task_id,
+        "seconds_from_resumed_sprint": 0,
+        "position": 1,
+        "highlighted_at": None,
+        "enlist_at": None,
+        "created_at": started_at,
+        "updated_at": started_at,
+        # Nested ``task`` object that the API includes; we drop via extra=ignore
+        "task": {"id": task_id, "name": "parent task", "priority": 0},
+    }
+    if extras:
+        payload.update(extras)
+    return payload
+
+
+# ---------------------------------------------------------------------------
+# TimeTracker model
+# ---------------------------------------------------------------------------
+
+
+def test_time_tracker_model_round_trips() -> None:
+    """Validate a realistic wire payload, drop the nested ``task``, surface
+    the ``is_running`` computed flag."""
+    timer = TimeTracker.model_validate(_timer_payload(id=42, ended_at=None))
+
+    assert timer.id == 42
+    assert timer.is_running is True
+    # ``task`` is silently dropped by ``extra="ignore"``.
+    dump = timer.model_dump()
+    assert "task" not in dump
+
+
+def test_time_tracker_is_running_false_when_ended() -> None:
+    """Stopped timer has ``is_running == False``."""
+    timer = TimeTracker.model_validate(_timer_payload(ended_at="2026-05-01T19:00:00.000+02:00"))
+    assert timer.is_running is False
+
+
+# ---------------------------------------------------------------------------
+# start_timer
+# ---------------------------------------------------------------------------
+
+
+async def test_start_timer_happy_path(_inject_client: KanbanToolClient) -> None:
+    """POST hits ``time_trackers.json`` with a flat body containing both
+    ``board_id`` and ``task_id`` (live spike confirmed both required)."""
+    response = _timer_payload(id=999, board_id=4711, task_id=50000)
+    with respx.mock(assert_all_called=True) as router:
+        route = router.post(TIMERS_URL).mock(return_value=httpx.Response(200, json=response))
+        result = await start_timer(task_id=50000, board_id=4711)
+
+    assert isinstance(result, TimeTracker)
+    assert result.id == 999
+    assert result.task_id == 50000
+    body = _request_body(route)
+    assert body == {"board_id": 4711, "task_id": 50000}
+
+
+async def test_start_timer_body_has_no_envelope(_inject_client: KanbanToolClient) -> None:
+    """Wire shape regression guard: NO ``{"time_tracker": {...}}`` envelope."""
+    with respx.mock(assert_all_called=True) as router:
+        route = router.post(TIMERS_URL).mock(
+            return_value=httpx.Response(200, json=_timer_payload())
+        )
+        await start_timer(task_id=1, board_id=2)
+
+    body = _request_body(route)
+    assert "time_tracker" not in body
+    assert "board_id" in body
+    assert "task_id" in body
+
+
+async def test_start_timer_rejects_non_positive_ids(_inject_client: KanbanToolClient) -> None:
+    """``validate_call`` enforces ``ge=1`` on both args so we never hit the
+    API with bogus ids that would 404 confusingly."""
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        await start_timer(task_id=0, board_id=1)
+    with pytest.raises(ValidationError):
+        await start_timer(task_id=1, board_id=0)
+
+
+async def test_start_timer_404_raises_http_error(_inject_client: KanbanToolClient) -> None:
+    """API returns 404 when ``board_id`` / ``task_id`` mismatch — surface
+    as the typed error."""
+    with respx.mock() as router:
+        router.post(TIMERS_URL).mock(return_value=httpx.Response(404, text="not found"))
+        with pytest.raises(KanbanToolHTTPError) as exc_info:
+            await start_timer(task_id=1, board_id=2)
+        assert exc_info.value.status_code == 404
+
+
+async def test_start_timer_malformed_response_raises_http_error(
+    _inject_client: KanbanToolClient,
+) -> None:
+    with respx.mock() as router:
+        router.post(TIMERS_URL).mock(return_value=httpx.Response(200, json={"name": "no-id"}))
+        with pytest.raises(KanbanToolHTTPError) as exc_info:
+            await start_timer(task_id=1, board_id=2)
+    assert exc_info.value.status_code == 200
+    assert "malformed" in exc_info.value.body_excerpt
+
+
+# ---------------------------------------------------------------------------
+# stop_timer
+# ---------------------------------------------------------------------------
+
+
+async def test_stop_timer_with_explicit_ended_at(_inject_client: KanbanToolClient) -> None:
+    """Caller-supplied ``ended_at`` is forwarded verbatim in the PUT body."""
+    explicit_ts = "2026-05-01T19:30:00.000+02:00"
+    response = _timer_payload(id=42, ended_at=explicit_ts)
+    with respx.mock(assert_all_called=True) as router:
+        route = router.put(_timer_url(42)).mock(return_value=httpx.Response(200, json=response))
+        result = await stop_timer(timer_id=42, ended_at=explicit_ts)
+
+    assert isinstance(result, TimeTracker)
+    assert result.is_running is False
+    body = _request_body(route)
+    assert body == {"ended_at": explicit_ts}
+
+
+async def test_stop_timer_defaults_ended_at_to_now(_inject_client: KanbanToolClient) -> None:
+    """Omitting ``ended_at`` defaults to current UTC ISO timestamp ending in
+    ``Z`` — verifying the format the API echoes back."""
+    with respx.mock(assert_all_called=True) as router:
+        route = router.put(_timer_url(42)).mock(
+            return_value=httpx.Response(200, json=_timer_payload(id=42, ended_at="2026"))
+        )
+        await stop_timer(timer_id=42)
+
+    body = _request_body(route)
+    # ISO 8601 with millisecond precision + Z suffix, e.g.
+    # "2026-05-01T17:32:11.123Z"
+    assert re.match(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$", body["ended_at"])
+
+
+async def test_stop_timer_body_has_no_envelope(_inject_client: KanbanToolClient) -> None:
+    with respx.mock(assert_all_called=True) as router:
+        route = router.put(_timer_url(42)).mock(
+            return_value=httpx.Response(200, json=_timer_payload(id=42))
+        )
+        await stop_timer(timer_id=42, ended_at="2026-05-01T19:00:00.000Z")
+
+    body = _request_body(route)
+    assert "time_tracker" not in body
+
+
+async def test_stop_timer_rejects_non_positive_id(_inject_client: KanbanToolClient) -> None:
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        await stop_timer(timer_id=0)
+
+
+async def test_stop_timer_404_raises_http_error(_inject_client: KanbanToolClient) -> None:
+    with respx.mock() as router:
+        router.put(_timer_url(999)).mock(return_value=httpx.Response(404, text="not found"))
+        with pytest.raises(KanbanToolHTTPError) as exc_info:
+            await stop_timer(timer_id=999, ended_at="2026-05-01T19:00:00Z")
+        assert exc_info.value.status_code == 404
+
+
+async def test_stop_timer_malformed_response_raises_http_error(
+    _inject_client: KanbanToolClient,
+) -> None:
+    with respx.mock() as router:
+        router.put(_timer_url(42)).mock(return_value=httpx.Response(200, json={"name": "no-id"}))
+        with pytest.raises(KanbanToolHTTPError) as exc_info:
+            await stop_timer(timer_id=42, ended_at="2026-05-01T19:00:00Z")
+    assert exc_info.value.status_code == 200
+    assert "malformed" in exc_info.value.body_excerpt
+
+
+# ---------------------------------------------------------------------------
+# delete_timer
+# ---------------------------------------------------------------------------
+
+
+async def test_delete_timer_returns_none_on_empty_response(
+    _inject_client: KanbanToolClient,
+) -> None:
+    """The API returns 204/empty body on DELETE; the tool's typed return is
+    ``None``."""
+    with respx.mock(assert_all_called=True) as router:
+        route = router.delete(_timer_url(42)).mock(return_value=httpx.Response(204))
+        result = await delete_timer(timer_id=42)
+
+    assert result is None
+    request = route.calls.last.request
+    assert request.method == "DELETE"
+    assert str(request.url) == _timer_url(42)
+
+
+async def test_delete_timer_rejects_non_positive_id(_inject_client: KanbanToolClient) -> None:
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        await delete_timer(timer_id=0)
+
+
+async def test_delete_timer_404_raises_http_error(_inject_client: KanbanToolClient) -> None:
+    with respx.mock() as router:
+        router.delete(_timer_url(999)).mock(return_value=httpx.Response(404, text="not found"))
+        with pytest.raises(KanbanToolHTTPError) as exc_info:
+            await delete_timer(timer_id=999)
+        assert exc_info.value.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# list_my_timers
+# ---------------------------------------------------------------------------
+
+
+async def test_list_my_timers_extracts_from_users_current(
+    _inject_client: KanbanToolClient,
+) -> None:
+    """The list comes off ``GET /users/current.json``'s ``time_trackers``
+    array — there's no dedicated list endpoint."""
+    user_payload = {
+        "id": 7,
+        "name": "Test User",
+        "time_trackers": [
+            _timer_payload(id=1, ended_at=None),
+            _timer_payload(id=2, ended_at="2026-05-01T19:00:00.000+02:00"),
+        ],
+    }
+    with respx.mock(assert_all_called=True) as router:
+        router.get(USERS_CURRENT_URL).mock(return_value=httpx.Response(200, json=user_payload))
+        result = await list_my_timers()
+
+    assert len(result) == 2
+    assert all(isinstance(t, TimeTracker) for t in result)
+    assert [t.id for t in result] == [1, 2]
+    assert result[0].is_running is True
+    assert result[1].is_running is False
+
+
+async def test_list_my_timers_empty_when_no_timers(_inject_client: KanbanToolClient) -> None:
+    """A user with no timers (empty array on the wire) returns ``[]``."""
+    with respx.mock(assert_all_called=True) as router:
+        router.get(USERS_CURRENT_URL).mock(
+            return_value=httpx.Response(200, json={"id": 7, "time_trackers": []})
+        )
+        result = await list_my_timers()
+
+    assert result == []
+
+
+async def test_list_my_timers_missing_field(_inject_client: KanbanToolClient) -> None:
+    """If the user payload omits ``time_trackers`` entirely (e.g. on accounts
+    without time tracking), surface as ``[]``."""
+    with respx.mock(assert_all_called=True) as router:
+        router.get(USERS_CURRENT_URL).mock(
+            return_value=httpx.Response(200, json={"id": 7, "name": "no-tracking"})
+        )
+        result = await list_my_timers()
+
+    assert result == []
+
+
+async def test_list_my_timers_401_raises_permission_error(
+    _inject_client: KanbanToolClient,
+) -> None:
+    with respx.mock() as router:
+        router.get(USERS_CURRENT_URL).mock(return_value=httpx.Response(401, text="unauthorized"))
+        with pytest.raises(KanbanToolPermissionError):
+            await list_my_timers()
+
+
+async def test_list_my_timers_malformed_entry_raises_http_error(
+    _inject_client: KanbanToolClient,
+) -> None:
+    """A 200 with a timer entry missing ``id`` surfaces as
+    ``KanbanToolHTTPError(status_code=200)`` — never raw pydantic."""
+    payload = {
+        "id": 7,
+        "time_trackers": [
+            _timer_payload(id=1),
+            {"user_id": 7},  # missing id
+        ],
+    }
+    with respx.mock(assert_all_called=True) as router:
+        router.get(USERS_CURRENT_URL).mock(return_value=httpx.Response(200, json=payload))
+        with pytest.raises(KanbanToolHTTPError) as exc_info:
+            await list_my_timers()
+
+    assert exc_info.value.status_code == 200
+    assert "malformed" in exc_info.value.body_excerpt
+
+
+# ---------------------------------------------------------------------------
+# Task.time_trackers round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_task_time_trackers_round_trips() -> None:
+    """``Task.time_trackers`` validates an inline list of ``TimeTracker``
+    objects; defaults to ``[]`` for compact list-style payloads that omit
+    the field."""
+    from kanbantool_mcp.models import Task
+
+    full = Task.model_validate(
+        {
+            "id": 50000,
+            "name": "parent",
+            "time_trackers": [_timer_payload(id=1, task_id=50000)],
+        }
+    )
+    assert len(full.time_trackers) == 1
+    assert isinstance(full.time_trackers[0], TimeTracker)
+    assert full.time_trackers[0].id == 1
+
+    bare = Task.model_validate({"id": 50001, "name": "compact"})
+    assert bare.time_trackers == []


### PR DESCRIPTION
Closes #104. Live spike confirmed wire shapes; 4 new tools (start/stop/delete/list_my_timers); tool surface 19 → 23; tests 179 → 201 offline + 12 → 13 live. See commit message for full details.