### PR TITLE
ci(release): sync from uv.lock --frozen before uv build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,14 @@ jobs:
           # input ``tag`` so the build artifacts match the right version.
           ref: ${{ github.event.inputs.tag || github.ref }}
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+      # Sync from ``uv.lock`` (no resolver pass) before building so the wheel
+      # that ships to PyPI is built against exactly the dependency set we
+      # tested against. Without this, ``uv build`` lets the resolver pick
+      # whatever satisfies the loose constraints in ``pyproject.toml`` at
+      # tag-push time, which can drift from CI. CI deliberately stays on the
+      # unfrozen path — that's how we catch loose-bound regressions before
+      # they ship — so ``--frozen`` only goes here.
+      - run: uv sync --frozen --no-dev
       - run: uv build
       - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
       - uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3.0.0


### PR DESCRIPTION
## Summary

`release.yml` currently goes straight from `setup-uv` to `uv build` with no intermediate sync. `uv build` triggers a fresh resolver pass behind the scenes, so the wheel that ships to PyPI is built against whatever the resolver picks at tag-push time — not against `uv.lock`. Small but real provenance gap.

This PR adds `uv sync --frozen --no-dev` before `uv build`. `--frozen` refuses to touch `uv.lock`; `--no-dev` keeps build/test deps out of the runtime graph.

CI deliberately stays on the **unfrozen** path — the resolver running fresh on every PR is how we catch loose-bound regressions before they ship. `--frozen` only goes in `release.yml`. (FOSS audit Tier 2 #16)

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` — valid
- [x] `uv sync --frozen --no-dev` + `uv run uv build` locally produces clean wheel + sdist for v0.7.2
- [x] Existing CI suite still green (`ruff check`, `ruff format --check`, `ty check`, `pytest -q` — 228 passed)
- [ ] On the next release tag, wheel build picks up exact pins from `uv.lock` (verifiable from PyPI metadata after release)