### PR TITLE
feat(server): add set_custom_field tool (M5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,9 @@ M4 — Completeness:
 - `delete_timer` — hard-delete a timer
 - `list_my_timers` — current user's time trackers across all tasks
 
+M5 — Custom-field writes:
+- `set_custom_field` — set or clear one of the 15 `custom_field_N` slots on a task. `value=None` clears (sends literal `null` on the wire — does NOT route through `_patch_task` because that helper has None-skip "omit, don't clear" semantics).
+
 ## Kanban Tool API quirks
 
 - Per-account base URL: `https://{KANBANTOOL_DOMAIN}.kanbantool.com/api/v3/`. There is no global host.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Kanban Tool holds the authoritative state of your boards, tasks, and workflow �
 
 ## Status
 
-**Alpha.** The 23-tool surface is settled and exercised against a real Kanban Tool account via the `Live Integration` workflow. Pre-1.0 means the surface may still evolve based on real-world feedback — pin a specific version if you need stability across upgrades.
+**Alpha.** The 24-tool surface is settled and exercised against a real Kanban Tool account via the `Live Integration` workflow. Pre-1.0 means the surface may still evolve based on real-world feedback — pin a specific version if you need stability across upgrades.
 
 ## Install
 
@@ -89,6 +89,7 @@ Add to your MCP client's `mcp.json`:
 | `get_user` | Fetch one user by id. | `user_id` |
 | `list_board_collaborators` | List users with access to a board (the canonical user-discovery surface — the API has no bulk list-users endpoint). | `board_id` |
 | `list_custom_field_definitions` | List the per-board metadata for the 15 ``custom_field_*`` slots (label, type, enabled state). Use to interpret the values surfaced on `Task.custom_fields`. | `board_id` |
+| `set_custom_field` | Set or clear one of the 15 ``custom_field_N`` slots on a task. ``value=None`` clears (sends literal ``null``). | `task_id`, `slot` (1..15), `value` |
 | `start_timer` | Start a per-user time tracker on a task. | `task_id`, `board_id` |
 | `stop_timer` | Stop a running time tracker. ``ended_at`` defaults to "now" if omitted. | `timer_id`, `ended_at?` |
 | `delete_timer` | Delete a time tracker (hard-delete). Returns `None`. | `timer_id` |

--- a/src/kanbantool_mcp/server.py
+++ b/src/kanbantool_mcp/server.py
@@ -472,6 +472,39 @@ async def archive_task(task_id: int) -> Task:
 
 
 @mcp.tool
+@validate_call
+async def set_custom_field(task_id: int, slot: int, value: Any | None) -> Task:
+    """Set or clear one of the 15 ``custom_field_*`` slots on a task.
+
+    ``slot`` selects which numbered slot to write (1..15 inclusive — the
+    Kanban Tool API exposes exactly 15). Pair with
+    ``list_custom_field_definitions(board_id)`` to learn each slot's label
+    and type on a given board before writing.
+
+    ``value`` is sent verbatim — strings, numbers, and booleans all work.
+    Pass ``value=None`` to **clear** the slot: the wire body explicitly sends
+    ``null`` (not omits the key), and a subsequent ``get_task`` will see
+    ``custom_field_N: null``. This differs from ``update_task`` semantics
+    where ``None`` means *omit*; for custom fields ``None`` means *clear*.
+
+    Type mismatches (e.g. writing ``"hi"`` into a numeric slot) surface as
+    ``KanbanToolValidationError`` (422) from the API, with parsed
+    ``field_errors`` populated."""
+    # NOTE: Deliberately does NOT route through ``_patch_task``. That helper
+    # has None-skip semantics ("omit, don't clear"); here ``None`` MUST land
+    # on the wire as a literal ``null`` to clear the field. Build the body
+    # inline.
+    if not 1 <= slot <= 15:
+        # ``validate_call`` accepts any int — explicit range guard mirrors
+        # the API surface (15 fixed slots) and avoids round-tripping a
+        # clearly-bogus slot number for a 422.
+        raise ValueError(f"slot must be between 1 and 15 inclusive; got {slot}.")
+    body = {"task": {f"custom_field_{slot}": value}}
+    data = await _get_client().request("PUT", f"tasks/{task_id}", json=body)
+    return _decode(Task, data, label="task")
+
+
+@mcp.tool
 async def add_comment(task_id: int, text: str) -> Comment:
     """Post a comment on a task. Returns the created ``Comment`` with id,
     text, author, and timestamps. Empty ``text`` typically raises

--- a/tests/test_set_custom_field.py
+++ b/tests/test_set_custom_field.py
@@ -1,0 +1,144 @@
+"""Tests for the ``set_custom_field`` MCP tool.
+
+This tool is the *write* counterpart to ``list_custom_field_definitions`` —
+it targets one of the 15 ``custom_field_N`` slots on a task and either sets
+its value or clears it. Two behaviours warrant the dedicated tool (rather
+than routing through ``update_task``):
+
+- ``None`` means **clear** here, not **omit**: the request must put a literal
+  ``null`` on the wire so the API drops the stored value. ``update_task``'s
+  shared ``_patch_task`` helper has None-skip semantics, so this tool builds
+  its body inline.
+- Slot range is hard-bounded to ``1..15`` client-side; ``validate_call``
+  accepts any int otherwise.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+import respx
+
+from kanbantool_mcp.client import KanbanToolClient
+from kanbantool_mcp.exceptions import KanbanToolValidationError
+from kanbantool_mcp.server import set_custom_field
+
+from .conftest import BASE_URL
+
+TASK_ID = 42
+TASK_URL = f"{BASE_URL}tasks/{TASK_ID}.json"
+
+
+def _request_body(route: respx.Route) -> dict[str, object]:
+    return json.loads(route.calls.last.request.content)
+
+
+async def test_set_custom_field_writes_string_value(_inject_client: KanbanToolClient) -> None:
+    """A simple string write lands as ``{"task": {"custom_field_3": "hello"}}``
+    on the wire, hits PUT ``/tasks/{id}.json``, and round-trips into a
+    ``Task`` carrying the same value on ``custom_fields``."""
+    response_payload = {
+        "id": TASK_ID,
+        "name": "with custom",
+        "board_id": 7,
+        "custom_field_3": "hello",
+    }
+    with respx.mock(assert_all_called=True) as router:
+        route = router.put(TASK_URL).mock(return_value=httpx.Response(200, json=response_payload))
+        task = await set_custom_field(task_id=TASK_ID, slot=3, value="hello")
+
+    request = route.calls.last.request
+    assert request.method == "PUT"
+    assert str(request.url) == TASK_URL
+    assert _request_body(route) == {"task": {"custom_field_3": "hello"}}
+
+    assert task.id == TASK_ID
+    assert task.custom_fields == {"custom_field_3": "hello"}
+
+
+async def test_set_custom_field_none_clears_via_explicit_null(
+    _inject_client: KanbanToolClient,
+) -> None:
+    """``value=None`` MUST land as a literal JSON ``null`` on the wire (the API
+    treats null as "clear"). It must NOT be silently omitted — that's the
+    ``update_task`` semantic and the bug this dedicated tool exists to avoid."""
+    response_payload = {
+        "id": TASK_ID,
+        "name": "cleared",
+        "board_id": 7,
+        "custom_field_1": None,
+    }
+    with respx.mock(assert_all_called=True) as router:
+        route = router.put(TASK_URL).mock(return_value=httpx.Response(200, json=response_payload))
+        task = await set_custom_field(task_id=TASK_ID, slot=1, value=None)
+
+    body = _request_body(route)
+    assert body == {"task": {"custom_field_1": None}}
+
+    # The raw request bytes must contain literal ``null`` — defensive against
+    # any future serializer change that decides ``None`` should drop the key.
+    raw = route.calls.last.request.content.decode()
+    assert "null" in raw
+    assert "custom_field_1" in raw
+
+    # The response shows the cleared value carried back through
+    # ``Task.custom_fields``.
+    assert task.custom_fields == {"custom_field_1": None}
+
+
+@pytest.mark.parametrize("bad_slot", [0, -1, 16, 100])
+async def test_set_custom_field_rejects_out_of_range_slot(
+    monkeypatch: pytest.MonkeyPatch,
+    _inject_client: KanbanToolClient,
+    bad_slot: int,
+) -> None:
+    """Slots outside 1..15 must raise ``ValueError`` *before* any HTTP call —
+    the API has exactly 15 fixed slots, and round-tripping a bogus number
+    just to get a 422 wastes quota."""
+    sentinel = AsyncMock(
+        side_effect=AssertionError("set_custom_field issued an HTTP call for an out-of-range slot")
+    )
+    monkeypatch.setattr(_inject_client, "request", sentinel)
+
+    with pytest.raises(ValueError) as exc_info:
+        await set_custom_field(task_id=TASK_ID, slot=bad_slot, value="anything")
+    assert "1 and 15" in str(exc_info.value)
+    sentinel.assert_not_awaited()
+
+
+async def test_set_custom_field_422_raises_validation_error(
+    _inject_client: KanbanToolClient,
+) -> None:
+    """A 422 from the API (e.g. wrong type for the slot — writing a string
+    into a numeric field) propagates as the typed ``KanbanToolValidationError``
+    subclass with parsed ``field_errors``."""
+    error_body = {"errors": {"custom_field_2": ["is not a number"]}}
+    with respx.mock() as router:
+        router.put(TASK_URL).mock(return_value=httpx.Response(422, json=error_body))
+        with pytest.raises(KanbanToolValidationError) as exc_info:
+            await set_custom_field(task_id=TASK_ID, slot=2, value="not-a-number")
+
+    err = exc_info.value
+    assert err.status_code == 422
+    assert err.field_errors == {"custom_field_2": ["is not a number"]}
+
+
+async def test_set_custom_field_accepts_non_string_values(
+    _inject_client: KanbanToolClient,
+) -> None:
+    """The signature is ``Any | None``; ints, floats, and bools must all be
+    forwarded verbatim into the wire body without coercion."""
+    response_payload = {
+        "id": TASK_ID,
+        "name": "n",
+        "board_id": 7,
+        "custom_field_5": 42,
+    }
+    with respx.mock(assert_all_called=True) as router:
+        route = router.put(TASK_URL).mock(return_value=httpx.Response(200, json=response_payload))
+        await set_custom_field(task_id=TASK_ID, slot=5, value=42)
+
+    assert _request_body(route) == {"task": {"custom_field_5": 42}}


### PR DESCRIPTION
## Summary

- Adds `set_custom_field(task_id, slot, value) -> Task` — the first M5 tool, completing the round trip on the 15 `custom_field_N` slots that landed read-only in M4.
- `value=None` clears the slot: the wire body sends a literal `null` (not an omitted key), and a subsequent `get_task` sees `custom_field_N: null`.
- Deliberately does **not** route through `_patch_task`. That helper has None-skip "omit, don't clear" semantics, which is the wrong contract for custom-field writes. Body is built inline (`{"task": {"custom_field_N": value}}`).
- `slot` is hard-bounded to 1..15 client-side; `validate_call` accepts any int otherwise.

## Wire shape (live-spike confirmed)

- `PUT /tasks/{id}.json` body `{"task": {"custom_field_N": value}}` -> 200, value persists.
- `PUT /tasks/{id}.json` body `{"task": {"custom_field_N": null}}` -> 200, field cleared.
- Type mismatches surface as `KanbanToolValidationError` (422) automatically via `client.request`.

## Test plan

- [x] `set_custom_field(task_id=42, slot=3, value="hello")` -> request body equals `{"task": {"custom_field_3": "hello"}}` and returns parsed `Task`.
- [x] `set_custom_field(task_id=42, slot=1, value=None)` -> request body is `{"task": {"custom_field_1": null}}` (literal `null` on the wire, raw bytes asserted).
- [x] `slot=0`, `slot=-1`, `slot=16`, `slot=100` all raise `ValueError` before any HTTP call (verified the underlying `client.request` is never awaited).
- [x] 422 from server propagates as `KanbanToolValidationError` with `field_errors` populated.
- [x] Non-string values (ints) are forwarded verbatim.
- [x] `uv run ruff check .` / `uv run ruff format --check .` / `uv run ty check` / `uv run pytest` (209 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)