### PR TITLE
chore: gitignore .claude/ and exclude it from ty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,10 @@ venv/
 .idea/
 .DS_Store
 
+# Claude Code session-local artifacts (agent worktrees, transcripts, etc.).
+# Cleaning up after a crashed agent shouldn't be a git operation.
+.claude/
+
 # secrets
 # Defense-in-depth: never commit credentials. Project rule is to keep
 # secrets out of the tree entirely; these patterns just stop the obvious

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,13 @@ select = ["E", "F", "I", "B", "UP", "SIM"]
 [tool.ruff.format]
 quote-style = "double"
 
+[tool.ty.src]
+# ``.claude/worktrees/`` holds in-flight Claude Code agent checkouts of this
+# same repo. Without this exclude, ty traverses those copies and reports
+# duplicate-symbol / cross-tree import errors that have nothing to do with
+# the working tree. The directory is gitignored and session-local.
+exclude = [".claude"]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 # Live integration tests hit a real Kanban Tool account — exclude from the


### PR DESCRIPTION
## Summary
- Adds \`.claude/\` to \`.gitignore\` (Claude Code agent worktrees and session-local artifacts).
- Adds \`[tool.ty.src] exclude = [\".claude\"]\` to \`pyproject.toml\` so \`ty check\` doesn't traverse stale agent worktrees and emit duplicate-symbol / cross-tree import errors.

## Why
Caught while reviewing PR #111: \`uv run ty check\` reported 23 errors entirely from stale \`.claude/worktrees/agent-*/tests/\` files left over from prior agent runs. \`git status\` also reports \`.claude/\` as untracked on every commit, which trips \`gh pr create\` warnings.

Both changes are local hygiene — no behavior change to the package itself.

## Test plan
- [x] \`uv run ty check\` — was reporting 23 errors, now \"All checks passed!\"
- [x] \`uv run ruff check .\` and \`ruff format --check .\`
- [x] \`uv run pytest\` — 209 passed
- [x] \`git status\` no longer lists \`.claude/\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)