### PR TITLE
test(integration): cover M1/M2 write tools with live integration tests

### DIFF
--- a/tests/integration/test_comment_delete_live.py
+++ b/tests/integration/test_comment_delete_live.py
@@ -1,15 +1,20 @@
-"""Live integration tests for the M5 ``delete_comment`` tool.
+"""Live integration tests for the M2/M5 comment write tools.
 
-Coverage scope: the comment soft-delete flow end-to-end against the real
-Kanban Tool API. The interesting contract bit live coverage locks in:
+Coverage scope: ``add_comment`` (M2) and ``delete_comment`` (M5) end-to-end
+against the real Kanban Tool API. The interesting contract bits live
+coverage locks in:
 
+- ``add_comment`` POSTs and returns a ``Comment`` with ``content`` populated.
+  The body field is ``content``, not ``text`` — the M5 wire-field bugfix
+  documents this; locking it live prevents silent regression to the broken
+  pre-fix shape (every call 422'd ``Content can't be blank``).
 - ``delete_comment`` returns a ``Comment`` with ``deleted_at`` populated
   (soft-delete, mirroring ``delete_subtask``). The offline mock stipulates
   this; the live test confirms the API actually behaves that way.
 
 Cleanup: each test creates a throwaway task and a comment on it, exercises
-the delete, then archives the task. No orphans — the parent task is gone
-after the test even if assertions fail.
+the operation, then archives the task. No orphans — the parent task is
+gone after the test even if assertions fail.
 """
 
 from __future__ import annotations
@@ -52,6 +57,36 @@ async def throwaway_task_id(_inject_live_client: KanbanToolClient) -> AsyncItera
     finally:
         with contextlib.suppress(Exception):
             await archive_task(task.id)
+
+
+async def test_add_comment_returns_comment_with_content(
+    _inject_live_client: KanbanToolClient,
+    throwaway_task_id: int,
+) -> None:
+    """``add_comment`` POSTs and returns a ``Comment`` whose ``content``
+    echoes the request. The wire-field name is ``content`` (not ``text``);
+    pre-M5 the body said ``text`` and every call 422'd ``Content can't be
+    blank``. This test is the live regression guard for that fix.
+
+    The created comment is a real artifact on the parent task — clean up by
+    soft-deleting it before the parent is archived on fixture teardown.
+    Soft-delete is sufficient: archived parents drop their comments from
+    listings regardless, and the test is about ``add_comment``'s contract,
+    not the lifecycle interaction."""
+    sentinel = "kanbantool-mcp live integration: add_comment probe"
+    posted = await add_comment(task_id=throwaway_task_id, content=sentinel)
+    try:
+        assert isinstance(posted, Comment)
+        assert posted.id > 0
+        # Locking the content round-trip is the bit the M5 wire-field bugfix
+        # actually unblocked — pre-fix this assertion would never run because
+        # the create call 422'd.
+        assert posted.content == sentinel
+        # Sanity: a freshly-posted comment isn't pre-deleted.
+        assert posted.deleted_at is None
+    finally:
+        with contextlib.suppress(Exception):
+            await delete_comment(task_id=throwaway_task_id, comment_id=posted.id)
 
 
 async def test_delete_comment_returns_soft_deleted_comment(

--- a/tests/integration/test_subtask_write_live.py
+++ b/tests/integration/test_subtask_write_live.py
@@ -1,0 +1,169 @@
+"""Live integration tests for the M2 subtask write tools.
+
+Coverage scope: ``add_subtask``, ``update_subtask``, ``delete_subtask``,
+``reorder_subtasks`` end-to-end against the real Kanban Tool API. The
+offline suite mocks these against ``respx`` recordings; this file locks
+the wire-shape contract against an actual account.
+
+Subtasks live under a parent task — every test creates its own throwaway
+parent task on the first available board, performs the assertion, and
+archives the parent on teardown. Subtasks die with the parent (soft-deleted
+along with the archive), so cleanup is one ``archive_task`` per test.
+
+Wire quirks worth noting (already in ``server.py`` docstrings — this is
+just the test-author's lens):
+
+- ``POST /subtasks.json`` takes a flat top-level body, NOT a Rails-style
+  envelope. Live spike confirmed wrapping breaks the parent linkage.
+- ``PUT /subtasks/reorder.json`` takes ``ids`` as a comma-joined string,
+  not a JSON array. The tool accepts ``list[int]`` and joins on the way out.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from collections.abc import AsyncIterator
+
+import pytest
+
+from kanbantool_mcp.client import KanbanToolClient
+from kanbantool_mcp.models import Subtask
+from kanbantool_mcp.server import (
+    add_subtask,
+    archive_task,
+    create_task,
+    delete_subtask,
+    list_boards,
+    list_subtasks,
+    reorder_subtasks,
+    update_subtask,
+)
+
+
+@pytest.fixture
+async def throwaway_task_id(_inject_live_client: KanbanToolClient) -> AsyncIterator[int]:
+    """Create a single-use parent task on the first available board, yield
+    its id, archive on teardown.
+
+    Subtasks attach to a real parent — there is no "standalone subtask"
+    concept on the API. Per-test fresh parents keep state contained and
+    avoid cross-test ordering coupling on subtask ids."""
+    boards = await list_boards()
+    if not boards:
+        pytest.skip("test account has no boards; live tests need at least one.")
+    board_id = boards[0].id
+    task = await create_task(
+        name="kanbantool-mcp live integration: subtask scratch",
+        board_id=board_id,
+        description="Throwaway task created by tests/integration/test_subtask_write_live.py.",
+    )
+    try:
+        yield task.id
+    finally:
+        with contextlib.suppress(Exception):
+            await archive_task(task.id)
+
+
+async def test_add_subtask_returns_subtask(
+    _inject_live_client: KanbanToolClient,
+    throwaway_task_id: int,
+) -> None:
+    """``add_subtask`` POSTs and returns a ``Subtask`` whose ``name`` echoes
+    the request and whose ``task_id`` links back to the parent. The flat-body
+    convention (no Rails envelope) is exercised implicitly — if it broke,
+    ``task_id`` would come back ``None`` and this assertion would fail."""
+    sentinel = "kanbantool-mcp live integration: add_subtask probe"
+    sub = await add_subtask(task_id=throwaway_task_id, name=sentinel)
+
+    assert isinstance(sub, Subtask)
+    assert sub.id > 0
+    assert sub.name == sentinel
+    # Parent linkage — the bit the flat-body convention guards.
+    assert sub.task_id == throwaway_task_id
+    # A freshly-created subtask isn't deleted; lock that so soft-delete
+    # tests below have a meaningful before/after.
+    assert sub.deleted_at is None
+
+
+async def test_update_subtask_marks_completed(
+    _inject_live_client: KanbanToolClient,
+    throwaway_task_id: int,
+) -> None:
+    """``update_subtask`` PATCHes a partial body and returns the updated
+    ``Subtask``. Marking complete is the cheapest mutation that has a
+    type-stable, observable effect on the response."""
+    seeded = await add_subtask(
+        task_id=throwaway_task_id,
+        name="kanbantool-mcp live integration: about to be completed",
+    )
+    assert seeded.is_completed is False or seeded.is_completed is None
+
+    updated = await update_subtask(subtask_id=seeded.id, is_completed=True)
+
+    assert isinstance(updated, Subtask)
+    assert updated.id == seeded.id
+    assert updated.is_completed is True
+
+
+async def test_delete_subtask_returns_soft_deleted_subtask(
+    _inject_live_client: KanbanToolClient,
+    throwaway_task_id: int,
+) -> None:
+    """``delete_subtask`` returns the deleted ``Subtask`` with ``deleted_at``
+    populated — soft-delete semantics, mirroring ``delete_comment``. The
+    record stays server-side; the MCP-visible effect is "the subtask is
+    gone" because it stops appearing on the parent's ``subtasks`` array."""
+    seeded = await add_subtask(
+        task_id=throwaway_task_id,
+        name="kanbantool-mcp live integration: about to be deleted",
+    )
+    assert seeded.deleted_at is None  # sanity
+
+    deleted = await delete_subtask(subtask_id=seeded.id)
+
+    assert isinstance(deleted, Subtask)
+    assert deleted.id == seeded.id
+    # The soft-delete signal: ``deleted_at`` is now populated.
+    assert deleted.deleted_at is not None
+    assert isinstance(deleted.deleted_at, str)
+
+
+async def test_reorder_subtasks_returns_reordered_list(
+    _inject_live_client: KanbanToolClient,
+    throwaway_task_id: int,
+) -> None:
+    """``reorder_subtasks`` PUTs ``{task_id, ids: "comma,joined"}`` and
+    returns ``list[Subtask]`` in the new order. Seeds two subtasks, reverses
+    the order, asserts the response reflects it.
+
+    The wire-quirk worth guarding: the ``ids`` parameter is sent as a
+    comma-joined string — the tool joins on the way out. The integration
+    happy path is the safety net if that ever silently regresses to a JSON
+    array (the API would 422)."""
+    first = await add_subtask(
+        task_id=throwaway_task_id,
+        name="kanbantool-mcp live integration: reorder probe A",
+    )
+    second = await add_subtask(
+        task_id=throwaway_task_id,
+        name="kanbantool-mcp live integration: reorder probe B",
+    )
+
+    # The API requires the FULL set of subtask ids on the parent, in order.
+    # Pull the live list rather than assume only our two exist (defensive
+    # against any leftover state from a partial previous run).
+    current = await list_subtasks(throwaway_task_id)
+    current_ids = [s.id for s in current if s.deleted_at is None]
+    assert first.id in current_ids
+    assert second.id in current_ids
+    # Reverse to make the operation observable: whatever the current order,
+    # reversing produces a different one (unless there's only one subtask,
+    # which we've already prevented by seeding two).
+    new_order = list(reversed(current_ids))
+
+    result = await reorder_subtasks(task_id=throwaway_task_id, ids=new_order)
+
+    assert isinstance(result, list)
+    assert all(isinstance(s, Subtask) for s in result)
+    # The defining contract: the response order matches the requested order.
+    assert [s.id for s in result] == new_order

--- a/tests/integration/test_task_write_live.py
+++ b/tests/integration/test_task_write_live.py
@@ -1,0 +1,162 @@
+"""Live integration tests for the M2 task write tools.
+
+Coverage scope: ``create_task``, ``update_task``, ``move_task``, ``archive_task``
+end-to-end against the real Kanban Tool API. PR #121 covered M4/M5; the older
+M1/M2 surface was assumed-tested but the only live coverage was indirect (these
+tools were used as setup in other integration files, not contract-tested).
+With v1.0 committing to wire shapes via SEMVER.md, every tool needs at least
+one direct live happy-path that asserts the response shape.
+
+Each test creates the artifacts it needs on the first available board, runs
+the contract assertion, and archives the throwaway task on teardown. No
+orphans — even if assertions fail, ``contextlib.suppress(Exception)`` keeps
+cleanup from masking the real failure while still leaving the account clean
+in the common case.
+
+Assertions are SHAPE-not-VALUE: lock the typed model and the specific field
+the tool modifies (``update_task(name="X")`` → ``result.name == "X"``);
+don't lock unrelated drift-prone fields like timestamps or counts.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from collections.abc import AsyncIterator
+
+import pytest
+
+from kanbantool_mcp.client import KanbanToolClient
+from kanbantool_mcp.models import Task
+from kanbantool_mcp.server import (
+    archive_task,
+    create_task,
+    get_board,
+    get_task,
+    list_boards,
+    move_task,
+    update_task,
+)
+
+
+@pytest.fixture
+async def throwaway_task_id(_inject_live_client: KanbanToolClient) -> AsyncIterator[int]:
+    """Create a single-use task on the first available board, yield its id,
+    archive on teardown.
+
+    Each test gets its own task so concurrent or repeat runs don't trip over
+    each other's state. Archival on teardown leaves the test account clean."""
+    boards = await list_boards()
+    if not boards:
+        pytest.skip("test account has no boards; live tests need at least one.")
+    board_id = boards[0].id
+    task = await create_task(
+        name="kanbantool-mcp live integration: task-write scratch",
+        board_id=board_id,
+        description="Throwaway task created by tests/integration/test_task_write_live.py.",
+    )
+    try:
+        yield task.id
+    finally:
+        with contextlib.suppress(Exception):
+            await archive_task(task.id)
+
+
+async def test_create_task_returns_task_with_name_and_board(
+    _inject_live_client: KanbanToolClient,
+) -> None:
+    """``create_task`` POSTs and returns a ``Task`` whose ``name`` and
+    ``board_id`` echo the request. Cleans up by archiving the new task."""
+    boards = await list_boards()
+    if not boards:
+        pytest.skip("test account has no boards; live tests need at least one.")
+    board_id = boards[0].id
+
+    sentinel_name = "kanbantool-mcp live integration: create_task probe"
+    task = await create_task(
+        name=sentinel_name,
+        board_id=board_id,
+        description="Created by test_create_task_returns_task_with_name_and_board.",
+    )
+    try:
+        assert isinstance(task, Task)
+        assert task.id > 0
+        assert task.name == sentinel_name
+        assert task.board_id == board_id
+        # Newly-created tasks aren't archived; lock that derived flag here so
+        # ``archive_task`` later has a meaningful before/after.
+        assert task.is_archived is False
+    finally:
+        with contextlib.suppress(Exception):
+            await archive_task(task.id)
+
+
+async def test_update_task_sets_new_name(
+    _inject_live_client: KanbanToolClient,
+    throwaway_task_id: int,
+) -> None:
+    """``update_task`` PATCHes a partial body and returns a ``Task`` with the
+    updated field reflected on the response. Renaming is the cheapest write
+    that has an observable, type-stable effect."""
+    sentinel = "kanbantool-mcp live integration: renamed by update_task"
+
+    updated = await update_task(task_id=throwaway_task_id, name=sentinel)
+
+    assert isinstance(updated, Task)
+    assert updated.id == throwaway_task_id
+    assert updated.name == sentinel
+
+
+async def test_move_task_changes_lane(
+    _inject_live_client: KanbanToolClient,
+    throwaway_task_id: int,
+) -> None:
+    """``move_task`` PATCHes ``{column_id: ...}`` (wire ``workflow_stage_id``)
+    and returns a ``Task`` whose ``lane_id`` is the requested column. Picks
+    a column on the same board different from the task's current lane so the
+    move is observable, skipping if the board has only a single column."""
+    task = await get_task(throwaway_task_id)
+    assert task.board_id is not None
+    board = await get_board(task.board_id)
+    other_columns = [c for c in board.columns if c.id != task.lane_id]
+    if not other_columns:
+        pytest.skip("board has only one column; move_task needs at least two to be observable.")
+    target_column_id = other_columns[0].id
+
+    moved = await move_task(task_id=throwaway_task_id, column_id=target_column_id)
+
+    assert isinstance(moved, Task)
+    assert moved.id == throwaway_task_id
+    # ``column_id`` (caller-facing) → wire ``workflow_stage_id`` → model ``lane_id``.
+    assert moved.lane_id == target_column_id
+
+
+async def test_archive_task_sets_is_archived(
+    _inject_live_client: KanbanToolClient,
+) -> None:
+    """``archive_task`` PATCHes ``{_action: "archive"}`` and returns a ``Task``
+    with ``archived_at`` populated and the derived ``is_archived`` True.
+
+    This test does NOT use the ``throwaway_task_id`` fixture — that fixture's
+    teardown also archives, which would no-op on an already-archived task but
+    the contract assertion belongs in-test. Manage the throwaway lifecycle
+    inline."""
+    boards = await list_boards()
+    if not boards:
+        pytest.skip("test account has no boards; live tests need at least one.")
+    board_id = boards[0].id
+    fresh = await create_task(
+        name="kanbantool-mcp live integration: archive_task probe",
+        board_id=board_id,
+    )
+    # Sanity: a brand-new task is not archived.
+    assert fresh.is_archived is False
+
+    archived = await archive_task(fresh.id)
+
+    assert isinstance(archived, Task)
+    assert archived.id == fresh.id
+    # The defining bit of contract: ``archived_at`` populates and the derived
+    # ``is_archived`` flag flips.
+    assert archived.archived_at is not None
+    assert isinstance(archived.archived_at, str)
+    assert archived.is_archived is True


### PR DESCRIPTION
## Summary

PR #121 covered M4/M5 tools with live integration tests; the older M1/M2 write surface was assumed-tested but only had **indirect** live coverage (these tools were used as setup in other integration files, never contract-asserted). With v1.0 committing to wire shapes via SEMVER.md, every tool needs at least one direct live happy-path that locks the response shape.

This PR closes that gap with 9 new tests, one per uncovered M1/M2 write tool plus a promoted dedicated contract test for ``add_comment``.

## Tools covered

**``tests/integration/test_task_write_live.py`` — 4 tests:**
- ``create_task`` — POST returns ``Task`` with echoed ``name`` / ``board_id``, ``is_archived=False``
- ``update_task`` — PATCH partial body returns ``Task`` with the updated field
- ``move_task`` — PATCH ``column_id`` (wire ``workflow_stage_id``) returns ``Task`` with new ``lane_id``; uses ``get_board`` to discover an alternate column on the same board
- ``archive_task`` — PATCH ``{_action: "archive"}`` returns ``Task`` with ``archived_at`` populated and ``is_archived=True``

**``tests/integration/test_subtask_write_live.py`` — 4 tests:**
- ``add_subtask`` — POST flat body returns ``Subtask`` with linked ``task_id`` (regression guard for the no-Rails-envelope quirk)
- ``update_subtask`` — PATCH partial body returns ``Subtask`` with ``is_completed=True``
- ``delete_subtask`` — DELETE returns ``Subtask`` with ``deleted_at`` populated (soft-delete)
- ``reorder_subtasks`` — PUT ``ids`` (comma-joined string on the wire) returns reordered ``list[Subtask]`` matching the requested order

**``tests/integration/test_comment_delete_live.py`` — extended with 1 new test:**
- ``add_comment`` — POST returns ``Comment`` with ``content`` populated. Locks the M5 wire-field bugfix (body field is ``content``, not ``text`` — pre-fix every call 422'd ``Content can't be blank``). Previously ``add_comment`` was only used as setup for ``delete_comment`` with no direct contract assertion.

## Cleanup behaviour

All tests follow the existing pattern from ``test_time_tracker_live.py`` / ``test_custom_field_writes_live.py`` / ``test_comment_delete_live.py``:

- Each test creates its own throwaway task on the first available board (per-test fresh state — no cross-test ordering coupling).
- Per-test ``throwaway_task_id`` fixtures yield the id and archive the task in a ``finally`` block on teardown.
- All cleanup uses ``contextlib.suppress(Exception)`` so a teardown failure (e.g. transient 5xx) never masks the real assertion failure. The orphaned task would surface in the next test run's listing for manual sweep.
- Subtask tests rely on parent-archive cascade for cleanup — soft-deleting the parent removes subtasks from listings.
- ``add_comment`` test soft-deletes its created comment before parent archive, so the comment lands on the wire only briefly.
- ``archive_task`` is the only test that manages its own throwaway lifecycle inline (rather than using the fixture) — the fixture's teardown also archives, which would no-op on an already-archived task but fights for ownership of the contract assertion.

Assertions are SHAPE-not-VALUE throughout: typed model + the field the tool modifies. No specific timestamps, ids, or counts locked in.

## Test plan

- [x] ``uv run ruff check .`` passes
- [x] ``uv run ruff format --check .`` passes
- [x] ``uv run ty check src tests`` passes
- [x] ``uv run pytest`` passes (223 offline tests; integration excluded via existing ``--ignore=tests/integration``)
- [x] All 3 new/modified files import cleanly (``uv run python -c "import tests.integration.test_<file>"``)
- [x] All 10 integration tests collect cleanly under ``pytest tests/integration/``
- [ ] Live Integration workflow: trigger manually after merge to confirm contracts hold against the real account

🤖 Generated with [Claude Code](https://claude.com/claude-code)