### PR TITLE
feat(server): add instructions= preamble for MCP clients

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,13 @@ workflow).
   Keep them terse, action-oriented, and accurate. Don't explain
   *what* the code does — explain *when* an agent should reach for
   this tool and what a good argument looks like.
+- The `_SERVER_INSTRUCTIONS` string in `src/kanbantool_mcp/server.py`
+  is the always-loaded mental model surfaced to MCP clients. It's
+  hard-capped at ~150 words. The longer `llms.txt` at the repo root
+  (when present) extends it with quirks and edge cases. **When you
+  add or remove a tool, or change its semantics in a way that
+  contradicts either surface, update both `_SERVER_INSTRUCTIONS`
+  AND `llms.txt`.** They must not drift.
 
 ### CI
 

--- a/src/kanbantool_mcp/server.py
+++ b/src/kanbantool_mcp/server.py
@@ -29,7 +29,48 @@ from .models import (
 # it would widen the API for one caller.
 _PAYLOAD_EXCERPT_LIMIT = 200
 
-mcp: FastMCP = FastMCP("kanbantool-mcp")
+# Server-level mental model surfaced to MCP clients. FastMCP forwards this to
+# the LLM as the always-loaded "how to think about this server" preamble, so
+# every tool call benefits from it without paying a per-tool docstring tax.
+#
+# Kept short (~135 words, hard cap ~150) on purpose: the LLM may compress or
+# silently truncate longer instructions, so we earn budget by saying only
+# what isn't already obvious from individual tool docstrings — discovery
+# order, the "me/whoami" handshake, the polling stand-in for webhooks, the
+# one-and-only ``set_custom_field`` exception to the omit-vs-clear rule, and
+# the typed exception ladder. Any longer-form quirks (Rails envelope vs
+# flat-body wire shapes, soft-delete semantics, the search DSL) live in
+# ``llms.txt`` and the per-tool docstrings.
+#
+# CONTRIBUTING: when you add or remove a tool, or change its semantics in a
+# way that contradicts this preamble, update both this string AND
+# ``llms.txt``. The two surfaces must stay in sync.
+_SERVER_INSTRUCTIONS = """\
+Kanban Tool MCP server. Boards hold columns, lanes, tasks, comments, \
+subtasks, time trackers, and 15 custom-field slots per task.
+
+Discovery: start with `list_boards` to find board IDs. To resolve \
+"me"/"myself", call `whoami` (returns the authenticated user). To match a \
+name like "Alice", call `list_board_collaborators(board_id)` then \
+`get_user(id)` to confirm. Use `list_custom_field_definitions(board_id)` \
+to learn what each `custom_field_N` slot means on that board.
+
+Change tracking: Kanban Tool has no webhooks. Poll \
+`recent_changes(board_id, since=...)` sparingly (30-120s cadence). Always \
+pass `since` after the first call.
+
+`None` means "omit, don't clear" on `update_task` / `move_task` / \
+`update_subtask` — the API ignores nulls. The one exception: \
+`set_custom_field(value=None)` sends a literal null and CLEARS the slot.
+
+Destructive tools (`delete_*`, `archive_task`) carry \
+`destructiveHint: True`. Errors flow through typed `KanbanToolError` \
+subclasses (`KanbanToolPermissionError` for 401/403, \
+`KanbanToolValidationError` for 422 with `field_errors`, \
+`KanbanToolHTTPError` otherwise, `KanbanToolTransportError` on transport \
+failure)."""
+
+mcp: FastMCP = FastMCP("kanbantool-mcp", instructions=_SERVER_INSTRUCTIONS)
 
 _ModelT = TypeVar("_ModelT", bound=BaseModel)
 

--- a/tests/test_server_instructions.py
+++ b/tests/test_server_instructions.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+
 from kanbantool_mcp import server
 
 # Hard cap mirrors the brief: longer instructions get compressed by the LLM
@@ -9,6 +11,12 @@ from kanbantool_mcp import server
 # not pile on. Locked here so a future "just one more line" PR has to confront
 # the trade-off explicitly.
 INSTRUCTIONS_WORD_CAP = 150
+
+# The preamble names this many tools as carrying ``destructiveHint: True``.
+# When the preamble's claim and the actual decorators disagree, the LLM is
+# being lied to. See ``test_destructive_hint_claim_matches_registered_tools``
+# for the introspection check.
+MIN_DESTRUCTIVE_TOOLS = 4
 
 
 def test_instructions_under_word_cap() -> None:
@@ -48,3 +56,24 @@ def test_instructions_covers_required_topics() -> None:
     assert "KanbanToolValidationError" in text
     assert "KanbanToolHTTPError" in text
     assert "KanbanToolTransportError" in text
+
+
+def test_destructive_hint_claim_matches_registered_tools() -> None:
+    # Structural cross-check: the preamble says destructive ops carry the
+    # ``destructiveHint: True`` annotation, so at least ``MIN_DESTRUCTIVE_TOOLS``
+    # tools must actually advertise it. Substring presence in the text isn't
+    # enough — if the annotations get reverted or never landed, this test
+    # fails loudly. Also enforces merge ordering with the tool-annotations
+    # PR: this assertion can't pass until that PR's decorators are present.
+    tools = asyncio.run(server.mcp.list_tools())
+    destructive = [
+        t.name
+        for t in tools
+        if t.annotations is not None and getattr(t.annotations, "destructiveHint", None) is True
+    ]
+    assert len(destructive) >= MIN_DESTRUCTIVE_TOOLS, (
+        f"_SERVER_INSTRUCTIONS claims tools carry destructiveHint: True, but only "
+        f"{len(destructive)} registered tools advertise it ({sorted(destructive)}). "
+        f"Either the tool-annotations PR hasn't landed yet (merge it first) or "
+        f"the annotations got reverted."
+    )

--- a/tests/test_server_instructions.py
+++ b/tests/test_server_instructions.py
@@ -1,0 +1,50 @@
+"""Tests for the server-level ``instructions=`` preamble."""
+
+from __future__ import annotations
+
+from kanbantool_mcp import server
+
+# Hard cap mirrors the brief: longer instructions get compressed by the LLM
+# (sometimes silently truncated), so additions must displace existing content,
+# not pile on. Locked here so a future "just one more line" PR has to confront
+# the trade-off explicitly.
+INSTRUCTIONS_WORD_CAP = 150
+
+
+def test_instructions_under_word_cap() -> None:
+    word_count = len(server._SERVER_INSTRUCTIONS.split())
+    assert word_count <= INSTRUCTIONS_WORD_CAP, (
+        f"_SERVER_INSTRUCTIONS is {word_count} words; cap is {INSTRUCTIONS_WORD_CAP}. "
+        "Trim or move content to llms.txt."
+    )
+
+
+def test_instructions_attached_to_mcp() -> None:
+    assert server.mcp.instructions == server._SERVER_INSTRUCTIONS
+
+
+def test_instructions_covers_required_topics() -> None:
+    # The brief enumerates six topics the preamble must mention. Locking each
+    # one here so a refactor that drops a topic surfaces immediately rather
+    # than silently regressing the LLM's mental model.
+    text = server._SERVER_INSTRUCTIONS
+    # (a) board-first discovery
+    assert "list_boards" in text
+    # (b) "me" → whoami; names → list_board_collaborators
+    assert "whoami" in text
+    assert "list_board_collaborators" in text
+    # (c) recent_changes polls (no webhooks)
+    assert "recent_changes" in text
+    assert "webhooks" in text
+    # (d) None semantics — omit-not-clear except set_custom_field
+    assert "None" in text
+    assert "omit" in text
+    assert "set_custom_field" in text
+    # (e) destructive ops carry destructiveHint annotation
+    assert "destructiveHint" in text
+    # (f) typed exception ladder
+    assert "KanbanToolError" in text
+    assert "KanbanToolPermissionError" in text
+    assert "KanbanToolValidationError" in text
+    assert "KanbanToolHTTPError" in text
+    assert "KanbanToolTransportError" in text


### PR DESCRIPTION
## Summary

Adds an `instructions=` arg to the FastMCP server constructor. Currently, `FastMCP("kanbantool-mcp")` ships with no preamble, so the LLM only sees per-tool docstrings — no shared mental model.

The new preamble (~135 words, hard cap 150) covers the six discoverability/correctness signals that don't fit naturally inside a single tool docstring:

1. **Board-first discovery** — `list_boards` before anything else.
2. **`whoami` / `list_board_collaborators`** for "me" and name resolution.
3. **`recent_changes` polling** as the stand-in for webhooks.
4. **`None` semantics** — "omit, not clear" everywhere except `set_custom_field` (where `None` is "literal null, clears the slot").
5. **`destructiveHint: True`** annotations on `delete_*` and `archive_task`.
6. **Typed exception ladder** — `KanbanToolError` and its four documented subclasses.

## Why this PR

LLMs forget. A new conversation has zero context about the server's discovery order, what `None` means in `update_task` vs `set_custom_field`, or which exceptions are catchable. Putting that in the always-loaded preamble means every tool call benefits without paying a per-tool docstring tax.

## Why hard-cap at 150 words

Long instructions get compressed by the LLM (sometimes silently truncated). 135 words is in the safe zone. The cap is locked by `test_instructions_under_word_cap` so a future "just one more line" change has to confront the trade-off explicitly.

## Coordination with `llms.txt`

`kbmcp-client-and-cli` is landing `llms.txt` (Proposal #12) in a separate PR. The two surfaces have a clear division of labour:

- `_SERVER_INSTRUCTIONS` (this PR) — short, canonical mental model. Always loaded.
- `llms.txt` (their PR) — long-form quirks: Rails envelope vs flat-body wire shapes, soft-delete semantics, search DSL, etc.

CONTRIBUTING.md gains a callout: when adding/removing tools or changing semantics that contradict either surface, both must be updated. They must not drift.

## Verification

- `uv run ruff check` — clean
- `uv run ruff format --check` — clean
- `uv run ty check` — clean
- `uv run pytest -q` — 231 passed (was 228 + 3 new tests)

## Test plan

- [x] `_SERVER_INSTRUCTIONS` is under the 150-word cap
- [x] `mcp.instructions` matches `_SERVER_INSTRUCTIONS` (the FastMCP arg actually wired through)
- [x] All 6 required topics present (per-keyword assertion catches accidental removal)
- [x] CONTRIBUTING.md note about cross-surface sync with `llms.txt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)