### PR TITLE
docs(releasing): refine bump table with empirical evidence

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -64,18 +64,25 @@ release-please reads merge-commit titles on `main`. Pattern:
 |----------|-------|----------------------------|
 | `feat` | minor | `### Features` |
 | `fix` | patch | `### Bug Fixes` |
-| `perf` | none[*] | `### Performance Improvements` |
-| `refactor` | none[*] | `### Refactors` |
-| `docs` | none[*] | `### Documentation` |
-| `chore` | none | `### Miscellaneous Chores` |
-| `ci` / `build` / `test` | none | `### Continuous Integration` / `### Build System` / `### Tests` |
+| `perf` | patch | `### Performance Improvements` |
+| `docs` | patch | `### Documentation` |
+| `refactor` | none[*] | (omitted) |
+| `chore` | none | (omitted) |
+| `ci` / `build` / `test` | none | (omitted) |
 
-[*] release-please-action's default Python release-type only bumps on
-`feat:` (minor) and `fix:` (patch). Other types are recognised — they
-appear in the CHANGELOG when a release IS cut by an accompanying
-feat/fix in the same window — but on their own they don't trigger a
-release PR. If a stretch of commits is `refactor:`/`chore:`/`docs:`
-only and you want them tagged anyway, see "Forcing a release" below.
+[*] release-please-action's default Python release-type bumps on
+`feat:` (minor), `fix:` (patch), `docs:` (patch), and `perf:` (patch).
+The other types (`refactor:`, `chore:`, `ci:`, `build:`, `test:`) are
+recognised in commit messages but don't trigger a release PR. They also
+don't appear in CHANGELOG by default — if you want them recorded, lift
+them into a `fix:` (when behaviour-affecting) or use the `Release-As:`
+escape hatch (see "Forcing a release" below) to tag a milestone-style
+stretch.
+
+The `refactor: doesn't bump` rule is what tripped us cutting v0.7.0
+from M7 — three commits (`refactor:` + `test:` + `chore:`), zero auto-
+bump candidates. v0.7.0 ended up via a `Release-As:` footer on an
+empty commit. v0.7.1 then bumped automatically off a `docs:` PR.
 
 A `!` after the type or a `BREAKING CHANGE:` footer triggers a major
 bump (e.g. `feat!: drop py3.10` or `fix(server): swap error


### PR DESCRIPTION
## Summary
PR #125 over-corrected by marking \`docs:\`/\`perf:\` as \`none[*]\` (no auto-bump). Empirically the *automatic* v0.7.1 release PR opened off the single \`docs:\` commit in #125 — meaning \`docs:\` does in fact bump patch under release-please-action's default Python release-type. The original table had this right.

## What this PR changes
- Marks \`docs:\` and \`perf:\` as \"patch\" again (matches reality).
- Keeps \`refactor:\` as \"none\" — that one actually doesn't bump (verified during M7 / v0.7.0 cut).
- Adds a worked-example paragraph explaining the M7 sequence so the next maintainer doesn't have to re-derive when \`Release-As:\` is needed.

## Test plan
- [x] Markdown only.
- This is a \`docs:\` commit, so release-please will fold it into the existing v0.7.1 release PR rather than opening a new one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)