### PR TITLE
feat(cli,docs): add --check flag and per-MCP-client install snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,41 +54,34 @@ Two environment variables, regardless of how you launch the server:
 
 ### Wiring it into your client
 
-The `mcp.json` payload is the same across clients; only the file location and UI for editing it differ. See your client's docs for where the config lives:
+The JSON shape is the same across MCP clients — only the file location and the launcher CLI differ. Pick your client below, drop the snippet into the matching `mcp.json`, and substitute your `KANBANTOOL_DOMAIN` / `KANBANTOOL_API_TOKEN` values.
 
-| Client | Setup docs |
-| --- | --- |
-| Claude Desktop | <https://modelcontextprotocol.io/quickstart/user> |
-| Cursor | <https://cursor.com/docs/mcp> |
-| Cline | <https://docs.cline.bot/mcp/configuring-mcp-servers> |
-| Continue | <https://docs.continue.dev/customize/deep-dives/mcp> |
-
-Drop one of the snippets below into wherever your client expects MCP server configuration.
-
-### From git (current)
-
-Add to your MCP client's `mcp.json`:
+Each snippet shows the **PyPI** form (`uvx kanbantool-mcp`) — swap the `args` for the **git form** below if you want to track `main` instead of a release:
 
 ```json
-{
-  "mcpServers": {
-    "kanbantool": {
-      "command": "uvx",
-      "args": [
-        "--from",
-        "git+https://github.com/VeryLongOrgNameSuchWow/kanbantool-mcp",
-        "kanbantool-mcp"
-      ],
-      "env": {
-        "KANBANTOOL_DOMAIN": "your-account",
-        "KANBANTOOL_API_TOKEN": "your-token"
-      }
-    }
-  }
-}
+"args": ["--from", "git+https://github.com/VeryLongOrgNameSuchWow/kanbantool-mcp", "kanbantool-mcp"]
 ```
 
-### From PyPI
+#### Claude Code
+
+Easiest path is the CLI:
+
+```sh
+claude mcp add-json kanbantool '{
+  "command": "uvx",
+  "args": ["kanbantool-mcp"],
+  "env": {
+    "KANBANTOOL_DOMAIN": "your-account",
+    "KANBANTOOL_API_TOKEN": "your-token"
+  }
+}'
+```
+
+Or edit `~/.claude.json` (project-scoped via `claude mcp add-json -s project ...`). See <https://docs.claude.com/en/docs/claude-code/mcp> for scopes.
+
+#### Claude Desktop
+
+Edit the config file (`~/Library/Application Support/Claude/claude_desktop_config.json` on macOS, `%APPDATA%\Claude\claude_desktop_config.json` on Windows). Setup docs: <https://modelcontextprotocol.io/quickstart/user>.
 
 ```json
 {
@@ -105,9 +98,80 @@ Add to your MCP client's `mcp.json`:
 }
 ```
 
+#### Cursor
+
+Edit `~/.cursor/mcp.json` (or per-project `.cursor/mcp.json`). Setup docs: <https://cursor.com/docs/mcp>.
+
+```json
+{
+  "mcpServers": {
+    "kanbantool": {
+      "command": "uvx",
+      "args": ["kanbantool-mcp"],
+      "env": {
+        "KANBANTOOL_DOMAIN": "your-account",
+        "KANBANTOOL_API_TOKEN": "your-token"
+      }
+    }
+  }
+}
+```
+
+#### Continue
+
+Edit `~/.continue/config.yaml` (Continue uses YAML, not JSON, for MCP entries). Setup docs: <https://docs.continue.dev/customize/deep-dives/mcp>.
+
+```yaml
+mcpServers:
+  - name: kanbantool
+    command: uvx
+    args:
+      - kanbantool-mcp
+    env:
+      KANBANTOOL_DOMAIN: your-account
+      KANBANTOOL_API_TOKEN: your-token
+```
+
+#### Cline
+
+Edit `cline_mcp_settings.json` via the Cline panel's MCP Servers > Edit Config button. Setup docs: <https://docs.cline.bot/mcp/configuring-mcp-servers>.
+
+```json
+{
+  "mcpServers": {
+    "kanbantool": {
+      "command": "uvx",
+      "args": ["kanbantool-mcp"],
+      "env": {
+        "KANBANTOOL_DOMAIN": "your-account",
+        "KANBANTOOL_API_TOKEN": "your-token"
+      }
+    }
+  }
+}
+```
+
+#### Generic MCP-over-stdio
+
+Any MCP client that supports launching a stdio server. Spawn this command with the env vars set in the child process; the server speaks JSON-RPC on stdin/stdout.
+
+```sh
+KANBANTOOL_DOMAIN=your-account \
+  KANBANTOOL_API_TOKEN=your-token \
+  uvx kanbantool-mcp
+```
+
 ### Verify your install
 
-After wiring the server into your client, ask the assistant **"who am I?"** — it'll call the `whoami` tool and confirm your token resolves to your Kanban Tool account. If that comes back with your name and email, the server is reachable and your credentials work.
+Run `kanbantool-mcp --check` (e.g. `uvx kanbantool-mcp --check`) — it validates your env vars, hits the `whoami` endpoint, and prints a one-line OK/FAIL signal. Sample success output:
+
+```
+OK: Alice Example (your-account) — token resolves; you can use kanbantool-mcp now
+```
+
+The flag exits 0 on success and non-zero on failure (missing env, 401/403 auth, network failure), with an actionable hint per error class. Run it once after wiring the server into your client to confirm the token reaches Kanban Tool **before** asking your assistant to do anything with it.
+
+You can also verify from inside the assistant: ask **"who am I?"** — it'll call the `whoami` tool and confirm your token resolves. If that comes back with your name, the server is reachable and your credentials work.
 
 ## Tool reference
 

--- a/README.md
+++ b/README.md
@@ -171,6 +171,8 @@ OK: Alice Example (your-account) — token resolves; you can use kanbantool-mcp 
 
 The flag exits 0 on success and non-zero on failure (missing env, 401/403 auth, network failure), with an actionable hint per error class. Run it once after wiring the server into your client to confirm the token reaches Kanban Tool **before** asking your assistant to do anything with it.
 
+To check which version you have installed, run `kanbantool-mcp --version` (e.g. `uvx kanbantool-mcp --version`). Useful when reporting an issue.
+
 You can also verify from inside the assistant: ask **"who am I?"** — it'll call the `whoami` tool and confirm your token resolves. If that comes back with your name, the server is reachable and your credentials work.
 
 ## Tool reference

--- a/src/kanbantool_mcp/__main__.py
+++ b/src/kanbantool_mcp/__main__.py
@@ -1,6 +1,6 @@
 """Console script entry point for kanbantool-mcp.
 
-Two modes:
+Three modes:
 
 - Default (no args): runs the FastMCP stdio server. The MCP client launches
   this and talks JSON-RPC over the process's stdin/stdout.
@@ -8,11 +8,12 @@ Two modes:
   signal, and exits. Intended as the first thing you run after wiring the
   server into an MCP client to confirm the token resolves and the network
   reaches Kanban Tool. Exits 0 on success, non-zero on failure.
+- ``--version``: prints the installed package version and exits.
 
-``--check`` is a flag, not a subcommand, on purpose: it keeps the v1.0 CLI
-surface tight (one entry point, one optional behavior switch). Adding a
-subcommand would imply more subcommands later — we'd rather grow that
-surface only if real demand shows up.
+``--check`` and ``--version`` are flags, not subcommands, on purpose: they
+keep the v1.0 CLI surface tight (one entry point, two optional behavior
+switches). Adding a subcommand would imply more subcommands later — we'd
+rather grow that surface only if real demand shows up.
 """
 
 from __future__ import annotations
@@ -20,6 +21,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import sys
+from importlib.metadata import PackageNotFoundError, version
 
 import httpx
 
@@ -28,6 +30,20 @@ from .config import Config
 from .exceptions import KanbanToolPermissionError, KanbanToolTransportError
 from .models import User
 from .server import run
+
+
+def _resolve_version() -> str:
+    """Return the installed package version, or ``"unknown"`` if the package
+    isn't installed (e.g. running from a checked-out source tree without
+    ``uv pip install -e .``). ``importlib.metadata`` is the canonical source
+    — single source of truth shared with PyPI / wheel metadata, so a
+    release-please version bump on ``__init__.py.__version__`` flows here
+    automatically once the wheel rebuilds."""
+    try:
+        return version("kanbantool-mcp")
+    except PackageNotFoundError:
+        return "unknown"
+
 
 _TOKEN_REGEN_HINT = (
     "https://kanbantool.com/ -> log in -> account avatar -> My profile -> API tokens"
@@ -96,8 +112,14 @@ def main() -> None:
             "MCP server bridging an MCP client (Claude Code, Cursor, etc.) to "
             "the Kanban Tool API v3. With no flags, runs the stdio server. "
             "Use --check to validate your env + token before wiring the server "
-            "into a client."
+            "into a client; --version prints the installed package version."
         ),
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {_resolve_version()}",
+        help="Print the installed kanbantool-mcp version and exit.",
     )
     parser.add_argument(
         "--check",

--- a/src/kanbantool_mcp/__main__.py
+++ b/src/kanbantool_mcp/__main__.py
@@ -24,10 +24,15 @@ import sys
 from importlib.metadata import PackageNotFoundError, version
 
 import httpx
+from pydantic import ValidationError as PydanticValidationError
 
-from .client import KanbanToolClient
+from .client import KanbanToolClient, _scrub_secrets
 from .config import Config
-from .exceptions import KanbanToolPermissionError, KanbanToolTransportError
+from .exceptions import (
+    KanbanToolHTTPError,
+    KanbanToolPermissionError,
+    KanbanToolTransportError,
+)
 from .models import User
 from .server import run
 
@@ -49,6 +54,32 @@ _TOKEN_REGEN_HINT = (
     "https://kanbantool.com/ -> log in -> account avatar -> My profile -> API tokens"
 )
 
+# Exit codes for ``--check`` failure paths. Pinned (rather than just "non-zero")
+# so callers — humans grepping logs, install scripts, CI gates — can branch on
+# the cause without parsing the stderr text. Kept locally as constants because
+# they're scoped to this entry point; promoting them to ``exceptions.py`` would
+# imply a wider re-use that doesn't exist yet.
+_EXIT_OK = 0
+_EXIT_MISSING_ENV = 2
+_EXIT_AUTH_FAILED = 3
+_EXIT_TRANSPORT_FAILED = 4
+_EXIT_HTTP_FAILED = 5
+_EXIT_MALFORMED_RESPONSE = 6
+
+
+def _fail(exc: BaseException, hint: str) -> None:
+    """Print a ``FAIL: <scrubbed-exception> / <hint>`` block to stderr.
+
+    The exception message is run through ``_scrub_secrets`` defensively. The
+    typed Kanban Tool exceptions already scrub bearer-token sequences in their
+    ``__str__`` output, but a future exception subclass — or a stray
+    ``RuntimeError`` from somewhere we don't expect — could surface an
+    un-scrubbed token. Cheap belt-and-suspenders that the audit brief
+    explicitly required for the ``--check`` flow.
+    """
+    print(f"FAIL: {_scrub_secrets(str(exc))}", file=sys.stderr)
+    print(hint, file=sys.stderr)
+
 
 async def _run_check() -> int:
     """Resolve the configured token against ``whoami`` and print a one-line
@@ -61,46 +92,77 @@ async def _run_check() -> int:
     except RuntimeError as exc:
         # ``Config.from_env`` already names the missing var(s) in its message;
         # add the actionable next step so the operator knows what to do.
-        print(f"FAIL: {exc}", file=sys.stderr)
-        print(
+        _fail(
+            exc,
             "Set both KANBANTOOL_DOMAIN (your account subdomain) and "
-            "KANBANTOOL_API_TOKEN (bearer token) in the MCP client's `env` block, "
-            f"then re-run --check. Get a token at: {_TOKEN_REGEN_HINT}",
-            file=sys.stderr,
+            "KANBANTOOL_API_TOKEN (bearer token) in the MCP client's `env` "
+            f"block, then re-run --check. Get a token at: {_TOKEN_REGEN_HINT}",
         )
-        return 2
+        return _EXIT_MISSING_ENV
 
     client = KanbanToolClient(config)
     try:
         try:
             data = await client.request("GET", "users/current")
         except KanbanToolPermissionError as exc:
-            print(f"FAIL: {exc}", file=sys.stderr)
-            print(
-                f"Auth failed. Verify KANBANTOOL_API_TOKEN at {_TOKEN_REGEN_HINT}",
-                file=sys.stderr,
-            )
-            return 3
+            _fail(exc, f"Auth failed. Verify KANBANTOOL_API_TOKEN at {_TOKEN_REGEN_HINT}")
+            return _EXIT_AUTH_FAILED
         except KanbanToolTransportError as exc:
             host = httpx.URL(config.base_url).host
-            print(f"FAIL: {exc}", file=sys.stderr)
-            print(
-                f"Network failed reaching {host}. "
-                "Check KANBANTOOL_DOMAIN, your firewall/proxy settings, and "
-                "DNS resolution. Re-run --check once the network reaches "
-                "kanbantool.com.",
-                file=sys.stderr,
+            _fail(
+                exc,
+                f"Network failed reaching {host}. Check KANBANTOOL_DOMAIN, "
+                "your firewall/proxy settings, and DNS resolution. Re-run "
+                "--check once the network reaches kanbantool.com.",
             )
-            return 4
+            return _EXIT_TRANSPORT_FAILED
+        except KanbanToolHTTPError as exc:
+            # Catches the full 4xx/5xx surface that isn't 401/403. Most likely
+            # cause: a typo'd ``KANBANTOOL_DOMAIN`` resolves to a wildcard
+            # ``*.kanbantool.com`` host that 404s on every path. Also catches
+            # ``KanbanToolValidationError`` (subclass) — unlikely from
+            # ``whoami`` but kept generic to avoid leaking through unhandled.
+            if exc.status_code == 404:
+                hint = (
+                    f"Got 404 from {config.base_url}users/current.json. "
+                    "Likely cause: KANBANTOOL_DOMAIN is wrong (the subdomain "
+                    "doesn't exist). Verify the subdomain you log into matches "
+                    "what's in KANBANTOOL_DOMAIN."
+                )
+            elif exc.status_code >= 500:
+                hint = (
+                    f"Kanban Tool API returned {exc.status_code}. The service "
+                    "may be down or having issues; check kanbantool.com status "
+                    "and re-run --check shortly."
+                )
+            else:
+                hint = (
+                    f"Kanban Tool API returned an unexpected HTTP "
+                    f"{exc.status_code}. Inspect the FAIL: line above for "
+                    "details and re-run --check after addressing the cause."
+                )
+            _fail(exc, hint)
+            return _EXIT_HTTP_FAILED
         # Validate the response shape minimally — same model as the ``whoami``
         # MCP tool uses, so a malformed body surfaces the same way an LLM would
         # see it via the live tool.
-        user = User.model_validate(data)
+        try:
+            user = User.model_validate(data)
+        except PydanticValidationError as exc:
+            _fail(
+                exc,
+                "Kanban Tool API returned a body that doesn't match the "
+                "expected `User` shape — likely a kanbantool-mcp bug or an "
+                "upstream API change. Please file an issue at "
+                "https://github.com/VeryLongOrgNameSuchWow/kanbantool-mcp/issues "
+                "with this output.",
+            )
+            return _EXIT_MALFORMED_RESPONSE
         display_name = user.name or f"user #{user.id}"
         print(
             f"OK: {display_name} ({config.domain}) — token resolves; you can use kanbantool-mcp now"
         )
-        return 0
+        return _EXIT_OK
     finally:
         await client.aclose()
 

--- a/src/kanbantool_mcp/__main__.py
+++ b/src/kanbantool_mcp/__main__.py
@@ -1,9 +1,122 @@
-"""Console script entry point for kanbantool-mcp."""
+"""Console script entry point for kanbantool-mcp.
 
+Two modes:
+
+- Default (no args): runs the FastMCP stdio server. The MCP client launches
+  this and talks JSON-RPC over the process's stdin/stdout.
+- ``--check``: validates the env vars, hits ``whoami``, prints a one-line
+  signal, and exits. Intended as the first thing you run after wiring the
+  server into an MCP client to confirm the token resolves and the network
+  reaches Kanban Tool. Exits 0 on success, non-zero on failure.
+
+``--check`` is a flag, not a subcommand, on purpose: it keeps the v1.0 CLI
+surface tight (one entry point, one optional behavior switch). Adding a
+subcommand would imply more subcommands later — we'd rather grow that
+surface only if real demand shows up.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+
+import httpx
+
+from .client import KanbanToolClient
+from .config import Config
+from .exceptions import KanbanToolPermissionError, KanbanToolTransportError
+from .models import User
 from .server import run
+
+_TOKEN_REGEN_HINT = (
+    "https://kanbantool.com/ -> log in -> account avatar -> My profile -> API tokens"
+)
+
+
+async def _run_check() -> int:
+    """Resolve the configured token against ``whoami`` and print a one-line
+    signal. Returns the exit code (0 on success, non-zero on failure).
+
+    Pulled into its own coroutine so the sync ``main`` entry point can await
+    it via ``asyncio.run`` without juggling a fresh event loop inline."""
+    try:
+        config = Config.from_env()
+    except RuntimeError as exc:
+        # ``Config.from_env`` already names the missing var(s) in its message;
+        # add the actionable next step so the operator knows what to do.
+        print(f"FAIL: {exc}", file=sys.stderr)
+        print(
+            "Set both KANBANTOOL_DOMAIN (your account subdomain) and "
+            "KANBANTOOL_API_TOKEN (bearer token) in the MCP client's `env` block, "
+            f"then re-run --check. Get a token at: {_TOKEN_REGEN_HINT}",
+            file=sys.stderr,
+        )
+        return 2
+
+    client = KanbanToolClient(config)
+    try:
+        try:
+            data = await client.request("GET", "users/current")
+        except KanbanToolPermissionError as exc:
+            print(f"FAIL: {exc}", file=sys.stderr)
+            print(
+                f"Auth failed. Verify KANBANTOOL_API_TOKEN at {_TOKEN_REGEN_HINT}",
+                file=sys.stderr,
+            )
+            return 3
+        except KanbanToolTransportError as exc:
+            host = httpx.URL(config.base_url).host
+            print(f"FAIL: {exc}", file=sys.stderr)
+            print(
+                f"Network failed reaching {host}. "
+                "Check KANBANTOOL_DOMAIN, your firewall/proxy settings, and "
+                "DNS resolution. Re-run --check once the network reaches "
+                "kanbantool.com.",
+                file=sys.stderr,
+            )
+            return 4
+        # Validate the response shape minimally — same model as the ``whoami``
+        # MCP tool uses, so a malformed body surfaces the same way an LLM would
+        # see it via the live tool.
+        user = User.model_validate(data)
+        display_name = user.name or f"user #{user.id}"
+        print(
+            f"OK: {display_name} ({config.domain}) — token resolves; you can use kanbantool-mcp now"
+        )
+        return 0
+    finally:
+        await client.aclose()
 
 
 def main() -> None:
+    parser = argparse.ArgumentParser(
+        prog="kanbantool-mcp",
+        description=(
+            "MCP server bridging an MCP client (Claude Code, Cursor, etc.) to "
+            "the Kanban Tool API v3. With no flags, runs the stdio server. "
+            "Use --check to validate your env + token before wiring the server "
+            "into a client."
+        ),
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help=(
+            "Validate KANBANTOOL_DOMAIN/KANBANTOOL_API_TOKEN and confirm the "
+            "token resolves against the Kanban Tool API. Prints a one-line "
+            "signal and exits (0 on success, non-zero on failure). Does NOT "
+            "start the MCP server."
+        ),
+    )
+    args = parser.parse_args()
+
+    if args.check:
+        # ``asyncio.run`` builds and tears down a fresh event loop for the
+        # short-lived check; the long-running stdio server uses its own loop
+        # via ``mcp.run`` below.
+        sys.exit(asyncio.run(_run_check()))
+
     run()
 
 

--- a/tests/test_check_flag.py
+++ b/tests/test_check_flag.py
@@ -1,0 +1,165 @@
+"""Tests for the ``kanbantool-mcp --check`` first-success-signal flag."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+
+from kanbantool_mcp.__main__ import main
+
+from .conftest import BASE_URL
+
+
+def test_check_success(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    """Happy path: env is set, ``whoami`` 200s, exit 0 with the OK signal."""
+    monkeypatch.setattr("sys.argv", ["kanbantool-mcp", "--check"])
+    with respx.mock(assert_all_called=True) as router:
+        router.get(f"{BASE_URL}users/current.json").mock(
+            return_value=httpx.Response(
+                200, json={"id": 42, "name": "Alice Example", "initials": "AE"}
+            )
+        )
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+        assert exc_info.value.code == 0
+    captured = capsys.readouterr()
+    assert "OK:" in captured.out
+    assert "Alice Example" in captured.out
+    assert "(testacct)" in captured.out
+    assert "you can use kanbantool-mcp now" in captured.out
+    assert captured.err == ""
+
+
+def test_check_success_user_without_name_falls_back_to_id(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """If the API returns a user with no ``name``, render ``user #<id>``."""
+    monkeypatch.setattr("sys.argv", ["kanbantool-mcp", "--check"])
+    with respx.mock() as router:
+        router.get(f"{BASE_URL}users/current.json").mock(
+            return_value=httpx.Response(200, json={"id": 7})
+        )
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+        assert exc_info.value.code == 0
+    captured = capsys.readouterr()
+    assert "user #7" in captured.out
+
+
+def test_check_missing_env_var_exits_non_zero(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Missing env var: exit non-zero with the var name AND the token-regen
+    pointer so the operator knows where to fix it."""
+    monkeypatch.delenv("KANBANTOOL_API_TOKEN")
+    monkeypatch.setattr("sys.argv", ["kanbantool-mcp", "--check"])
+    with pytest.raises(SystemExit) as exc_info:
+        main()
+    assert exc_info.value.code != 0
+    captured = capsys.readouterr()
+    assert "FAIL" in captured.err
+    # The missing var must be named explicitly so the operator knows what to set.
+    assert "KANBANTOOL_API_TOKEN" in captured.err
+    assert "API tokens" in captured.err
+
+
+def test_check_missing_both_env_vars_lists_both(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Missing both vars: both are named so the operator fixes both."""
+    monkeypatch.delenv("KANBANTOOL_DOMAIN")
+    monkeypatch.delenv("KANBANTOOL_API_TOKEN")
+    monkeypatch.setattr("sys.argv", ["kanbantool-mcp", "--check"])
+    with pytest.raises(SystemExit) as exc_info:
+        main()
+    assert exc_info.value.code != 0
+    captured = capsys.readouterr()
+    assert "KANBANTOOL_DOMAIN" in captured.err
+    assert "KANBANTOOL_API_TOKEN" in captured.err
+
+
+def test_check_401_prints_auth_hint(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """401 from ``whoami``: exit non-zero with the actionable token-regen hint."""
+    monkeypatch.setattr("sys.argv", ["kanbantool-mcp", "--check"])
+    with respx.mock() as router:
+        router.get(f"{BASE_URL}users/current.json").mock(
+            return_value=httpx.Response(401, text="unauthorized")
+        )
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+        assert exc_info.value.code != 0
+    captured = capsys.readouterr()
+    assert "FAIL" in captured.err
+    assert "Auth failed" in captured.err
+    assert "KANBANTOOL_API_TOKEN" in captured.err
+
+
+def test_check_403_prints_auth_hint(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """403 from ``whoami``: same auth-hint surface as 401 (both are
+    ``KanbanToolPermissionError``)."""
+    monkeypatch.setattr("sys.argv", ["kanbantool-mcp", "--check"])
+    with respx.mock() as router:
+        router.get(f"{BASE_URL}users/current.json").mock(
+            return_value=httpx.Response(403, text="forbidden")
+        )
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+        assert exc_info.value.code != 0
+    captured = capsys.readouterr()
+    assert "Auth failed" in captured.err
+
+
+def test_check_transport_error_prints_network_hint(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A network failure surfaces as ``KanbanToolTransportError``; the
+    actionable hint names the host and points at firewall/DNS as the likely
+    cause."""
+    monkeypatch.setattr("sys.argv", ["kanbantool-mcp", "--check"])
+    with respx.mock() as router:
+        router.get(f"{BASE_URL}users/current.json").mock(
+            side_effect=[
+                httpx.ConnectError("dns failure"),
+                httpx.ConnectError("dns failure"),
+            ]
+        )
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+        assert exc_info.value.code != 0
+    captured = capsys.readouterr()
+    assert "FAIL" in captured.err
+    assert "Network failed reaching" in captured.err
+    assert "testacct.kanbantool.com" in captured.err
+
+
+def test_main_no_args_invokes_server_run(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default behavior (no ``--check`` flag): falls through to ``server.run``,
+    starting the FastMCP stdio server. Verified by patching ``run`` and
+    asserting it was called exactly once."""
+    monkeypatch.setattr("sys.argv", ["kanbantool-mcp"])
+    calls: list[bool] = []
+
+    def _fake_run() -> None:
+        calls.append(True)
+
+    monkeypatch.setattr("kanbantool_mcp.__main__.run", _fake_run)
+    main()
+    assert calls == [True]
+
+
+def test_check_flag_is_documented_in_help(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """``--help`` mentions ``--check`` so first-time users discover the flag."""
+    monkeypatch.setattr("sys.argv", ["kanbantool-mcp", "--help"])
+    with pytest.raises(SystemExit) as exc_info:
+        main()
+    # argparse exits 0 on --help.
+    assert exc_info.value.code == 0
+    captured = capsys.readouterr()
+    assert "--check" in captured.out

--- a/tests/test_check_flag.py
+++ b/tests/test_check_flag.py
@@ -163,3 +163,29 @@ def test_check_flag_is_documented_in_help(
     assert exc_info.value.code == 0
     captured = capsys.readouterr()
     assert "--check" in captured.out
+    # ``--version`` should also be discoverable from --help.
+    assert "--version" in captured.out
+
+
+def test_version_flag_prints_version_and_exits_zero(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """``--version`` (locked flag name; future-proof) prints
+    ``kanbantool-mcp <version>`` and exits 0. Sourced via
+    ``importlib.metadata.version`` so the wheel's metadata is the
+    single source of truth — the test accepts either the source-tree
+    ``__version__`` (when installed) or the literal ``"unknown"``
+    (when running from a non-installed checkout)."""
+    from kanbantool_mcp import __version__ as src_version
+
+    monkeypatch.setattr("sys.argv", ["kanbantool-mcp", "--version"])
+    with pytest.raises(SystemExit) as exc_info:
+        main()
+    assert exc_info.value.code == 0
+    captured = capsys.readouterr()
+    # argparse's ``version`` action prints to stdout and includes the prog name.
+    assert "kanbantool-mcp" in captured.out
+    out = captured.out.strip()
+    assert out.endswith(src_version) or out.endswith("unknown"), (
+        f"Expected output ending with {src_version!r} or 'unknown', got {out!r}"
+    )

--- a/tests/test_check_flag.py
+++ b/tests/test_check_flag.py
@@ -6,7 +6,15 @@ import httpx
 import pytest
 import respx
 
-from kanbantool_mcp.__main__ import main
+from kanbantool_mcp.__main__ import (
+    _EXIT_AUTH_FAILED,
+    _EXIT_HTTP_FAILED,
+    _EXIT_MALFORMED_RESPONSE,
+    _EXIT_MISSING_ENV,
+    _EXIT_OK,
+    _EXIT_TRANSPORT_FAILED,
+    main,
+)
 
 from .conftest import BASE_URL
 
@@ -22,7 +30,7 @@ def test_check_success(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFi
         )
         with pytest.raises(SystemExit) as exc_info:
             main()
-        assert exc_info.value.code == 0
+        assert exc_info.value.code == _EXIT_OK
     captured = capsys.readouterr()
     assert "OK:" in captured.out
     assert "Alice Example" in captured.out
@@ -42,21 +50,21 @@ def test_check_success_user_without_name_falls_back_to_id(
         )
         with pytest.raises(SystemExit) as exc_info:
             main()
-        assert exc_info.value.code == 0
+        assert exc_info.value.code == _EXIT_OK
     captured = capsys.readouterr()
     assert "user #7" in captured.out
 
 
-def test_check_missing_env_var_exits_non_zero(
+def test_check_missing_env_var_exits_with_pinned_code(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """Missing env var: exit non-zero with the var name AND the token-regen
-    pointer so the operator knows where to fix it."""
+    """Missing env var: exit with the pinned ``_EXIT_MISSING_ENV`` code, the
+    var name, and the token-regen pointer."""
     monkeypatch.delenv("KANBANTOOL_API_TOKEN")
     monkeypatch.setattr("sys.argv", ["kanbantool-mcp", "--check"])
     with pytest.raises(SystemExit) as exc_info:
         main()
-    assert exc_info.value.code != 0
+    assert exc_info.value.code == _EXIT_MISSING_ENV
     captured = capsys.readouterr()
     assert "FAIL" in captured.err
     # The missing var must be named explicitly so the operator knows what to set.
@@ -73,16 +81,17 @@ def test_check_missing_both_env_vars_lists_both(
     monkeypatch.setattr("sys.argv", ["kanbantool-mcp", "--check"])
     with pytest.raises(SystemExit) as exc_info:
         main()
-    assert exc_info.value.code != 0
+    assert exc_info.value.code == _EXIT_MISSING_ENV
     captured = capsys.readouterr()
     assert "KANBANTOOL_DOMAIN" in captured.err
     assert "KANBANTOOL_API_TOKEN" in captured.err
 
 
-def test_check_401_prints_auth_hint(
+def test_check_401_exits_with_pinned_auth_code(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """401 from ``whoami``: exit non-zero with the actionable token-regen hint."""
+    """401 from ``whoami``: exit with the pinned ``_EXIT_AUTH_FAILED`` code
+    and the actionable token-regen hint."""
     monkeypatch.setattr("sys.argv", ["kanbantool-mcp", "--check"])
     with respx.mock() as router:
         router.get(f"{BASE_URL}users/current.json").mock(
@@ -90,18 +99,18 @@ def test_check_401_prints_auth_hint(
         )
         with pytest.raises(SystemExit) as exc_info:
             main()
-        assert exc_info.value.code != 0
+        assert exc_info.value.code == _EXIT_AUTH_FAILED
     captured = capsys.readouterr()
     assert "FAIL" in captured.err
     assert "Auth failed" in captured.err
     assert "KANBANTOOL_API_TOKEN" in captured.err
 
 
-def test_check_403_prints_auth_hint(
+def test_check_403_exits_with_pinned_auth_code(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """403 from ``whoami``: same auth-hint surface as 401 (both are
-    ``KanbanToolPermissionError``)."""
+    """403 from ``whoami``: same auth-hint surface and same pinned exit code
+    as 401 (both are ``KanbanToolPermissionError``)."""
     monkeypatch.setattr("sys.argv", ["kanbantool-mcp", "--check"])
     with respx.mock() as router:
         router.get(f"{BASE_URL}users/current.json").mock(
@@ -109,17 +118,19 @@ def test_check_403_prints_auth_hint(
         )
         with pytest.raises(SystemExit) as exc_info:
             main()
-        assert exc_info.value.code != 0
+        assert exc_info.value.code == _EXIT_AUTH_FAILED
     captured = capsys.readouterr()
     assert "Auth failed" in captured.err
 
 
-def test_check_transport_error_prints_network_hint(
+def test_check_transport_error_exits_with_pinned_transport_code(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """A network failure surfaces as ``KanbanToolTransportError``; the
-    actionable hint names the host and points at firewall/DNS as the likely
-    cause."""
+    """A network failure surfaces as ``KanbanToolTransportError``; pin the
+    ``_EXIT_TRANSPORT_FAILED`` code and assert the full actionable hint
+    string is emitted (not just the bare host substring — that would be
+    flagged by CodeQL's URL-substring-sanitization rule, plus a tighter
+    match catches accidental wording regressions)."""
     monkeypatch.setattr("sys.argv", ["kanbantool-mcp", "--check"])
     with respx.mock() as router:
         router.get(f"{BASE_URL}users/current.json").mock(
@@ -130,11 +141,122 @@ def test_check_transport_error_prints_network_hint(
         )
         with pytest.raises(SystemExit) as exc_info:
             main()
-        assert exc_info.value.code != 0
+        assert exc_info.value.code == _EXIT_TRANSPORT_FAILED
     captured = capsys.readouterr()
     assert "FAIL" in captured.err
-    assert "Network failed reaching" in captured.err
-    assert "testacct.kanbantool.com" in captured.err
+    # The full hint string is more precise than checking for the host
+    # substring alone — pins both the host AND the actionable advice that
+    # follows it.
+    assert "Network failed reaching testacct.kanbantool.com." in captured.err
+    assert "Check KANBANTOOL_DOMAIN" in captured.err
+
+
+def test_check_404_prints_domain_wrong_hint(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A typo'd ``KANBANTOOL_DOMAIN`` resolves to a wildcard
+    ``*.kanbantool.com`` host that 404s on every path. Surface that as a
+    typed ``KanbanToolHTTPError`` with a domain-wrong hint, exit
+    ``_EXIT_HTTP_FAILED`` — NOT a Python stack trace through the operator."""
+    monkeypatch.setattr("sys.argv", ["kanbantool-mcp", "--check"])
+    with respx.mock() as router:
+        router.get(f"{BASE_URL}users/current.json").mock(
+            return_value=httpx.Response(404, text="not found")
+        )
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+        assert exc_info.value.code == _EXIT_HTTP_FAILED
+    captured = capsys.readouterr()
+    assert "FAIL" in captured.err
+    assert "404" in captured.err
+    assert "KANBANTOOL_DOMAIN is wrong" in captured.err
+
+
+def test_check_500_prints_service_down_hint(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """5xx from ``whoami``: surface the typed error with a service-down hint,
+    exit ``_EXIT_HTTP_FAILED``."""
+    monkeypatch.setattr("sys.argv", ["kanbantool-mcp", "--check"])
+    with respx.mock() as router:
+        # 500 (no retry on this path because the endpoint is GET — the
+        # retry policy will do one more attempt; mock returns 500 both times).
+        router.get(f"{BASE_URL}users/current.json").mock(
+            return_value=httpx.Response(500, text="internal error")
+        )
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+        assert exc_info.value.code == _EXIT_HTTP_FAILED
+    captured = capsys.readouterr()
+    assert "FAIL" in captured.err
+    assert "500" in captured.err
+    assert "service may be down" in captured.err
+
+
+def test_check_unexpected_4xx_prints_generic_hint(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A 410 (or any other unexpected 4xx outside 401/403/404): surface the
+    typed error with the generic catch-all hint, exit ``_EXIT_HTTP_FAILED``.
+    Avoids the Python-stack-trace fall-through the /review flagged."""
+    monkeypatch.setattr("sys.argv", ["kanbantool-mcp", "--check"])
+    with respx.mock() as router:
+        router.get(f"{BASE_URL}users/current.json").mock(
+            return_value=httpx.Response(410, text="gone")
+        )
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+        assert exc_info.value.code == _EXIT_HTTP_FAILED
+    captured = capsys.readouterr()
+    assert "FAIL" in captured.err
+    assert "410" in captured.err
+
+
+def test_check_malformed_response_body_prints_bug_hint(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A 200 with a body that doesn't match the ``User`` shape (missing
+    required ``id`` field): surface the ``pydantic.ValidationError`` as a
+    typed failure with a "file an issue" hint, exit
+    ``_EXIT_MALFORMED_RESPONSE``. Without this catch the operator would see
+    a raw pydantic stack trace."""
+    monkeypatch.setattr("sys.argv", ["kanbantool-mcp", "--check"])
+    with respx.mock() as router:
+        router.get(f"{BASE_URL}users/current.json").mock(
+            return_value=httpx.Response(200, json={"name": "no-id-field"})
+        )
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+        assert exc_info.value.code == _EXIT_MALFORMED_RESPONSE
+    captured = capsys.readouterr()
+    assert "FAIL" in captured.err
+    assert "doesn't match" in captured.err
+    assert "file an issue" in captured.err
+
+
+def test_check_fail_helper_scrubs_bearer_tokens(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Defense-in-depth: the ``_fail`` helper that prints the ``FAIL: <exc>``
+    stderr line MUST scrub ``Bearer <token>`` sequences from the exception
+    message before printing.
+
+    Realistic leak path today is zero (the typed ``KanbanToolError`` subclasses
+    already scrub their own ``__str__`` output, and ``RuntimeError`` from
+    ``Config.from_env`` lists missing env-var names — never tokens). But the
+    audit brief required defense-in-depth at the entry-point boundary too,
+    so a future exception subclass that surfaces a bearer-token in its
+    message can't bypass the scrub.
+
+    Verified by directly invoking ``_fail`` with a synthetic exception
+    that intentionally carries a ``Bearer …`` substring in ``str(exc)``."""
+    from kanbantool_mcp.__main__ import _fail
+
+    _fail(RuntimeError("upstream echo: Authorization: Bearer leaked-token-xyz"), "hint")
+    captured = capsys.readouterr()
+    assert "leaked-token-xyz" not in captured.err
+    assert "Bearer ***" in captured.err
+    assert "hint" in captured.err
 
 
 def test_main_no_args_invokes_server_run(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

Two first-success-signal additions for the install path. Implements Proposal #5 from the M9 UX/QoL bundle.

### 1. `kanbantool-mcp --check` flag

Validates env vars + hits `whoami` over the existing client. Prints a one-line OK/FAIL signal and exits 0 on success / non-zero on failure.

Sample success:
```
OK: Alice Example (your-account) — token resolves; you can use kanbantool-mcp now
```

Per-error-class actionable hints on failure:
- **Missing env**: names the missing var(s) AND points at the token-regen URL.
- **401/403 auth**: "Auth failed. Verify KANBANTOOL_API_TOKEN at <token-regen URL>".
- **Transport**: names the host that failed AND points at firewall/DNS as the likely cause.

Modeled as a flag (not a subcommand) on purpose — keeps the v1.0 CLI surface tight. Adding a subcommand would imply more subcommands later.

### 2. Per-MCP-client README install snippets

Restructured the `Wiring it into your client` section into per-client subsections:

- **Claude Code** — shows `claude mcp add-json` CLI as the easiest path, plus pointer to manual `~/.claude.json` editing.
- **Claude Desktop** — config-file paths for macOS and Windows.
- **Cursor** — `~/.cursor/mcp.json` (with per-project alternative).
- **Continue** — uses YAML, so the snippet is in YAML (the only client that diverges).
- **Cline** — JSON via the Cline panel's MCP Servers > Edit Config button.
- **Generic MCP-over-stdio** — bare `env VAR=... uvx kanbantool-mcp` shape for any other MCP client.

The git-vs-PyPI form choice is shown once at the top as a swap-in for `args`, rather than duplicating the snippet 12 times.

The `Verify your install` section cross-links the new `--check` flag as the recommended one-shot verification step before asking the assistant to do anything with the server. The original "ask the assistant 'who am I?'" path is kept as the secondary in-assistant verification.

## Coordination

- Sent SendMessage to `kbmcp-server-shell` on first turn proposing they own README env-var docs (since they're adding new env vars) while I own install snippets. No conflicts in this PR.
- README env-var section (lines 46-54) untouched.

## Test plan

- [x] `uv run ruff check` — clean
- [x] `uv run ruff format --check` — clean
- [x] `uv run ty check` — clean
- [x] `uv run pytest -q` — 237 passed (228 existing + 9 new --check tests)
- [x] `--check` happy path: 200 from whoami, exit 0, OK signal printed
- [x] `--check` user-without-name: falls back to "user #<id>"
- [x] `--check` missing env (one var, both vars): exit non-zero, missing var named, token-regen pointer shown
- [x] `--check` 401 + 403: exit non-zero, auth hint shown
- [x] `--check` transport error: exit non-zero, network hint with host name shown
- [x] No-args invokes `server.run` (FastMCP stdio server)
- [x] `--help` documents `--check`
- [x] Manual smoke: `uvx kanbantool-mcp --help` and `env -u VARS uvx kanbantool-mcp --check` both behave correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)