### PR TITLE
docs(readme): per-client links table, roadmap pointer, response-time line

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ Kanban Tool holds the authoritative state of your boards, tasks, and workflow �
 
 **Alpha, approaching v1.0.** The 25-tool surface is settled and exercised against a real Kanban Tool account via the `Live Integration` workflow. Pre-1.0 means the surface may still evolve based on real-world feedback — pin a specific version if you need stability across upgrades. See [SEMVER.md](SEMVER.md) for the v1.0 stability commitment (which surfaces are stable, which are not, deprecation policy).
 
+## Roadmap & support
+
+Where the project is going: see the [open milestones](https://github.com/VeryLongOrgNameSuchWow/kanbantool-mcp/milestones). Larger workstreams are tagged with the [`epic`](https://github.com/VeryLongOrgNameSuchWow/kanbantool-mcp/issues?q=is%3Aissue+is%3Aopen+label%3Aepic) label.
+
+Maintainer is best-effort and typically responds to issues and PRs within ~a week. If something is blocking you and the silence is longer, a polite bump on the thread is welcome.
+
 ## What this looks like
 
 A short illustrative session — the shape of an interaction, not literal terminal output:
@@ -45,6 +51,19 @@ Two environment variables, regardless of how you launch the server:
 | --- | --- | --- |
 | `KANBANTOOL_DOMAIN` | Your account's subdomain prefix — `acme` for `https://acme.kanbantool.com`. | The URL you log into. |
 | `KANBANTOOL_API_TOKEN` | Bearer token for the Kanban Tool API v3. | Profile -> API tokens in your Kanban Tool account. |
+
+### Wiring it into your client
+
+The `mcp.json` payload is the same across clients; only the file location and UI for editing it differ. See your client's docs for where the config lives:
+
+| Client | Setup docs |
+| --- | --- |
+| Claude Desktop | <https://modelcontextprotocol.io/quickstart/user> |
+| Cursor | <https://cursor.com/docs/mcp> |
+| Cline | <https://docs.cline.bot/mcp/configuring-mcp-servers> |
+| Continue | <https://docs.continue.dev/customize/deep-dives/mcp> |
+
+Drop one of the snippets below into wherever your client expects MCP server configuration.
 
 ### From git (current)
 


### PR DESCRIPTION
## Summary

Three small README additions for discoverability and expectation-setting.

- **Per-client setup-docs table** inside Install (`### Wiring it into your client`). 4 rows: Claude Desktop / Cursor / Cline / Continue, each linking to the client's official MCP-setup page. Shared `mcp.json` snippet body sits below. Deliberately omits per-OS config-file paths — those drift and per-client docs are the right place to maintain them.
- **`## Roadmap & support`** after Status. One line pointing at the open [milestones](https://github.com/VeryLongOrgNameSuchWow/kanbantool-mcp/milestones) and the [`epic`](https://github.com/VeryLongOrgNameSuchWow/kanbantool-mcp/issues?q=is%3Aissue+is%3Aopen+label%3Aepic) label as the way to see project direction.
- **Response-time line** in the same section: maintainer responds best-effort within ~a week, polite bump welcome if longer. Honest expectation-setting for a small open-source project.

Resolves audit items: **Tier 2 #19** (per-client links) + **Tier 2 #18** (roadmap pointer) + **Tier 2 #20** (response-time line).

### Doc URLs

I verified all four client doc links return 200 and confirmed each page actually documents MCP server setup (not a generic landing page). Cursor previously lived at `docs.cursor.com` but redirects to `cursor.com/docs/mcp` — used the canonical URL.

### Follow-up

The `epic` label is referenced in this PR but does not yet exist on the repo. I'll file a separate issue (audit Tier 2 follow-up) suggesting it be applied to existing epic-shaped issues so the link surfaces something meaningful. The link is fine in the meantime — it just renders an empty list until the label is created and applied.

## Test plan

- [x] `uv run ruff check`
- [x] `uv run ruff format --check`
- [x] `uv run ty check`
- [x] `uv run pytest -q` (228 passed)
- [x] All 4 client doc URLs return 200 and are MCP-specific pages (not generic docs landing)
- [x] README diff renders cleanly mentally; tables format correctly
- [ ] Maintainer: skim the rendered README on this branch and confirm the new section flow makes sense