### PR TITLE
chore(server,tests): address PR #108 review nits

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,10 @@ M5 — Custom-field writes & comment polish:
 - **M0** — Scaffold: package layout, CI, license, docs. *Complete.*
 - **M1** — Read tools: list_boards, get_board, search_tasks, get_task, recent_changes. *Complete.*
 - **M2** — Write tools: create_task, update_task, move_task, archive_task, add_comment, add_subtask, list_subtasks. *Complete.*
-- **M3** — Polish & release: error messages, retries, docs pass, PyPI publish. *In progress.*
+- **M3** — Polish & release: error messages, retries, docs pass, PyPI publish. *Complete.*
+- **M4** — Completeness: custom-field reads + time-tracker tools. *Complete.*
+- **M5** — Custom-field writes + comment polish: `set_custom_field`, `delete_comment` (the API has no comment-edit endpoint), and the `add_comment` wire-field bugfix (`text` → `content`). *Complete.*
+- **M6** — v1.0 readiness: SemVer commitment policy, README pass, error-message audit, RELEASING.md updates. *In progress.*
 
 ## Codebase conventions
 

--- a/src/kanbantool_mcp/server.py
+++ b/src/kanbantool_mcp/server.py
@@ -473,7 +473,11 @@ async def archive_task(task_id: int) -> Task:
 
 @mcp.tool
 @validate_call
-async def set_custom_field(task_id: int, slot: int, value: Any | None) -> Task:
+async def set_custom_field(
+    task_id: Annotated[int, Field(ge=1)],
+    slot: Annotated[int, Field(ge=1, le=15)],
+    value: str | int | float | bool | None,
+) -> Task:
     """Set or clear one of the 15 ``custom_field_*`` slots on a task.
 
     ``slot`` selects which numbered slot to write (1..15 inclusive — the
@@ -494,11 +498,6 @@ async def set_custom_field(task_id: int, slot: int, value: Any | None) -> Task:
     # has None-skip semantics ("omit, don't clear"); here ``None`` MUST land
     # on the wire as a literal ``null`` to clear the field. Build the body
     # inline.
-    if not 1 <= slot <= 15:
-        # ``validate_call`` accepts any int — explicit range guard mirrors
-        # the API surface (15 fixed slots) and avoids round-tripping a
-        # clearly-bogus slot number for a 422.
-        raise ValueError(f"slot must be between 1 and 15 inclusive; got {slot}.")
     body = {"task": {f"custom_field_{slot}": value}}
     data = await _get_client().request("PUT", f"tasks/{task_id}", json=body)
     return _decode(Task, data, label="task")

--- a/tests/test_set_custom_field.py
+++ b/tests/test_set_custom_field.py
@@ -158,8 +158,10 @@ async def test_set_custom_field_422_raises_validation_error(
 async def test_set_custom_field_accepts_non_string_values(
     _inject_client: KanbanToolClient,
 ) -> None:
-    """The signature is ``Any | None``; ints, floats, and bools must all be
-    forwarded verbatim into the wire body without coercion."""
+    """The signature accepts ``str | int | float | bool | None``; ints, floats,
+    and bools must all be forwarded verbatim into the wire body without
+    coercion. (Sister test ``test_set_custom_field_rejects_unsupported_value_type``
+    proves the union's *exclusion* side.)"""
     response_payload = {
         "id": TASK_ID,
         "name": "n",

--- a/tests/test_set_custom_field.py
+++ b/tests/test_set_custom_field.py
@@ -16,6 +16,7 @@ than routing through ``update_task``):
 from __future__ import annotations
 
 import json
+from typing import Any
 from unittest.mock import AsyncMock
 
 import httpx
@@ -78,11 +79,15 @@ async def test_set_custom_field_none_clears_via_explicit_null(
     body = _request_body(route)
     assert body == {"task": {"custom_field_1": None}}
 
-    # The raw request bytes must contain literal ``null`` — defensive against
-    # any future serializer change that decides ``None`` should drop the key.
+    # The raw request bytes must contain literal ``"custom_field_1":null`` —
+    # defensive against any future serializer change that decides ``None``
+    # should drop the key. Substring is tighter than ``"null" in raw`` (which
+    # would silently match a payload like ``{"...": "nullable"}``). Note no
+    # space between the colon and ``null``: httpx's default JSON encoder uses
+    # the compact (separators=(",", ":")) form. If a future tweak switches to
+    # indented JSON this assertion will need ``": null"``.
     raw = route.calls.last.request.content.decode()
-    assert "null" in raw
-    assert "custom_field_1" in raw
+    assert '"custom_field_1":null' in raw
 
     # The response shows the cleared value carried back through
     # ``Task.custom_fields``.
@@ -95,9 +100,10 @@ async def test_set_custom_field_rejects_out_of_range_slot(
     _inject_client: KanbanToolClient,
     bad_slot: int,
 ) -> None:
-    """Slots outside 1..15 must raise ``ValueError`` *before* any HTTP call —
-    the API has exactly 15 fixed slots, and round-tripping a bogus number
-    just to get a 422 wastes quota."""
+    """Slots outside 1..15 must reject *before* any HTTP call — the API has
+    exactly 15 fixed slots, and round-tripping a bogus number just to get a
+    422 wastes quota. ``validate_call`` enforces ``Field(ge=1, le=15)`` so the
+    raised error is a ``pydantic.ValidationError`` (a ``ValueError`` subclass)."""
     sentinel = AsyncMock(
         side_effect=AssertionError("set_custom_field issued an HTTP call for an out-of-range slot")
     )
@@ -105,7 +111,30 @@ async def test_set_custom_field_rejects_out_of_range_slot(
 
     with pytest.raises(ValueError) as exc_info:
         await set_custom_field(task_id=TASK_ID, slot=bad_slot, value="anything")
-    assert "1 and 15" in str(exc_info.value)
+    assert "slot" in str(exc_info.value)
+    sentinel.assert_not_awaited()
+
+
+@pytest.mark.parametrize("bad_value", [{"key": "v"}, ["a", "b"], object()])
+async def test_set_custom_field_rejects_unsupported_value_type(
+    monkeypatch: pytest.MonkeyPatch,
+    _inject_client: KanbanToolClient,
+    bad_value: Any,
+) -> None:
+    """The narrowed ``value`` type (``str | int | float | bool | None``)
+    rejects dicts, lists, and arbitrary objects at the ``validate_call``
+    boundary — keeping the typed-error contract instead of letting an
+    untyped ``TypeError`` escape from ``json.dumps`` deep inside httpx.
+
+    ``bad_value`` is typed ``Any`` so the type checker does not flag the
+    intentionally-mistyped call below; the runtime is what we are exercising."""
+    sentinel = AsyncMock(
+        side_effect=AssertionError("set_custom_field accepted an unsupported value type")
+    )
+    monkeypatch.setattr(_inject_client, "request", sentinel)
+
+    with pytest.raises(ValueError):
+        await set_custom_field(task_id=TASK_ID, slot=1, value=bad_value)
     sentinel.assert_not_awaited()
 
 


### PR DESCRIPTION
## Summary
Picks up the non-blocker findings deferred from the PR #108 (set_custom_field) review:

- \`set_custom_field\`: \`task_id\` and \`slot\` gain \`Annotated[int, Field(ge=...)]\` for parity with the rest of the M3+ surface. The inline ValueError slot guard becomes dead code under \`validate_call\` and is dropped.
- \`set_custom_field\`: \`value: Any | None\` narrowed to \`str | int | float | bool | None\`. Keeps the typed-error surface — unsupported inputs raise \`pydantic.ValidationError\` instead of a raw \`TypeError\` from \`json.dumps\`.
- Tests: tighten the \`value=None\` raw-bytes check from \`'null' in raw\` (matches e.g. \`'nullable'\`) to \`'\"custom_field_1\":null' in raw\`. Adds an \`unsupported_value_type\` parametrize that proves dicts/lists/objects are rejected before any HTTP call.
- CLAUDE.md: Phases section refreshed — M3/M4/M5 complete, M6 (v1.0 readiness) in progress.

## Why
Code-quality and security reviewers on #108 both flagged these as in-scope-but-cheap. They didn't block the original merge, but the M5 sweep is the natural place to land them.

## Test plan
- [x] \`uv run ruff check .\`
- [x] \`uv run ruff format --check .\`
- [x] \`uv run ty check src tests\`
- [x] \`uv run pytest\` — 219 passed (was 216 → +3 from new \`unsupported_value_type\` parametrize)

🤖 Generated with [Claude Code](https://claude.com/claude-code)