### PR TITLE
chore(server): @validate_call parity across all id-taking tools (M7-B)

### DIFF
--- a/src/kanbantool_mcp/server.py
+++ b/src/kanbantool_mcp/server.py
@@ -588,7 +588,7 @@ async def update_subtask(
     *,
     name: str | None = None,
     is_completed: bool | None = None,
-    assigned_user_id: int | None = None,
+    assigned_user_id: Annotated[int, Field(ge=1)] | None = None,
 ) -> Subtask:
     """Partial update of an existing subtask. Returns the updated ``Subtask``.
 

--- a/src/kanbantool_mcp/server.py
+++ b/src/kanbantool_mcp/server.py
@@ -197,20 +197,25 @@ async def get_board(board_id: Annotated[int, Field(ge=1)]) -> Board:
 
 
 @mcp.tool
-async def get_task(task_id: int) -> Task:
+@validate_call
+async def get_task(task_id: Annotated[int, Field(ge=1)]) -> Task:
     """Fetch one task by id. Returns a Task with subtask/comment counts,
     total tracked time, and inline ``subtasks``.
 
     Subtasks live on ``Task.subtasks`` directly — no extra round-trip needed
     (use ``list_subtasks`` only when you want just the list and not the rest
     of the task).
+
     Raises ``KanbanToolHTTPError(404)`` if the task is unknown or inaccessible."""
     data = await _get_client().request("GET", f"tasks/{task_id}")
     return _decode(Task, data, label="task")
 
 
 @mcp.tool
-async def recent_changes(board_id: int, since: datetime | None = None) -> list[ChangelogEntry]:
+@validate_call
+async def recent_changes(
+    board_id: Annotated[int, Field(ge=1)], since: datetime | None = None
+) -> list[ChangelogEntry]:
     """Fetch a board's changelog (Kanban Tool has no webhooks; poll this instead).
 
     Always pass ``since`` (timestamp of the last entry seen) on follow-up calls —
@@ -229,11 +234,12 @@ _SEARCH_TASKS_MAX_LIMIT = 50
 
 
 @mcp.tool
+@validate_call
 async def search_tasks(
     query: str,
-    board_id: int | None = None,
-    limit: int = 25,
-    page: int = 1,
+    board_id: Annotated[int, Field(ge=1)] | None = None,
+    limit: Annotated[int, Field(ge=1)] = 25,
+    page: Annotated[int, Field(ge=1)] = 1,
 ) -> list[Task]:
     """Search tasks across boards using Kanban Tool's query DSL.
 
@@ -274,13 +280,14 @@ async def search_tasks(
 
 
 @mcp.tool
+@validate_call
 async def create_task(
     name: str,
-    board_id: int,
+    board_id: Annotated[int, Field(ge=1)],
     description: str | None = None,
-    lane_id: int | None = None,
+    lane_id: Annotated[int, Field(ge=1)] | None = None,
     position: int | None = None,
-    assigned_user_id: int | None = None,
+    assigned_user_id: Annotated[int, Field(ge=1)] | None = None,
     due_date: str | None = None,
     priority: int | str | None = None,
     tags: str | None = None,
@@ -390,20 +397,21 @@ async def _patch_task(
 
 
 @mcp.tool
+@validate_call
 async def update_task(
-    task_id: int,
+    task_id: Annotated[int, Field(ge=1)],
     name: str | None = None,
     description: str | None = None,
-    board_id: int | None = None,
-    lane_id: int | None = None,
-    swimlane_id: int | None = None,
+    board_id: Annotated[int, Field(ge=1)] | None = None,
+    lane_id: Annotated[int, Field(ge=1)] | None = None,
+    swimlane_id: Annotated[int, Field(ge=1)] | None = None,
     position: int | None = None,
     priority: int | str | None = None,
     color: str | None = None,
     due_date: str | None = None,
     start_date: str | None = None,
     tags: str | None = None,
-    assigned_user_id: int | None = None,
+    assigned_user_id: Annotated[int, Field(ge=1)] | None = None,
 ) -> Task:
     """Partially update a task's fields. Only the kwargs you pass are sent;
     ``None`` means *omit*, not *clear* (the API ignores nulls, doesn't wipe).
@@ -434,10 +442,11 @@ async def update_task(
 
 
 @mcp.tool
+@validate_call
 async def move_task(
-    task_id: int,
-    column_id: int | None = None,
-    swimlane_id: int | None = None,
+    task_id: Annotated[int, Field(ge=1)],
+    column_id: Annotated[int, Field(ge=1)] | None = None,
+    swimlane_id: Annotated[int, Field(ge=1)] | None = None,
     position: int | None = None,
 ) -> Task:
     """Move a task between columns, swimlanes, or positions on its board.
@@ -458,7 +467,8 @@ async def move_task(
 
 
 @mcp.tool
-async def archive_task(task_id: int) -> Task:
+@validate_call
+async def archive_task(task_id: Annotated[int, Field(ge=1)]) -> Task:
     """Archive a task. Returns the updated ``Task`` (caller can confirm
     ``is_archived=True``).
 
@@ -539,7 +549,8 @@ async def delete_comment(
 
 
 @mcp.tool
-async def list_subtasks(task_id: int) -> list[Subtask]:
+@validate_call
+async def list_subtasks(task_id: Annotated[int, Field(ge=1)]) -> list[Subtask]:
     """List subtasks on a task — id, name, completion state, position.
 
     Subtasks are returned inline on ``Task.subtasks`` whenever you fetch a
@@ -551,7 +562,8 @@ async def list_subtasks(task_id: int) -> list[Subtask]:
 
 
 @mcp.tool
-async def add_subtask(task_id: int, name: str) -> Subtask:
+@validate_call
+async def add_subtask(task_id: Annotated[int, Field(ge=1)], name: str) -> Subtask:
     """Add a subtask to a task. Returns the created ``Subtask``.
 
     ``name`` is the human-readable label. Empty ``name`` typically raises

--- a/tests/test_create_task.py
+++ b/tests/test_create_task.py
@@ -149,13 +149,15 @@ async def test_create_task_legacy_assignees_kwarg_rejected(
     _inject_client: KanbanToolClient,
 ) -> None:
     """The legacy ``assignees=[int]`` kwarg has been removed (the API silently
-    ignored it — see #62). Calling with it must raise ``TypeError`` before any
-    HTTP traffic, so the LLM gets an immediate signal to migrate."""
+    ignored it — see #62). Calling with it must reject before any HTTP traffic,
+    so the LLM gets an immediate signal to migrate. With ``@validate_call``
+    enabled (M7-B), pydantic raises ``ValidationError`` (a ``ValueError``
+    subclass) for unexpected kwargs rather than Python's bare ``TypeError``."""
     # Route through a kwargs dict typed as ``dict[str, Any]`` so the static
     # type-checker doesn't flag the removed kwarg — we're deliberately
     # exercising runtime rejection.
     legacy_kwargs: dict[str, Any] = {"name": "x", "board_id": 2, "assignees": [11]}
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError):
         await create_task(**legacy_kwargs)
 
 

--- a/tests/test_update_task.py
+++ b/tests/test_update_task.py
@@ -142,13 +142,14 @@ async def test_update_task_legacy_assignees_kwarg_rejected(
     _inject_client: KanbanToolClient,
 ) -> None:
     """The legacy ``assignees=[int]`` kwarg has been removed (the API silently
-    ignored it — see #62). Calling with it must raise ``TypeError`` before any
-    HTTP traffic."""
+    ignored it — see #62). Calling with it must reject before any HTTP traffic.
+    With ``@validate_call`` enabled (M7-B), pydantic raises ``ValidationError``
+    (a ``ValueError`` subclass) for unexpected kwargs."""
     # Route through a kwargs dict typed as ``dict[str, Any]`` so the static
     # type-checker doesn't flag the removed kwarg — we're deliberately
     # exercising runtime rejection.
     legacy_kwargs: dict[str, Any] = {"task_id": TASK_ID, "assignees": [11]}
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError):
         await update_task(**legacy_kwargs)
 
 


### PR DESCRIPTION
## Summary
Pre-1.0 polish completing the M7 readiness sweep: every tool that takes an integer id now has \`@validate_call\` + \`Annotated[int, Field(ge=1)]\` on its id parameters, matching the parity established by the M4/M5 surface.

## Tools updated
\`get_task\`, \`recent_changes\`, \`search_tasks\`, \`create_task\`, \`update_task\`, \`move_task\`, \`archive_task\`, \`list_subtasks\`, \`add_subtask\`.

## Behavioral change
- Caller that passes a 0/-N id now gets \`pydantic.ValidationError\` (a \`ValueError\` subclass) **before** any HTTP roundtrip, with a structured message naming the offending field.
- Previously: round-trip to API, get a confusing 404.

## Test changes
Two tests for the legacy \`assignees=\` kwarg now expect \`ValueError\` instead of \`TypeError\` — \`@validate_call\` intercepts unexpected kwargs and raises a typed \`ValidationError\` (which subclasses \`ValueError\`) before Python's bare \`TypeError\` fires. Same intent ("legacy kwarg is rejected"), updated exception type.

No wire shape changes. No tool-name or parameter-name changes.

## Test plan
- [x] \`uv run ruff check .\`
- [x] \`uv run ruff format --check .\`
- [x] \`uv run ty check src tests\`
- [x] \`uv run pytest\` — 219 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)