### PR TITLE
fix(client,exceptions): surface 422 detail when API uses flat message shape

### DIFF
--- a/src/kanbantool_mcp/client.py
+++ b/src/kanbantool_mcp/client.py
@@ -32,9 +32,19 @@ def _scrub_secrets(text: str) -> str:
 
 
 def _parse_field_errors(body: str) -> dict[str, list[str]]:
-    """Parse a 422 body's Rails-idiomatic ``{"errors": {field: [msg, ...]}}``
-    envelope. Returns an empty dict if the body is not JSON, the envelope is
-    missing, or the values are not the expected list-of-strings shape — the
+    """Parse a 422 body's error envelope. The Kanban Tool API uses two shapes
+    interchangeably depending on the endpoint and the failure mode:
+
+    1. Rails-idiomatic, per-field: ``{"errors": {field: [msg, ...]}}`` —
+       e.g. ``add_comment`` returns ``{"errors": {"content": ["can't be blank"]}}``.
+    2. Flat ``{"status": 422, "message": [msg, ...]}`` — e.g. ``create_task``
+       with a malformed enum like ``priority="high"`` returns
+       ``{"status": 422, "message": ["Priority is not a number"]}``. The flat
+       shape carries no field attribution; surfaced under a synthetic
+       ``"message"`` key so callers can still render it.
+
+    Returns an empty dict if the body is not JSON, neither envelope is
+    present, or the values are not the expected list-of-strings shape — the
     caller still surfaces the raw (scrubbed) excerpt in that case.
 
     Both message strings and field keys are run through ``_scrub_secrets`` so
@@ -48,18 +58,27 @@ def _parse_field_errors(body: str) -> dict[str, list[str]]:
     if not isinstance(decoded, dict):
         return {}
     errors = decoded.get("errors")
-    if not isinstance(errors, dict):
-        return {}
-    parsed: dict[str, list[str]] = {}
-    for field, messages in errors.items():
-        if not isinstance(field, str):
-            continue
-        scrubbed_field = _scrub_secrets(field)
-        if isinstance(messages, list):
-            parsed[scrubbed_field] = [_scrub_secrets(str(m)) for m in messages]
-        else:
-            parsed[scrubbed_field] = [_scrub_secrets(str(messages))]
-    return parsed
+    if isinstance(errors, dict):
+        parsed: dict[str, list[str]] = {}
+        for field, messages in errors.items():
+            if not isinstance(field, str):
+                continue
+            scrubbed_field = _scrub_secrets(field)
+            if isinstance(messages, list):
+                parsed[scrubbed_field] = [_scrub_secrets(str(m)) for m in messages]
+            else:
+                parsed[scrubbed_field] = [_scrub_secrets(str(messages))]
+        if parsed:
+            return parsed
+    # Flat ``{"status": 422, "message": [...]}`` shape — coerce ``message`` into
+    # a single-key dict so the renderer gives the LLM something concrete to
+    # read, even without per-field attribution.
+    flat_messages = decoded.get("message")
+    if isinstance(flat_messages, list) and flat_messages:
+        return {"message": [_scrub_secrets(str(m)) for m in flat_messages]}
+    if isinstance(flat_messages, str) and flat_messages:
+        return {"message": [_scrub_secrets(flat_messages)]}
+    return {}
 
 
 def _raise_for_status(response: httpx.Response, method: str, path: str) -> None:

--- a/src/kanbantool_mcp/exceptions.py
+++ b/src/kanbantool_mcp/exceptions.py
@@ -53,16 +53,24 @@ class KanbanToolValidationError(KanbanToolHTTPError):
 
     def __str__(self) -> str:
         base = super().__str__()
-        if not self.field_errors:
-            return base
-        rendered = "; ".join(
-            f"{field}: {', '.join(messages)}" for field, messages in self.field_errors.items()
-        )
-        # Belt-and-suspenders: scrub again here so direct construction of the
-        # exception with un-scrubbed input cannot leak a bearer token through
-        # the rendered string. The client construction path scrubs on the way
-        # in; this is a second line of defense for callers that bypass it.
-        return _BEARER_PATTERN.sub("Bearer ***", f"{base} {rendered}")
+        if self.field_errors:
+            rendered = "; ".join(
+                f"{field}: {', '.join(messages)}" for field, messages in self.field_errors.items()
+            )
+            # Belt-and-suspenders: scrub again here so direct construction of
+            # the exception with un-scrubbed input cannot leak a bearer token
+            # through the rendered string. The client construction path scrubs
+            # on the way in; this is a second line of defense for callers that
+            # bypass it.
+            return _BEARER_PATTERN.sub("Bearer ***", f"{base} {rendered}")
+        # Fall back to the (already-scrubbed) excerpt when the API returned a
+        # 422 body whose shape ``_parse_field_errors`` doesn't recognise. The
+        # excerpt is the LLM's only signal in that case — surfacing just the
+        # bare "rejected as invalid (422)" message strands the caller with no
+        # information about what went wrong.
+        if self.body_excerpt:
+            return _BEARER_PATTERN.sub("Bearer ***", f"{base} body: {self.body_excerpt}")
+        return base
 
 
 class KanbanToolTransportError(KanbanToolError):

--- a/tests/test_create_task.py
+++ b/tests/test_create_task.py
@@ -211,6 +211,73 @@ async def test_create_task_422_non_json_body_falls_back(
     assert err.status_code == 422
     assert err.field_errors == {}
     assert "<html>" in err.body_excerpt
+    # Surface the body excerpt in the rendered string when field_errors is
+    # empty, so the LLM has a signal to debug from.
+    rendered = str(err)
+    assert "<html>" in rendered
+
+
+async def test_create_task_422_flat_message_shape_parsed(
+    _inject_client: KanbanToolClient,
+) -> None:
+    """Some endpoints (e.g. ``create_task`` with malformed enums like
+    ``priority="high"``) return a flat ``{"status": 422, "message": [...]}``
+    body instead of the Rails-idiomatic ``{"errors": {field: [msg, ...]}}``
+    envelope. The flat shape carries no per-field attribution but still has
+    actionable detail; surface it under a synthetic ``"message"`` key so the
+    rendered ``__str__`` shows the LLM what actually went wrong.
+
+    Live wire shape (verified against rynbou.kanbantool.com):
+        POST /tasks.json with priority="high" →
+        ``{"status":422,"message":["Priority is not a number"]}``"""
+    with respx.mock() as router:
+        router.post(TASKS_URL).mock(
+            return_value=httpx.Response(
+                422, json={"status": 422, "message": ["Priority is not a number"]}
+            ),
+        )
+        with pytest.raises(KanbanToolValidationError) as exc_info:
+            await create_task(name="x", board_id=7)
+
+    err = exc_info.value
+    assert err.status_code == 422
+    assert err.field_errors == {"message": ["Priority is not a number"]}
+    rendered = str(err)
+    assert "Priority is not a number" in rendered
+
+
+async def test_create_task_422_flat_message_string_form(
+    _inject_client: KanbanToolClient,
+) -> None:
+    """Tolerate the ``message`` value being a single string instead of a list
+    — observed on at least one endpoint variant; treat as a one-element list."""
+    with respx.mock() as router:
+        router.post(TASKS_URL).mock(
+            return_value=httpx.Response(422, json={"status": 422, "message": "Tags is malformed"}),
+        )
+        with pytest.raises(KanbanToolValidationError) as exc_info:
+            await create_task(name="x", board_id=7)
+    assert exc_info.value.field_errors == {"message": ["Tags is malformed"]}
+
+
+async def test_create_task_422_unknown_shape_surfaces_body_excerpt(
+    _inject_client: KanbanToolClient,
+) -> None:
+    """A 422 with a JSON body that matches NEITHER known shape leaves
+    ``field_errors`` empty but the rendered ``__str__`` must still surface
+    the (scrubbed) body so the LLM has something to debug from. Pre-fix the
+    LLM only saw 'rejected as invalid (422)' with zero detail."""
+    with respx.mock() as router:
+        router.post(TASKS_URL).mock(
+            return_value=httpx.Response(422, json={"unexpected_envelope": True, "code": "X42"}),
+        )
+        with pytest.raises(KanbanToolValidationError) as exc_info:
+            await create_task(name="x", board_id=7)
+
+    err = exc_info.value
+    assert err.field_errors == {}
+    rendered = str(err)
+    assert "unexpected_envelope" in rendered or "X42" in rendered
 
 
 async def test_create_task_422_body_scrubs_bearer_token(


### PR DESCRIPTION
## Summary

Closes #131.

The Kanban Tool API uses two distinct 422 envelopes interchangeably depending on the endpoint and failure mode:

1. Rails-idiomatic: \`{\"errors\": {field: [msg, ...]}}\`
2. Flat: \`{\"status\": 422, \"message\": [msg, ...]}\`

Pre-fix, \`_parse_field_errors\` only handled (1). Endpoints returning (2) — e.g. \`create_task\` with a malformed enum like \`priority=\"high\"\` — produced an empty \`field_errors\` dict, and \`KanbanToolValidationError.__str__\` strips \`body_excerpt\` when field_errors is empty. Net result: the LLM saw only

> Kanban Tool API rejected POST tasks.json as invalid (422).

with zero signal about WHAT was invalid. Hit while dogfooding via ryzic on a real \`priority=\"high\"\` call.

## Changes

- \`_parse_field_errors\` now recognises the flat shape and lifts the \`message\` value (list or string) into a synthetic \`\"message\"\` key on field_errors.
- \`KanbanToolValidationError.__str__\` falls back to the (already-scrubbed) body_excerpt when field_errors is still empty — the LLM gets SOME signal even on shapes neither envelope recognises.

## Tests

- \`test_create_task_422_flat_message_shape_parsed\` — live wire shape \`{\"status\":422,\"message\":[\"Priority is not a number\"]}\`
- \`test_create_task_422_flat_message_string_form\` — tolerate string form of \`message\`
- \`test_create_task_422_unknown_shape_surfaces_body_excerpt\` — regression for the \`__str__\` fallback
- Existing \`test_create_task_422_non_json_body_falls_back\` updated to assert the body excerpt appears in the rendered string

## Test plan

- [x] \`uv run ruff check .\` — clean
- [x] \`uv run ruff format --check .\` — clean
- [x] \`uv run ty check\` — clean
- [x] \`uv run pytest -q\` — 228/228 passing
- [x] Bearer-token scrubbing still applies on both new code paths