### PR TITLE
test(integration): cover M4 and M5 tools with live integration tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,7 @@ M5 — Custom-field writes & comment polish:
 - **M3** — Polish & release: error messages, retries, docs pass, PyPI publish. *Complete.*
 - **M4** — Completeness: custom-field reads + time-tracker tools. *Complete.*
 - **M5** — Custom-field writes + comment polish: `set_custom_field`, `delete_comment` (the API has no comment-edit endpoint), and the `add_comment` wire-field bugfix (`text` → `content`). *Complete.*
-- **M6** — v1.0 readiness: SemVer commitment policy, README pass, error-message audit, RELEASING.md updates. *In progress.*
+- **M6** — v1.0 readiness: SemVer commitment policy, README pass, error-message audit, RELEASING.md updates. *Complete.*
 - **M7** — Pre-1.0 naming sweep: align Python parameter names with wire shapes / sibling tools before v1.0 locks them in. `add_comment(text=...)` → `add_comment(content=...)` (matches the wire field that the M5 bugfix had to send anyway). `add_subtask(title=...)` → `add_subtask(name=...)` (matches `Subtask.name` and `update_subtask(name=...)`). Wire bodies unchanged; this is purely a Python parameter rename. *Complete.*
 
 ## Codebase conventions

--- a/tests/integration/test_comment_delete_live.py
+++ b/tests/integration/test_comment_delete_live.py
@@ -1,0 +1,76 @@
+"""Live integration tests for the M5 ``delete_comment`` tool.
+
+Coverage scope: the comment soft-delete flow end-to-end against the real
+Kanban Tool API. The interesting contract bit live coverage locks in:
+
+- ``delete_comment`` returns a ``Comment`` with ``deleted_at`` populated
+  (soft-delete, mirroring ``delete_subtask``). The offline mock stipulates
+  this; the live test confirms the API actually behaves that way.
+
+Cleanup: each test creates a throwaway task and a comment on it, exercises
+the delete, then archives the task. No orphans — the parent task is gone
+after the test even if assertions fail.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from collections.abc import AsyncIterator
+
+import pytest
+
+from kanbantool_mcp.client import KanbanToolClient
+from kanbantool_mcp.models import Comment
+from kanbantool_mcp.server import (
+    add_comment,
+    archive_task,
+    create_task,
+    delete_comment,
+    list_boards,
+)
+
+
+@pytest.fixture
+async def throwaway_task_id(_inject_live_client: KanbanToolClient) -> AsyncIterator[int]:
+    """Create a single-use task on the first available board, yield its id,
+    archive on teardown.
+
+    Each delete_comment test gets its own task so a comment delete never
+    affects a sibling test's view of the comments collection. Archival on
+    teardown leaves the test account clean."""
+    boards = await list_boards()
+    if not boards:
+        pytest.skip("test account has no boards; live tests need at least one.")
+    board_id = boards[0].id
+    task = await create_task(
+        name="kanbantool-mcp live integration: comment scratch",
+        board_id=board_id,
+        description="Throwaway task created by tests/integration/test_comment_delete_live.py.",
+    )
+    try:
+        yield task.id
+    finally:
+        with contextlib.suppress(Exception):
+            await archive_task(task.id)
+
+
+async def test_delete_comment_returns_soft_deleted_comment(
+    _inject_live_client: KanbanToolClient,
+    throwaway_task_id: int,
+) -> None:
+    """``delete_comment`` returns the deleted ``Comment`` with ``deleted_at``
+    populated — soft-delete semantics. The id matches the original comment
+    (the record is retained server-side, just flagged)."""
+    posted = await add_comment(
+        task_id=throwaway_task_id,
+        text="kanbantool-mcp live integration: about to be deleted",
+    )
+    assert posted.deleted_at is None  # sanity: live comments aren't pre-deleted
+
+    deleted = await delete_comment(task_id=throwaway_task_id, comment_id=posted.id)
+
+    assert isinstance(deleted, Comment)
+    assert deleted.id == posted.id
+    # The soft-delete signal: ``deleted_at`` is now populated.
+    assert deleted.deleted_at is not None
+    assert isinstance(deleted.deleted_at, str)

--- a/tests/integration/test_comment_delete_live.py
+++ b/tests/integration/test_comment_delete_live.py
@@ -63,7 +63,7 @@ async def test_delete_comment_returns_soft_deleted_comment(
     (the record is retained server-side, just flagged)."""
     posted = await add_comment(
         task_id=throwaway_task_id,
-        text="kanbantool-mcp live integration: about to be deleted",
+        content="kanbantool-mcp live integration: about to be deleted",
     )
     assert posted.deleted_at is None  # sanity: live comments aren't pre-deleted
 

--- a/tests/integration/test_custom_field_writes_live.py
+++ b/tests/integration/test_custom_field_writes_live.py
@@ -1,0 +1,108 @@
+"""Live integration tests for the M5 ``set_custom_field`` write tool.
+
+Coverage scope: the write counterpart to ``list_custom_field_definitions``
+end-to-end against the real Kanban Tool API. The interesting bits worth
+locking in live (beyond the offline mock):
+
+- A simple string write round-trips through ``Task.custom_fields``.
+- ``value=None`` actually CLEARS the slot (the wire sends literal ``null``
+  rather than the ``update_task`` "omit" semantic). This is the bit most
+  likely to drift if a future refactor accidentally routes through
+  ``_patch_task``.
+
+Cleanup: each test creates a throwaway task, writes/clears the field,
+asserts, and archives the task before returning. No orphans — the task is
+gone after each test even if assertions fail.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from collections.abc import AsyncIterator
+
+import pytest
+
+from kanbantool_mcp.client import KanbanToolClient
+from kanbantool_mcp.models import Task
+from kanbantool_mcp.server import (
+    archive_task,
+    create_task,
+    list_boards,
+    set_custom_field,
+)
+
+
+@pytest.fixture
+async def throwaway_task_id(_inject_live_client: KanbanToolClient) -> AsyncIterator[int]:
+    """Create a single-use task on the first available board, yield its id,
+    archive on teardown.
+
+    Custom fields are per-task state; we use a fresh task per test rather
+    than mutating a shared one so test ordering and account state don't
+    cross-contaminate."""
+    boards = await list_boards()
+    if not boards:
+        pytest.skip("test account has no boards; live tests need at least one.")
+    board_id = boards[0].id
+    task = await create_task(
+        name="kanbantool-mcp live integration: custom-field scratch",
+        board_id=board_id,
+        description="Throwaway task created by tests/integration/test_custom_field_writes_live.py.",
+    )
+    try:
+        yield task.id
+    finally:
+        with contextlib.suppress(Exception):
+            await archive_task(task.id)
+
+
+async def test_set_custom_field_writes_string_value(
+    _inject_live_client: KanbanToolClient,
+    throwaway_task_id: int,
+) -> None:
+    """A string write lands on the wire and the response surfaces it on
+    ``Task.custom_fields["custom_field_N"]``. Slot 1 is used because every
+    Kanban Tool board exposes 15 slots regardless of board template."""
+    sentinel = "kanbantool-mcp live integration probe"
+
+    task = await set_custom_field(
+        task_id=throwaway_task_id,
+        slot=1,
+        value=sentinel,
+    )
+
+    assert isinstance(task, Task)
+    assert task.id == throwaway_task_id
+    assert isinstance(task.custom_fields, dict)
+    assert task.custom_fields.get("custom_field_1") == sentinel
+
+
+async def test_set_custom_field_none_clears_value(
+    _inject_live_client: KanbanToolClient,
+    throwaway_task_id: int,
+) -> None:
+    """``value=None`` round-trips: writing then clearing leaves the slot
+    empty on the next response. This is the contract bit that distinguishes
+    ``set_custom_field`` from ``update_task`` — None means *clear*, not
+    *omit*. Pre-fix routing through ``_patch_task`` would silently drop
+    the key and the slot would retain its prior value."""
+    # Seed the slot with a value first so the clear is observable.
+    seeded = await set_custom_field(
+        task_id=throwaway_task_id,
+        slot=2,
+        value="will be cleared",
+    )
+    assert seeded.custom_fields.get("custom_field_2") == "will be cleared"
+
+    # Clearing: the response should now show the slot as None / missing.
+    cleared = await set_custom_field(
+        task_id=throwaway_task_id,
+        slot=2,
+        value=None,
+    )
+
+    assert isinstance(cleared, Task)
+    # Either an explicit ``None`` value or the key absent from the dict —
+    # both are valid "cleared" representations on the wire. Lock the
+    # not-still-set semantic rather than the exact null/missing shape.
+    assert cleared.custom_fields.get("custom_field_2") is None

--- a/tests/integration/test_time_tracker_live.py
+++ b/tests/integration/test_time_tracker_live.py
@@ -1,0 +1,155 @@
+"""Live integration tests for the M4 time-tracker tools.
+
+Coverage scope: the four write/read time-tracker tools end-to-end against a
+real Kanban Tool account. Each test creates the artifacts it needs (timer
+on a throwaway task) and cleans them up before returning, so a re-run leaves
+no orphans on the test account.
+
+These run only via the ``Live Integration`` workflow — see
+``pyproject.toml``'s ``addopts`` (``--ignore=tests/integration``) and
+``.github/workflows/integration.yml``.
+
+Assertions are SHAPE-not-VALUE: the live API's specific ids, timestamps,
+and per-account state shift, so the tests lock model types and the bits of
+contract semantics worth guarding (``is_running`` flips, ``ended_at`` set,
+DELETE-returns-None) — never specific values.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from collections.abc import AsyncIterator
+
+import pytest
+
+from kanbantool_mcp.client import KanbanToolClient
+from kanbantool_mcp.models import TimeTracker
+from kanbantool_mcp.server import (
+    archive_task,
+    create_task,
+    delete_timer,
+    list_boards,
+    list_my_timers,
+    start_timer,
+    stop_timer,
+)
+
+
+@pytest.fixture
+async def throwaway_task(_inject_live_client: KanbanToolClient) -> AsyncIterator[tuple[int, int]]:
+    """Create a synthetic task on the first available board, yield
+    ``(task_id, board_id)``, then archive the task on teardown.
+
+    Timers must be attached to a real task on a real board — the API rejects
+    ``start_timer`` calls otherwise. We create a single-use task per test
+    so timer assertions can run against fresh state, and archive it after
+    (the API has no hard-delete for tasks via our tool surface; archival
+    is the cleanup signal an LLM caller would use too)."""
+    boards = await list_boards()
+    if not boards:
+        pytest.skip("test account has no boards; live tests need at least one.")
+    board_id = boards[0].id
+    task = await create_task(
+        name="kanbantool-mcp live integration: timer scratch",
+        board_id=board_id,
+        description="Throwaway task created by tests/integration/test_time_tracker_live.py.",
+    )
+    try:
+        yield task.id, board_id
+    finally:
+        # Best-effort cleanup — never let a teardown failure mask the
+        # actual test result. If archive_task raises (e.g. transient 5xx),
+        # the orphaned task will surface in the next run's listing and a
+        # maintainer can sweep it manually.
+        with contextlib.suppress(Exception):
+            await archive_task(task.id)
+
+
+async def test_start_timer_returns_running_tracker(
+    _inject_live_client: KanbanToolClient,
+    throwaway_task: tuple[int, int],
+) -> None:
+    """``start_timer`` POSTs and returns a ``TimeTracker`` in the running
+    state (``ended_at`` unset, ``is_running=True``). Cleans up by deleting
+    the timer immediately after the assertions land."""
+    task_id, board_id = throwaway_task
+
+    timer = await start_timer(task_id=task_id, board_id=board_id)
+    try:
+        assert isinstance(timer, TimeTracker)
+        assert timer.id > 0
+        assert timer.task_id == task_id
+        assert timer.board_id == board_id
+        assert timer.ended_at is None
+        assert timer.is_running is True
+    finally:
+        # Always clean up — even if the assertions failed, the timer is
+        # already on the wire and would persist on the test account.
+        with contextlib.suppress(Exception):
+            await delete_timer(timer.id)
+
+
+async def test_stop_timer_sets_ended_at(
+    _inject_live_client: KanbanToolClient,
+    throwaway_task: tuple[int, int],
+) -> None:
+    """``stop_timer`` PUTs ``ended_at`` (defaults to now) and the response's
+    ``is_running`` flips to ``False``. Round-trip: start → stop → delete."""
+    task_id, board_id = throwaway_task
+
+    started = await start_timer(task_id=task_id, board_id=board_id)
+    try:
+        stopped = await stop_timer(timer_id=started.id)
+
+        assert isinstance(stopped, TimeTracker)
+        assert stopped.id == started.id
+        # The defining bit of contract: stopping populates ``ended_at`` and
+        # the derived ``is_running`` flag flips.
+        assert stopped.ended_at is not None
+        assert isinstance(stopped.ended_at, str)
+        assert stopped.is_running is False
+    finally:
+        with contextlib.suppress(Exception):
+            await delete_timer(started.id)
+
+
+async def test_delete_timer_returns_none(
+    _inject_live_client: KanbanToolClient,
+    throwaway_task: tuple[int, int],
+) -> None:
+    """``delete_timer`` returns ``None`` on success — the API responds with
+    an empty body (204 / empty 200) and the typed return mirrors that.
+    No try/finally cleanup needed: deletion IS the cleanup."""
+    task_id, board_id = throwaway_task
+
+    timer = await start_timer(task_id=task_id, board_id=board_id)
+    result = await delete_timer(timer.id)
+
+    assert result is None
+
+
+async def test_list_my_timers_returns_typed_list(
+    _inject_live_client: KanbanToolClient,
+    throwaway_task: tuple[int, int],
+) -> None:
+    """``list_my_timers`` returns the authenticated user's timers across
+    all tasks. Seed one running timer so the list is guaranteed non-empty,
+    confirm the seeded id is present, then clean up.
+
+    Note: the basic typed-list shape is also covered by
+    ``test_live_read_tools.test_list_my_timers_returns_typed_list``; this
+    test additionally asserts the create→list round-trip works (a freshly
+    started timer surfaces on the listing)."""
+    task_id, board_id = throwaway_task
+
+    started = await start_timer(task_id=task_id, board_id=board_id)
+    try:
+        timers = await list_my_timers()
+
+        assert isinstance(timers, list)
+        assert all(isinstance(t, TimeTracker) for t in timers)
+        # The just-started timer must appear in the listing.
+        assert any(t.id == started.id for t in timers)
+    finally:
+        with contextlib.suppress(Exception):
+            await delete_timer(started.id)


### PR DESCRIPTION
## Summary

Add live integration coverage for the M4 (time-tracker) and M5 (custom-field
writes, comment delete) tools that lacked it. v1.0 commits to wire shape, and
offline mocks alone won't catch upstream API drift — every tool now has at
least one happy-path live contract guard.

## Tools covered, file by file

`tests/integration/test_time_tracker_live.py` (4 tests)
- `start_timer` — happy path, asserts `TimeTracker` shape with `is_running=True`.
- `stop_timer` — round-trips a start→stop, asserts `ended_at` populated and `is_running=False`.
- `delete_timer` — asserts the tool returns `None` (the API responds with empty body).
- `list_my_timers` — seeds one running timer and confirms it surfaces on the list, plus typed-list assertions.

`tests/integration/test_custom_field_writes_live.py` (2 tests)
- `set_custom_field` happy path — string write round-trips through `Task.custom_fields`.
- `set_custom_field` clear semantics — `value=None` actually clears the slot (the contract bit that distinguishes this tool from `update_task`'s "omit" semantics).

`tests/integration/test_comment_delete_live.py` (1 test)
- `delete_comment` — soft-delete returns a `Comment` with `deleted_at` populated.

`list_custom_field_definitions` was already covered live by
`tests/integration/test_live_read_tools.test_list_custom_field_definitions_against_populated_board`
(15-slot count and `slot`/`label`/`type_`/`enabled` shape locks); this PR does not duplicate it.

## Total: 7 new live tests across 3 files.

## Cleanup behaviour (so a reviewer trusts there's no orphaned data)

Every test runs an idempotent create→assert→archive/delete cycle:

- **Throwaway task fixtures** create a single-use task on the first available board, yield its id, and archive the task in a `contextlib.suppress(Exception)` finally block — even if assertions or the API itself raise, teardown runs.
- **Timer tests** additionally delete the timer they started after assertions land (timers are NOT auto-cleaned on parent-task archival; they live on `users/current.json`).
- **Comment test** posts then deletes the comment; archiving the parent task on teardown completes the cleanup.
- All test artifacts are name-tagged `kanbantool-mcp live integration: ...` so any orphan that does survive (transient 5xx on teardown) is trivially recognisable in the test account UI for manual sweep.

## How to run them locally

These are excluded from `uv run pytest` by `pyproject.toml`'s `addopts`. To run them against a real Kanban Tool account:

```bash
export KANBANTOOL_DOMAIN=<your-test-account-subdomain>
export KANBANTOOL_API_TOKEN=<your-api-token>
uv run pytest tests/integration/ -v
```

In CI: trigger the `Live Integration` workflow manually (`gh workflow run integration.yml` or the GitHub Actions UI). It pulls the same env vars from `KANBANTOOL_DOMAIN_TEST` / `KANBANTOOL_API_TOKEN_TEST` repo secrets.

## Pre-PR checks

- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run ty check src tests`
- [x] `uv run pytest` (offline suite — 219 passed; live tests are excluded by default)
- [x] `uv run python -c "import tests.integration.test_<each_file>"`

## Test plan

- [ ] Maintainer runs the `Live Integration` workflow once after merge to confirm the new tests pass against the real account.

`test:` per `RELEASING.md` doesn't bump version — this PR is release-please-neutral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)