### PR TITLE
feat(server): KANBANTOOL_READ_ONLY env var (read-only mode)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Kanban Tool holds the authoritative state of your boards, tasks, and workflow �
 
 ## Status
 
-**Alpha, approaching v1.0.** The 25-tool surface is settled and exercised against a real Kanban Tool account via the `Live Integration` workflow. Pre-1.0 means the surface may still evolve based on real-world feedback — pin a specific version if you need stability across upgrades. See [SEMVER.md](SEMVER.md) for the v1.0 stability commitment (which surfaces are stable, which are not, deprecation policy).
+**Alpha, approaching v1.0.** The 26-tool surface is settled and exercised against a real Kanban Tool account via the `Live Integration` workflow. Pre-1.0 means the surface may still evolve based on real-world feedback — pin a specific version if you need stability across upgrades. See [SEMVER.md](SEMVER.md) for the v1.0 stability commitment (which surfaces are stable, which are not, deprecation policy).
 
 ## Roadmap & support
 
@@ -45,12 +45,13 @@ Longer end-to-end walkthroughs (with realistic JSON request/response shapes) liv
 
 ### Configuration
 
-Two environment variables, regardless of how you launch the server:
-
 | Variable | What it is | Where to get it |
 | --- | --- | --- |
 | `KANBANTOOL_DOMAIN` | Your account's subdomain prefix — `acme` for `https://acme.kanbantool.com`. | The URL you log into. |
 | `KANBANTOOL_API_TOKEN` | Bearer token for the Kanban Tool API v3. | Profile -> API tokens in your Kanban Tool account. |
+| `KANBANTOOL_READ_ONLY` | Optional. Set to `1` (or `true`/`yes`/`on`) to register only the 11 read-class tools — see [Read-only mode](#read-only-mode) below. | — |
+
+The first two are required; the third is optional and unset by default.
 
 ### Wiring it into your client
 
@@ -160,6 +161,25 @@ KANBANTOOL_DOMAIN=your-account \
   KANBANTOOL_API_TOKEN=your-token \
   uvx kanbantool-mcp
 ```
+
+### Read-only mode
+
+Set `KANBANTOOL_READ_ONLY=1` (or `true`/`yes`/`on`) to register **only the 11 read-class tools**. Any value outside that set, including the empty string, leaves the full 26-tool surface intact.
+
+Use this when you want to give an LLM safe access to your boards — search, browse, summarise, answer questions about state — without giving it the ability to create, update, move, archive, comment on, or delete anything. The write tools simply don't appear in the tool list, so the model can't call them even if it tried.
+
+**Read-class tools (always registered):**
+
+```
+list_boards            get_board                       get_user
+search_tasks           list_board_collaborators        whoami
+get_task               list_custom_field_definitions   list_my_timers
+recent_changes         list_subtasks
+```
+
+**Write tools (suppressed when read-only):** `create_task`, `update_task`, `move_task`, `archive_task`, `set_custom_field`, `add_comment`, `delete_comment`, `add_subtask`, `update_subtask`, `delete_subtask`, `reorder_subtasks`, `start_timer`, `stop_timer`, `delete_timer`.
+
+The transport smoke test `ping` is always registered regardless of mode.
 
 ### Verify your install
 

--- a/SEMVER.md
+++ b/SEMVER.md
@@ -47,9 +47,11 @@ Breaking any of them requires a major bump.
    the contract. Removing or renaming them is a major. The MRO between
    them is also stable — anyone catching `KanbanToolHTTPError` should
    continue to catch `KanbanToolValidationError` (a subclass) too.
-5. **Environment variable names.** `KANBANTOOL_DOMAIN` and
-   `KANBANTOOL_API_TOKEN` are the configuration contract. Renaming or
-   adding a required env var is a major.
+5. **Environment variable names.** `KANBANTOOL_DOMAIN`,
+   `KANBANTOOL_API_TOKEN`, and `KANBANTOOL_READ_ONLY` are the
+   configuration contract. Renaming an existing env var, or adding a
+   new *required* one, is a major bump. Adding a new *optional* env
+   var (defaulting to current behaviour) is a minor.
 
 ### Unstable surfaces
 

--- a/src/kanbantool_mcp/config.py
+++ b/src/kanbantool_mcp/config.py
@@ -5,6 +5,22 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass, field
 
+# Accepted truthy spellings for boolean env vars. Kept narrow on purpose:
+# anything outside the set is treated as false so a typo'd value (e.g.
+# ``KANBANTOOL_READ_ONLY=ture``) fails closed (writes still gated) rather
+# than silently disabling the flag. Used for ``KANBANTOOL_READ_ONLY`` (and
+# any future boolean env vars).
+_TRUTHY_ENV_VALUES = frozenset({"1", "true", "yes", "on"})
+
+
+def env_flag(name: str) -> bool:
+    """Parse a boolean env var with the project-wide truthy convention.
+
+    Returns ``True`` only when the value (case-insensitive, surrounding
+    whitespace stripped) is one of ``1``/``true``/``yes``/``on``. Anything
+    else — unset, empty, ``0``, ``false``, a typo — returns ``False``."""
+    return os.environ.get(name, "").strip().lower() in _TRUTHY_ENV_VALUES
+
 
 @dataclass(frozen=True)
 class Config:

--- a/src/kanbantool_mcp/config.py
+++ b/src/kanbantool_mcp/config.py
@@ -5,20 +5,12 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass, field
 
-# Accepted truthy spellings for boolean env vars. Kept narrow on purpose:
-# anything outside the set is treated as false so a typo'd value (e.g.
-# ``KANBANTOOL_READ_ONLY=ture``) fails closed (writes still gated) rather
-# than silently disabling the flag. Used for ``KANBANTOOL_READ_ONLY`` (and
-# any future boolean env vars).
+# Narrow on purpose so typo'd values (``ture``) fail closed.
 _TRUTHY_ENV_VALUES = frozenset({"1", "true", "yes", "on"})
 
 
 def env_flag(name: str) -> bool:
-    """Parse a boolean env var with the project-wide truthy convention.
-
-    Returns ``True`` only when the value (case-insensitive, surrounding
-    whitespace stripped) is one of ``1``/``true``/``yes``/``on``. Anything
-    else — unset, empty, ``0``, ``false``, a typo — returns ``False``."""
+    """Parse a boolean env var with the project-wide truthy convention."""
     return os.environ.get(name, "").strip().lower() in _TRUTHY_ENV_VALUES
 
 

--- a/src/kanbantool_mcp/server.py
+++ b/src/kanbantool_mcp/server.py
@@ -94,16 +94,8 @@ READ_ONLY_TOOLS: frozenset[str] = frozenset(
 
 mcp: FastMCP = FastMCP("kanbantool-mcp", instructions=_SERVER_INSTRUCTIONS)
 
-# ``KANBANTOOL_READ_ONLY=1`` (or true/yes/on) gates every state-mutating tool —
-# create/update/move/archive/delete + subtask write tools + timer start/stop/delete +
-# set_custom_field + add/delete_comment. The 11 names in ``READ_ONLY_TOOLS`` stay
-# registered. ``ping`` is always registered (transport smoke test, no API calls).
-#
-# Read at import time, not inside ``Config.from_env()``: tool registration
-# happens during decorator evaluation at import, so the gate must be settled
-# before the @mcp.tool decorators run. ``Config.from_env()`` is lazy and
-# requires KANBANTOOL_API_TOKEN to be set, which is the wrong precondition for
-# choosing how to register tools.
+# Read at import time, not via Config.from_env(): @mcp.tool decorators
+# evaluate at import, so the gate must be settled before they run.
 _READ_ONLY_MODE = env_flag("KANBANTOOL_READ_ONLY")
 
 

--- a/src/kanbantool_mcp/server.py
+++ b/src/kanbantool_mcp/server.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Annotated, Any, Generic, Literal, TypeVar
@@ -10,7 +11,7 @@ from fastmcp import FastMCP
 from pydantic import BaseModel, Field, TypeAdapter, ValidationError, validate_call
 
 from .client import KanbanToolClient
-from .config import Config
+from .config import Config, env_flag
 from .exceptions import KanbanToolHTTPError
 from .models import (
     Board,
@@ -73,7 +74,56 @@ subclasses (`KanbanToolPermissionError` for 401/403, \
 `KanbanToolHTTPError` otherwise, `KanbanToolTransportError` on transport \
 failure)."""
 
+# Names of the 11 read-class tools — the read/write split in one place,
+# not implicit in decorator usage below.
+READ_ONLY_TOOLS: frozenset[str] = frozenset(
+    {
+        "list_boards",
+        "get_board",
+        "search_tasks",
+        "get_task",
+        "recent_changes",
+        "whoami",
+        "get_user",
+        "list_board_collaborators",
+        "list_custom_field_definitions",
+        "list_subtasks",
+        "list_my_timers",
+    }
+)
+
 mcp: FastMCP = FastMCP("kanbantool-mcp", instructions=_SERVER_INSTRUCTIONS)
+
+# ``KANBANTOOL_READ_ONLY=1`` (or true/yes/on) gates every state-mutating tool —
+# create/update/move/archive/delete + subtask write tools + timer start/stop/delete +
+# set_custom_field + add/delete_comment. The 11 names in ``READ_ONLY_TOOLS`` stay
+# registered. ``ping`` is always registered (transport smoke test, no API calls).
+#
+# Read at import time, not inside ``Config.from_env()``: tool registration
+# happens during decorator evaluation at import, so the gate must be settled
+# before the @mcp.tool decorators run. ``Config.from_env()`` is lazy and
+# requires KANBANTOOL_API_TOKEN to be set, which is the wrong precondition for
+# choosing how to register tools.
+_READ_ONLY_MODE = env_flag("KANBANTOOL_READ_ONLY")
+
+
+def _write_tool(**tool_kwargs: Any) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Decorator factory for write tools: forwards ``tool_kwargs`` to
+    ``@mcp.tool(**tool_kwargs)`` in default mode, and is a no-op in read-only
+    mode (returns the bare function so tests and in-process callers can still
+    invoke it directly).
+
+    Use as ``@_write_tool(annotations=..., output_schema=...)`` on every
+    state-mutating tool — same kwargs as ``@mcp.tool``, just gated by
+    ``KANBANTOOL_READ_ONLY``."""
+
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        if _READ_ONLY_MODE:
+            return func
+        return mcp.tool(**tool_kwargs)(func)
+
+    return decorator
+
 
 _ModelT = TypeVar("_ModelT", bound=BaseModel)
 
@@ -440,7 +490,7 @@ async def search_tasks(
     return _decode_list(Task, raw, label="search")
 
 
-@mcp.tool(annotations=_WRITE, output_schema=_output_schema(Task))
+@_write_tool(annotations=_WRITE, output_schema=_output_schema(Task))
 @validate_call
 async def create_task(
     name: str,
@@ -564,7 +614,7 @@ async def _patch_task(
     return _decode(Task, data, label="task")
 
 
-@mcp.tool(annotations=_WRITE, output_schema=_output_schema(Task))
+@_write_tool(annotations=_WRITE, output_schema=_output_schema(Task))
 @validate_call
 async def update_task(
     task_id: Annotated[int, Field(ge=1)],
@@ -615,7 +665,7 @@ async def update_task(
     )
 
 
-@mcp.tool(annotations=_WRITE, output_schema=_output_schema(Task))
+@_write_tool(annotations=_WRITE, output_schema=_output_schema(Task))
 @validate_call
 async def move_task(
     task_id: Annotated[int, Field(ge=1)],
@@ -646,7 +696,7 @@ async def move_task(
     )
 
 
-@mcp.tool(annotations=_WRITE_DESTRUCTIVE_IDEMPOTENT, output_schema=_output_schema(Task))
+@_write_tool(annotations=_WRITE_DESTRUCTIVE_IDEMPOTENT, output_schema=_output_schema(Task))
 @validate_call
 async def archive_task(task_id: Annotated[int, Field(ge=1)]) -> Task:
     """Archive a task. Returns the updated ``Task`` (caller can confirm
@@ -668,7 +718,7 @@ async def archive_task(task_id: Annotated[int, Field(ge=1)]) -> Task:
     return _decode(Task, data, label="task")
 
 
-@mcp.tool(annotations=_WRITE_IDEMPOTENT, output_schema=_output_schema(Task))
+@_write_tool(annotations=_WRITE_IDEMPOTENT, output_schema=_output_schema(Task))
 @validate_call
 async def set_custom_field(
     task_id: Annotated[int, Field(ge=1)],
@@ -702,7 +752,7 @@ async def set_custom_field(
     return _decode(Task, data, label="task")
 
 
-@mcp.tool(annotations=_WRITE, output_schema=_output_schema(Comment))
+@_write_tool(annotations=_WRITE, output_schema=_output_schema(Comment))
 @validate_call
 async def add_comment(task_id: Annotated[int, Field(ge=1)], content: str) -> Comment:
     """Post a comment on a task. Returns the created ``Comment`` with id,
@@ -716,7 +766,7 @@ async def add_comment(task_id: Annotated[int, Field(ge=1)], content: str) -> Com
     return _decode(Comment, data, label="comment")
 
 
-@mcp.tool(annotations=_WRITE_DESTRUCTIVE, output_schema=_output_schema(Comment))
+@_write_tool(annotations=_WRITE_DESTRUCTIVE, output_schema=_output_schema(Comment))
 @validate_call
 async def delete_comment(
     task_id: Annotated[int, Field(ge=1)],
@@ -752,7 +802,7 @@ async def list_subtasks(task_id: Annotated[int, Field(ge=1)]) -> list[Subtask]:
     return task.subtasks
 
 
-@mcp.tool(annotations=_WRITE, output_schema=_output_schema(Subtask))
+@_write_tool(annotations=_WRITE, output_schema=_output_schema(Subtask))
 @validate_call
 async def add_subtask(task_id: Annotated[int, Field(ge=1)], name: str) -> Subtask:
     """Add a subtask to a task. Returns the created ``Subtask``.
@@ -774,7 +824,7 @@ async def add_subtask(task_id: Annotated[int, Field(ge=1)], name: str) -> Subtas
     return _decode(Subtask, data, label="subtask")
 
 
-@mcp.tool(annotations=_WRITE, output_schema=_output_schema(Subtask))
+@_write_tool(annotations=_WRITE, output_schema=_output_schema(Subtask))
 @validate_call
 async def update_subtask(
     subtask_id: Annotated[int, Field(ge=1)],
@@ -812,7 +862,7 @@ async def update_subtask(
     return _decode(Subtask, data, label="subtask")
 
 
-@mcp.tool(annotations=_WRITE_DESTRUCTIVE, output_schema=_output_schema(Subtask))
+@_write_tool(annotations=_WRITE_DESTRUCTIVE, output_schema=_output_schema(Subtask))
 @validate_call
 async def delete_subtask(subtask_id: Annotated[int, Field(ge=1)]) -> Subtask:
     """Delete a subtask (soft-delete). Returns the deleted ``Subtask`` with
@@ -832,7 +882,7 @@ async def delete_subtask(subtask_id: Annotated[int, Field(ge=1)]) -> Subtask:
     return _decode(Subtask, data, label="subtask")
 
 
-@mcp.tool(annotations=_WRITE_IDEMPOTENT, output_schema=_output_schema(list[Subtask]))
+@_write_tool(annotations=_WRITE_IDEMPOTENT, output_schema=_output_schema(list[Subtask]))
 @validate_call
 async def reorder_subtasks(
     task_id: Annotated[int, Field(ge=1)],
@@ -871,7 +921,7 @@ async def reorder_subtasks(
     return _decode_list(Subtask, data, label="subtasks")
 
 
-@mcp.tool(annotations=_WRITE, output_schema=_output_schema(TimeTracker))
+@_write_tool(annotations=_WRITE, output_schema=_output_schema(TimeTracker))
 @validate_call
 async def start_timer(
     task_id: Annotated[int, Field(ge=1)],
@@ -921,7 +971,7 @@ async def start_timer(
     return _decode(TimeTracker, data, label="time tracker")
 
 
-@mcp.tool(annotations=_WRITE, output_schema=_output_schema(TimeTracker))
+@_write_tool(annotations=_WRITE, output_schema=_output_schema(TimeTracker))
 @validate_call
 async def stop_timer(
     timer_id: Annotated[int, Field(ge=1)],
@@ -952,7 +1002,7 @@ async def stop_timer(
     return _decode(TimeTracker, data, label="time tracker")
 
 
-@mcp.tool(annotations=_WRITE_DESTRUCTIVE)
+@_write_tool(annotations=_WRITE_DESTRUCTIVE)
 @validate_call
 async def delete_timer(timer_id: Annotated[int, Field(ge=1)]) -> None:
     """Delete a time tracker entirely (e.g. cancel a mistakenly-started

--- a/tests/test_read_only_mode.py
+++ b/tests/test_read_only_mode.py
@@ -4,7 +4,7 @@ The flag is read at module import time (decorators evaluate during import,
 so the read/write split must be settled by then). Each test reloads the
 ``server`` module under a fresh env to assert a specific registration
 outcome, then reloads it back to default state to keep the rest of the
-suite working against the full 25-tool surface.
+suite working against the full 26-tool surface.
 """
 
 from __future__ import annotations
@@ -68,10 +68,12 @@ def test_read_only_constant_lists_eleven_tools() -> None:
 
 
 def test_default_mode_registers_full_tool_surface() -> None:
-    # Sanity check on the default-state baseline: 11 reads + 14 writes + ping.
-    assert _registered_tool_names() >= EXPECTED_READ_ONLY_TOOLS
-    assert "create_task" in _registered_tool_names()
-    assert "delete_subtask" in _registered_tool_names()
+    # Locks the canonical 26-tool count (11 reads + 14 writes + ping).
+    names = _registered_tool_names()
+    assert len(names) == 26
+    assert names >= EXPECTED_READ_ONLY_TOOLS
+    assert "create_task" in names
+    assert "delete_subtask" in names
 
 
 @pytest.mark.parametrize("flag_value", ["1", "true", "yes", "on", "TRUE", "On"])

--- a/tests/test_read_only_mode.py
+++ b/tests/test_read_only_mode.py
@@ -1,0 +1,116 @@
+"""Tests for the ``KANBANTOOL_READ_ONLY`` env var.
+
+The flag is read at module import time (decorators evaluate during import,
+so the read/write split must be settled by then). Each test reloads the
+``server`` module under a fresh env to assert a specific registration
+outcome, then reloads it back to default state to keep the rest of the
+suite working against the full 25-tool surface.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+
+import pytest
+
+from kanbantool_mcp import config as config_module
+from kanbantool_mcp import server as server_module
+
+# The 11 read-class tools, mirrors ``server.READ_ONLY_TOOLS``. Spelled out
+# inline here as a check on the constant — if the constant drifts, this set
+# stays correct (and the assertion below catches the drift).
+EXPECTED_READ_TOOLS = frozenset(
+    {
+        "list_boards",
+        "get_board",
+        "search_tasks",
+        "get_task",
+        "recent_changes",
+        "whoami",
+        "get_user",
+        "list_board_collaborators",
+        "list_custom_field_definitions",
+        "list_subtasks",
+        "list_my_timers",
+    }
+)
+
+# ``ping`` is always registered (transport smoke test, no API calls).
+EXPECTED_READ_ONLY_TOOLS = EXPECTED_READ_TOOLS | {"ping"}
+
+
+def _registered_tool_names() -> set[str]:
+    tools = asyncio.run(server_module.mcp.list_tools())
+    return {t.name for t in tools}
+
+
+@pytest.fixture
+def reload_server_module(monkeypatch: pytest.MonkeyPatch):
+    """Yield a callable that reloads ``server`` (and its config dependency)
+    so a freshly-set ``KANBANTOOL_READ_ONLY`` value takes effect for the
+    decorators. After the test, reload one more time with the flag cleared
+    so the default-mode test fixtures see the full tool surface."""
+
+    def _reload() -> None:
+        importlib.reload(config_module)
+        importlib.reload(server_module)
+
+    yield _reload
+
+    monkeypatch.delenv("KANBANTOOL_READ_ONLY", raising=False)
+    _reload()
+
+
+def test_read_only_constant_lists_eleven_tools() -> None:
+    assert len(server_module.READ_ONLY_TOOLS) == 11
+    assert server_module.READ_ONLY_TOOLS == EXPECTED_READ_TOOLS
+
+
+def test_default_mode_registers_full_tool_surface() -> None:
+    # Sanity check on the default-state baseline: 11 reads + 14 writes + ping.
+    assert _registered_tool_names() >= EXPECTED_READ_ONLY_TOOLS
+    assert "create_task" in _registered_tool_names()
+    assert "delete_subtask" in _registered_tool_names()
+
+
+@pytest.mark.parametrize("flag_value", ["1", "true", "yes", "on", "TRUE", "On"])
+def test_read_only_mode_registers_only_read_tools(
+    monkeypatch: pytest.MonkeyPatch, reload_server_module, flag_value: str
+) -> None:
+    monkeypatch.setenv("KANBANTOOL_READ_ONLY", flag_value)
+    reload_server_module()
+
+    names = _registered_tool_names()
+    assert names == EXPECTED_READ_ONLY_TOOLS
+    assert len(names) == 12  # 11 read tools + ping
+
+
+@pytest.mark.parametrize("flag_value", ["", "0", "false", "no", "off", "ture"])
+def test_falsey_or_unrecognised_values_keep_writes_enabled(
+    monkeypatch: pytest.MonkeyPatch, reload_server_module, flag_value: str
+) -> None:
+    # A typo'd value (``ture``) MUST NOT silently disable the gate by accident.
+    # Anything outside the known truthy set leaves the full surface registered.
+    monkeypatch.setenv("KANBANTOOL_READ_ONLY", flag_value)
+    reload_server_module()
+
+    names = _registered_tool_names()
+    assert "create_task" in names
+    assert "add_comment" in names
+    assert "delete_timer" in names
+
+
+def test_read_only_mode_keeps_write_functions_importable(
+    monkeypatch: pytest.MonkeyPatch, reload_server_module
+) -> None:
+    # The decorator returns the bare function in read-only mode; tests and
+    # other in-process callers can still invoke ``server.create_task`` even
+    # when the MCP surface hides it. Locks the "decorator returns the
+    # function unchanged" branch so a future refactor doesn't accidentally
+    # turn it into a registration-only wrapper.
+    monkeypatch.setenv("KANBANTOOL_READ_ONLY", "1")
+    reload_server_module()
+
+    assert callable(server_module.create_task)
+    assert callable(server_module.delete_timer)


### PR DESCRIPTION
## Summary

Adds a `KANBANTOOL_READ_ONLY` env var. When set to `1` / `true` / `yes` / `on`, the server registers only the 11 read-class tools — `create_*` / `update_*` / `delete_*` / `archive_task` / `move_task` / `add_comment` / `set_custom_field` / timer write tools never appear in the client's tool list.

**Use case:** giving an LLM safe browse / search / summarise access to your boards without granting it the ability to mutate state.

## What changes

- `KANBANTOOL_READ_ONLY` parsed in `config.env_flag` (canonical truthy spellings: `1`/`true`/`yes`/`on`, case-insensitive). Anything else fails closed.
- New module-private decorator `server._write_tool` — equivalent to `@mcp.tool` in default mode, no-op (returns the bare function) in read-only mode. Applied to the 14 write tools in place of `@mcp.tool`.
- Public constant `server.READ_ONLY_TOOLS: frozenset[str]` documents the 11 names so the read/write split lives in one place rather than being inferred from decorators.
- README: new "Read-only mode" subsection + new row in Configuration table.
- SEMVER.md: env-var contract updated to commit `KANBANTOOL_READ_ONLY` to v1.0 stable surface alongside `KANBANTOOL_DOMAIN` / `KANBANTOOL_API_TOKEN`. A future rename = major bump. (Surfaced in this PR rather than later so the v1.0 contract can't drift quietly.)

## Why read at import time, not at request time?

`@mcp.tool` decorators evaluate during module import — the registration choice has to be settled before any request lands. `Config.from_env()` is lazy and (correctly) requires `KANBANTOOL_API_TOKEN` to succeed; that's the wrong precondition for shaping the tool surface, so the gate is its own one-shot env read at import.

## Tests

`tests/test_read_only_mode.py` reloads `server` (and `config`) under each parametrised env value and asserts:

- 11-tool read constant matches the spelled-out set.
- Default mode → full 26-tool surface (11 reads + 14 writes + `ping`).
- `1`/`true`/`yes`/`on` (incl. mixed case) → 12 tools (11 reads + `ping`); `add_comment` etc. are absent.
- `0`/`false`/`no`/`off`/empty/typos → writes still registered (fail-closed contract).
- Write functions remain importable and callable in-process even when the MCP surface hides them — locks the "decorator returns the function unchanged" branch so a future refactor doesn't accidentally make it registration-only.

## Verification

- `uv run ruff check` — clean
- `uv run ruff format --check` — clean
- `uv run ty check` — clean
- `uv run pytest -q` — 243 passed (was 232 + 11 new parametrised cases)

## Test plan

- [x] Default-mode tool count is 26 (full surface)
- [x] Read-only-mode tool count is 12 (`ping` + 11 reads)
- [x] Truthy values disable writes (`1`, `true`, `yes`, `on`, mixed case)
- [x] Falsey/typo values keep writes (`0`, `false`, `no`, `off`, empty, `ture`)
- [x] Write functions still callable in-process under read-only
- [x] SEMVER.md amended in same PR
- [x] README documents env var, use case, and read/write tool lists

🤖 Generated with [Claude Code](https://claude.com/claude-code)