### PR TITLE
ci(release-please): mint App token instead of GITHUB_TOKEN (#98)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -33,7 +33,20 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      # Mint an installation token from the kanbantool-mcp-release-please
+      # GitHub App (App ID + private key in repo secrets) instead of falling
+      # through to the workflow's default GITHUB_TOKEN. Tags and PRs created
+      # via GITHUB_TOKEN do not fire downstream workflows — that's GitHub's
+      # anti-loop rule — which would mean release-please's tag push silently
+      # skips ``release.yml`` (PyPI publish + GitHub Release). An App token
+      # has no such restriction, so the cut becomes fully hands-off again.
+      - uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349  # v2.2.2
+        id: app-token
+        with:
+          app-id: ${{ secrets.RELEASE_PLEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7  # v5.0.0
         with:
+          token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
## Summary
- Adds `actions/create-github-app-token@v2.2.2` step to release-please.yml that mints an installation token from the new `kanbantool-mcp-release-please` GitHub App.
- Wires that token into `release-please-action` via the `token:` input so all PRs, tags, and commits release-please creates are authenticated as the App.
- Closes #98 (release-please tag push not firing release.yml).

## Why
GitHub's anti-loop rule blocks tags/PRs created via `GITHUB_TOKEN` from triggering downstream workflows. With release-please using `GITHUB_TOKEN`, its `v*` tag pushes never fire `release.yml`, so the PyPI publish has to be `workflow_dispatch`-ed by hand for every cut. App-minted tokens are not subject to that rule.

## Repo secrets (already configured)
- `RELEASE_PLEASE_APP_ID` — the App's numeric id (3570474)
- `RELEASE_PLEASE_APP_PRIVATE_KEY` — the App's private key in PEM form

## Test plan
- [ ] Merge this PR.
- [ ] Confirm release-please opens its next release PR via the App identity (commit author `kanbantool-mcp-release-please[bot]`, not `github-actions[bot]`).
- [ ] Merge that release PR. Confirm:
  - [ ] The `v*` tag is pushed.
  - [ ] `release.yml` fires automatically (no manual workflow_dispatch).
  - [ ] PyPI publish succeeds.
  - [ ] GitHub Release is created with the changelog body.
- [ ] If the dry-run is clean, follow up by removing the now-unnecessary `workflow_dispatch:` fallback in release.yml.

🤖 Generated with [Claude Code](https://claude.com/claude-code)