### PR TITLE
refactor(server): align tool parameter names with wire shapes (M7)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,7 @@ M5 — Custom-field writes & comment polish:
 - **M4** — Completeness: custom-field reads + time-tracker tools. *Complete.*
 - **M5** — Custom-field writes + comment polish: `set_custom_field`, `delete_comment` (the API has no comment-edit endpoint), and the `add_comment` wire-field bugfix (`text` → `content`). *Complete.*
 - **M6** — v1.0 readiness: SemVer commitment policy, README pass, error-message audit, RELEASING.md updates. *In progress.*
+- **M7** — Pre-1.0 naming sweep: align Python parameter names with wire shapes / sibling tools before v1.0 locks them in. `add_comment(text=...)` → `add_comment(content=...)` (matches the wire field that the M5 bugfix had to send anyway). `add_subtask(title=...)` → `add_subtask(name=...)` (matches `Subtask.name` and `update_subtask(name=...)`). Wire bodies unchanged; this is purely a Python parameter rename. *Complete.*
 
 ## Codebase conventions
 

--- a/README.md
+++ b/README.md
@@ -79,10 +79,10 @@ Add to your MCP client's `mcp.json`:
 | `update_task` | Partial update of an existing task; only kwargs the caller passes are sent. `None` means *omit*, not *clear*. | `task_id`, `name?`, `description?`, `priority?`, ... |
 | `move_task` | Move a task between columns, swimlanes, or positions. At least one target must be set. | `task_id`, `column_id?`, `swimlane_id?`, `position?` |
 | `archive_task` | Archive a task. Idempotent. | `task_id` |
-| `add_comment` | Post a comment on a task. | `task_id`, `text` |
+| `add_comment` | Post a comment on a task. | `task_id`, `content` |
 | `delete_comment` | Soft-delete a comment on a task. Returns the deleted comment with `deleted_at` populated. The API has no edit endpoint — delete and re-post if you need to change a comment. | `task_id`, `comment_id` |
 | `list_subtasks` | List subtasks attached to a task. | `task_id` |
-| `add_subtask` | Add a subtask to a task. | `task_id`, `title` |
+| `add_subtask` | Add a subtask to a task. | `task_id`, `name` |
 | `update_subtask` | Partial update of an existing subtask — mark complete, rename, change assignee. `None` kwargs are omitted. | `subtask_id`, `name?`, `is_completed?`, `assigned_user_id?` |
 | `delete_subtask` | Soft-delete a subtask. Returns the deleted subtask with `deleted_at` populated. | `subtask_id` |
 | `reorder_subtasks` | Reorder all subtasks under a task. `ids` must include the full set in the desired order. | `task_id`, `ids: list[int]` |
@@ -128,7 +128,7 @@ Assistant: (calls list_boards)             -> resolves "Engineering" -> id 4217
               priority="high")             -> task id 88231 created
            (calls add_comment
               task_id=88231,
-              text="Picking this up today.")
+              content="Picking this up today.")
 
            Created "Fix login bug" (id 88231) in Engineering at high priority,
            and added your comment.

--- a/examples/02-create-and-comment.md
+++ b/examples/02-create-and-comment.md
@@ -51,7 +51,7 @@ annotated with reproduction steps. The assistant resolves the board, calls
 ```text
 > add_comment(
     task_id=50240,
-    text="Steps to reproduce:\n1. Log out.\n2. Visit /login on Safari 17.\n3. Submit valid creds — page reloads with no session cookie set.\nExpected: redirect to /dashboard.",
+    content="Steps to reproduce:\n1. Log out.\n2. Visit /login on Safari 17.\n3. Submit valid creds — page reloads with no session cookie set.\nExpected: redirect to /dashboard.",
   )
 ```
 

--- a/src/kanbantool_mcp/server.py
+++ b/src/kanbantool_mcp/server.py
@@ -508,17 +508,12 @@ async def set_custom_field(
 
 @mcp.tool
 @validate_call
-async def add_comment(task_id: Annotated[int, Field(ge=1)], text: str) -> Comment:
+async def add_comment(task_id: Annotated[int, Field(ge=1)], content: str) -> Comment:
     """Post a comment on a task. Returns the created ``Comment`` with id,
-    content, author, and timestamps. Empty ``text`` typically raises
-    ``KanbanToolValidationError`` from the API; the field key in
-    ``field_errors`` is ``"content"``, not ``"text"`` (that's the wire field
-    name, not the Python parameter)."""
-    # Wire quirk: the body field is ``content``, not ``text`` — sending
-    # ``{"comment": {"text": ...}}`` makes the live API 422 with
-    # ``Content can't be blank``. Confirmed via spike. The tool's caller-facing
-    # ``text`` parameter stays unchanged for ergonomics; the rename is internal.
-    body = {"comment": {"content": text}}
+    content, author, and timestamps. Empty ``content`` typically raises
+    ``KanbanToolValidationError`` from the API; the ``field_errors`` key
+    matches the parameter name (``"content"``)."""
+    body = {"comment": {"content": content}}
     data = await _get_client().request("POST", f"tasks/{task_id}/comments", json=body)
     return _decode(Comment, data, label="comment")
 
@@ -556,11 +551,12 @@ async def list_subtasks(task_id: int) -> list[Subtask]:
 
 
 @mcp.tool
-async def add_subtask(task_id: int, title: str) -> Subtask:
+async def add_subtask(task_id: int, name: str) -> Subtask:
     """Add a subtask to a task. Returns the created ``Subtask``.
 
-    ``title`` is the human-readable label. Empty ``title`` typically raises
-    ``KanbanToolValidationError`` from the API."""
+    ``name`` is the human-readable label. Empty ``name`` typically raises
+    ``KanbanToolValidationError`` from the API. Mirrors the parameter name
+    used by ``update_subtask`` and the wire/model field on ``Subtask.name``."""
     # Wire quirk: ``POST /subtasks.json`` takes a flat top-level body —
     # ``{"name": ..., "task_id": ...}`` — NOT the Rails-style ``{"subtask": {...}}``
     # envelope used by ``POST /tasks.json`` and friends. A spike against the
@@ -568,7 +564,7 @@ async def add_subtask(task_id: int, title: str) -> Subtask:
     # parent linkage (the response's ``task_id`` came back null and the
     # subtask never appeared on the parent task). Don't copy ``create_task``'s
     # shape here.
-    body = {"name": title, "task_id": task_id}
+    body = {"name": name, "task_id": task_id}
     data = await _get_client().request("POST", "subtasks", json=body)
     return _decode(Subtask, data, label="subtask")
 

--- a/tests/test_comments.py
+++ b/tests/test_comments.py
@@ -1,8 +1,9 @@
 """Tests for the add_comment / delete_comment MCP tools.
 
-Regression bait: this file asserts the wire field is ``content``, not ``text``
-— pre-fix prod always 422'd because the body was sent as
-``{"comment": {"text": ...}}``. Both sides of the new contract live here.
+Regression bait: this file asserts the wire body field is ``content``, not
+``text`` — pre-M5 prod always 422'd because the body was sent as
+``{"comment": {"text": ...}}``. The Python parameter is also ``content`` (M7
+naming sweep) so both sides of the contract are aligned.
 """
 
 from __future__ import annotations
@@ -57,7 +58,7 @@ async def test_add_comment_happy_path_full_payload(_inject_client: KanbanToolCli
         route = router.post(COMMENTS_URL).mock(
             return_value=httpx.Response(201, json=response_payload),
         )
-        comment = await add_comment(task_id=TASK_ID, text="Looks good to me.")
+        comment = await add_comment(task_id=TASK_ID, content="Looks good to me.")
 
     assert comment.id == COMMENT_ID
     assert comment.content == "Looks good to me."
@@ -78,7 +79,7 @@ async def test_add_comment_minimal_response_payload(_inject_client: KanbanToolCl
     response_payload = {"id": 5, "content": "hi"}
     with respx.mock(assert_all_called=True) as router:
         router.post(COMMENTS_URL).mock(return_value=httpx.Response(201, json=response_payload))
-        comment = await add_comment(task_id=TASK_ID, text="hi")
+        comment = await add_comment(task_id=TASK_ID, content="hi")
 
     assert comment.id == 5
     assert comment.content == "hi"
@@ -95,7 +96,7 @@ async def test_add_comment_url_shape(_inject_client: KanbanToolClient) -> None:
         route = router.post(COMMENTS_URL).mock(
             return_value=httpx.Response(201, json={"id": 1, "content": "hi"}),
         )
-        await add_comment(task_id=TASK_ID, text="hi")
+        await add_comment(task_id=TASK_ID, content="hi")
 
     request = route.calls.last.request
     assert request.method == "POST"
@@ -112,7 +113,7 @@ async def test_add_comment_body_uses_content_not_text(
         route = router.post(COMMENTS_URL).mock(
             return_value=httpx.Response(201, json={"id": 1, "content": "hi"}),
         )
-        await add_comment(task_id=TASK_ID, text="hi")
+        await add_comment(task_id=TASK_ID, content="hi")
 
     body = _request_body(route)
     assert body == {"comment": {"content": "hi"}}
@@ -131,7 +132,7 @@ async def test_add_comment_401_raises_permission_error(
             return_value=httpx.Response(401, text="unauthorized"),
         )
         with pytest.raises(KanbanToolPermissionError):
-            await add_comment(task_id=TASK_ID, text="hi")
+            await add_comment(task_id=TASK_ID, content="hi")
 
 
 async def test_add_comment_422_raises_validation_error(
@@ -146,7 +147,7 @@ async def test_add_comment_422_raises_validation_error(
             return_value=httpx.Response(422, json=error_body),
         )
         with pytest.raises(KanbanToolHTTPError) as exc_info:
-            await add_comment(task_id=TASK_ID, text="")
+            await add_comment(task_id=TASK_ID, content="")
 
     err = exc_info.value
     assert isinstance(err, KanbanToolValidationError)
@@ -158,7 +159,7 @@ async def test_add_comment_404_raises_http_error(_inject_client: KanbanToolClien
     with respx.mock() as router:
         router.post(COMMENTS_URL).mock(return_value=httpx.Response(404, text="task not found"))
         with pytest.raises(KanbanToolHTTPError) as exc_info:
-            await add_comment(task_id=TASK_ID, text="hi")
+            await add_comment(task_id=TASK_ID, content="hi")
     assert exc_info.value.status_code == 404
     assert not isinstance(exc_info.value, KanbanToolValidationError)
 
@@ -167,7 +168,7 @@ async def test_add_comment_500_raises_http_error(_inject_client: KanbanToolClien
     with respx.mock() as router:
         router.post(COMMENTS_URL).mock(return_value=httpx.Response(500, text="server exploded"))
         with pytest.raises(KanbanToolHTTPError) as exc_info:
-            await add_comment(task_id=TASK_ID, text="hi")
+            await add_comment(task_id=TASK_ID, content="hi")
     assert exc_info.value.status_code == 500
 
 
@@ -182,7 +183,7 @@ async def test_add_comment_malformed_response_raises_http_error(
             return_value=httpx.Response(201, json={"content": "no-id"}),
         )
         with pytest.raises(KanbanToolHTTPError) as exc_info:
-            await add_comment(task_id=TASK_ID, text="hi")
+            await add_comment(task_id=TASK_ID, content="hi")
 
     assert exc_info.value.status_code == 200
     assert "malformed" in exc_info.value.body_excerpt
@@ -270,6 +271,6 @@ async def test_add_comment_rejects_non_positive_task_id(
     from pydantic import ValidationError
 
     with pytest.raises(ValidationError):
-        await add_comment(task_id=0, text="hi")
+        await add_comment(task_id=0, content="hi")
     with pytest.raises(ValidationError):
-        await add_comment(task_id=-1, text="hi")
+        await add_comment(task_id=-1, content="hi")

--- a/tests/test_subtasks.py
+++ b/tests/test_subtasks.py
@@ -208,7 +208,7 @@ async def test_add_subtask_happy_path(_inject_client: KanbanToolClient) -> None:
         route = router.post(SUBTASKS_URL).mock(
             return_value=httpx.Response(201, json=response_payload)
         )
-        subtask = await add_subtask(task_id=TASK_ID, title="Draft tests")
+        subtask = await add_subtask(task_id=TASK_ID, name="Draft tests")
 
     assert subtask.id == 17
     assert subtask.name == "Draft tests"
@@ -229,7 +229,7 @@ async def test_add_subtask_body_has_no_envelope(_inject_client: KanbanToolClient
         route = router.post(SUBTASKS_URL).mock(
             return_value=httpx.Response(201, json={"id": 1, "name": "x", "task_id": TASK_ID})
         )
-        await add_subtask(task_id=TASK_ID, title="x")
+        await add_subtask(task_id=TASK_ID, name="x")
 
     body = _request_body(route)
     assert "subtask" not in body
@@ -244,7 +244,7 @@ async def test_add_subtask_minimal_response(_inject_client: KanbanToolClient) ->
         router.post(SUBTASKS_URL).mock(
             return_value=httpx.Response(201, json={"id": 1, "name": "x"})
         )
-        subtask = await add_subtask(task_id=TASK_ID, title="x")
+        subtask = await add_subtask(task_id=TASK_ID, name="x")
 
     assert subtask.id == 1
     assert subtask.name == "x"
@@ -263,7 +263,7 @@ async def test_add_subtask_422_raises_validation_error(
     with respx.mock() as router:
         router.post(SUBTASKS_URL).mock(return_value=httpx.Response(422, json=error_body))
         with pytest.raises(KanbanToolValidationError) as exc_info:
-            await add_subtask(task_id=TASK_ID, title="")
+            await add_subtask(task_id=TASK_ID, name="")
 
     err = exc_info.value
     assert err.status_code == 422
@@ -277,7 +277,7 @@ async def test_add_subtask_url_shape(_inject_client: KanbanToolClient) -> None:
         route = router.post(SUBTASKS_URL).mock(
             return_value=httpx.Response(201, json={"id": 1, "name": "x"})
         )
-        await add_subtask(task_id=TASK_ID, title="x")
+        await add_subtask(task_id=TASK_ID, name="x")
 
     request = route.calls.last.request
     assert request.method == "POST"
@@ -288,7 +288,7 @@ async def test_add_subtask_404_raises_http_error(_inject_client: KanbanToolClien
     with respx.mock() as router:
         router.post(SUBTASKS_URL).mock(return_value=httpx.Response(404, text="task not found"))
         with pytest.raises(KanbanToolHTTPError) as exc_info:
-            await add_subtask(task_id=TASK_ID, title="x")
+            await add_subtask(task_id=TASK_ID, name="x")
     assert exc_info.value.status_code == 404
     assert not isinstance(exc_info.value, KanbanToolValidationError)
 
@@ -297,7 +297,7 @@ async def test_add_subtask_500_raises_http_error(_inject_client: KanbanToolClien
     with respx.mock() as router:
         router.post(SUBTASKS_URL).mock(return_value=httpx.Response(500, text="server exploded"))
         with pytest.raises(KanbanToolHTTPError) as exc_info:
-            await add_subtask(task_id=TASK_ID, title="x")
+            await add_subtask(task_id=TASK_ID, name="x")
     assert exc_info.value.status_code == 500
 
 
@@ -312,7 +312,7 @@ async def test_add_subtask_malformed_response_raises_http_error(
             return_value=httpx.Response(201, json={"name": "no-id"}),
         )
         with pytest.raises(KanbanToolHTTPError) as exc_info:
-            await add_subtask(task_id=TASK_ID, title="x")
+            await add_subtask(task_id=TASK_ID, name="x")
 
     assert exc_info.value.status_code == 200
     assert "malformed" in exc_info.value.body_excerpt


### PR DESCRIPTION
## Summary

Pre-1.0 naming sweep. Two MCP tool parameter names didn't match their wire
field name; rename them now while a Python-parameter rename is still cheap
(per [SEMVER.md](SEMVER.md), once v1.0 ships, renaming a required tool
parameter is a major bump).

- `add_comment(task_id, text)` -> `add_comment(task_id, content)`
- `add_subtask(task_id, title)` -> `add_subtask(task_id, name)`

Wire bodies are unchanged. Pure Python-parameter rename.

## Why now (cheap pre-1.0; expensive post-1.0)

`SEMVER.md` commits to "renaming a required tool parameter ... is a major
bump" once we reach v1.0. Pre-1.0 minor / patch releases MAY include
breaking changes. Two cheap-to-fix mismatches today, two majors avoided
later.

### `add_comment`: `text` -> `content`

The wire field has always been `content`. The M5 P0 bugfix (#111) was
about exactly this: the server was sending `{"comment": {"text": ...}}`
and the API 422'd `Content can't be blank`. M5 fixed the wire body
without renaming the Python parameter, leaving an internal-only rename
that surprises callers when they see `field_errors` keyed on `"content"`
even though their kwarg was `text`. Aligning the parameter to `content`
removes the rename entirely.

### `add_subtask`: `title` -> `name`

Wire-spike verification:

- `Subtask` model declares `name: str` (no alias) with a docstring
  comment: *"`name` is the API-native field — kept verbatim rather
  than aliased to `title` so there's no rename to maintain on either
  edge."*
- `add_subtask` body construction is already
  `{"name": title, "task_id": task_id}` — sends wire `name`, just
  with a Python parameter spelling that diverges.
- `tests/test_subtasks.py::test_add_subtask_happy_path` asserts
  `body == {"name": "Draft tests", "task_id": TASK_ID}`.
- `update_subtask` already uses `name`. The pre-PR state had
  `add_subtask(title=...)` then `update_subtask(name=...)` for the
  same field on sibling tools — confusing for LLMs.

## Breaking change

The Python parameter names change. Callers using keyword arguments must update:

```python
# Before
add_comment(task_id=42, text="hi")
add_subtask(task_id=42, title="step 1")

# After
add_comment(task_id=42, content="hi")
add_subtask(task_id=42, name="step 1")
```

Per [SEMVER.md](SEMVER.md):

> Before v1.0.0:
> - **Minor** bumps (e.g. 0.5.0 -> 0.6.0) MAY include breaking changes.
> - **Patch** bumps (e.g. 0.6.0 -> 0.6.1) are bug-fix only and SHOULD
>   not break anything, but as with any pre-1.0 project the tag is not
>   load-bearing.

The conventional-commit prefix is `refactor:` (no `!`) so release-please
treats this as a patch bump. The breaking-change context lives in the
commit body and CHANGELOG entry, not in a major-tag flip — pinning a
v1.0 tag is a separate, intentional decision.

## What this PR does NOT do

- No `validate_call` / `Field(ge=1)` parity work (separate PR in flight).
- No new tools.
- No behavioural change. Wire bodies, error-mapping, return types unchanged.

## Test plan

- [x] `uv run ruff check .` — All checks passed
- [x] `uv run ruff format --check .` — 29 files already formatted
- [x] `uv run ty check src tests` — All checks passed
- [x] `uv run pytest` — 219 passed
- [x] `tests/test_comments.py` regression-bait assertion `"text" not in inner`
      remains valid (the wire body never had `text`, only the Python parameter
      did, and that's now gone)
- [x] `tests/test_subtasks.py` body-shape assertion
      `body == {"name": "Draft tests", "task_id": TASK_ID}` remains valid
      (no wire change)
- [x] `README.md` Tool reference table updated for both renamed parameters
- [x] `examples/02-create-and-comment.md` updated (`add_comment(text=...)` -> `content=...`)
- [x] `CLAUDE.md` updated with M7 entry in the Phases list