### PR TITLE
chore(release-please): align pre-1.0 breaking-change convention with ryzic (bump-minor-pre-major)

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -84,12 +84,16 @@ from M7 — three commits (`refactor:` + `test:` + `chore:`), zero auto-
 bump candidates. v0.7.0 ended up via a `Release-As:` footer on an
 empty commit. v0.7.1 then bumped automatically off a `docs:` PR.
 
-A `!` after the type or a `BREAKING CHANGE:` footer triggers a major
-bump (e.g. `feat!: drop py3.10` or `fix(server): swap error
+A `!` after the type or a `BREAKING CHANGE:` footer marks a breaking
+change (e.g. `feat!: drop py3.10` or `fix(server): swap error
 code\n\nBREAKING CHANGE: clients must handle KanbanToolValidationError
-now`). Pre-1.0, breaking changes can ship as minor or patch per
-[SEMVER.md](SEMVER.md) — the `!` is reserved for the eventual major
-gate.
+now`). **Pre-1.0** — where we are today — these cut a **minor** bump,
+not a major, because `release-please-config.json` sets
+`bump-minor-pre-major: true`. The major version stays at `0` until the
+project is deliberately graduated to v1.0; the loud "this might break
+you" signal is the minor bump itself, surfaced as a `### BREAKING CHANGES`
+section in the CHANGELOG. **Post-1.0**, the standard SemVer mapping
+applies (`feat!:` → major).
 
 The `Closes #N` footer is honoured separately by `release.yml`'s
 auto-close step — see "Tag → publish flow" below.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,7 +7,8 @@
     ".": {
       "package-name": "kanbantool-mcp",
       "version-file": "src/kanbantool_mcp/__init__.py",
-      "changelog-path": "CHANGELOG.md"
+      "changelog-path": "CHANGELOG.md",
+      "bump-minor-pre-major": true
     }
   }
 }


### PR DESCRIPTION
## Summary

Adds `"bump-minor-pre-major": true` to `release-please-config.json` and flips the corresponding paragraph in `RELEASING.md` so `feat!:` / `BREAKING CHANGE:` pre-1.0 cuts a **minor** bump rather than jumping to v1.0.0.

**Why now**: M9 has two breaking-change PRs in the queue (`recent_changes(since=...)` required, `SearchResults` wrapper) that need a clear `feat!:` / `BREAKING CHANGE:` signal in the CHANGELOG. Without this config, release-please's default for `release-type=python` treats `feat!:` as a major-version trigger — which would have surprise-bumped 0.7.x to 1.0.0 on the next M9 push, prematurely freezing the stable surfaces enumerated in `SEMVER.md`.

**Alignment with ryzic**: ryzic's `release-please-config.json` already sets `bump-minor-pre-major: true` (and ryzic's SEMVER.md says explicitly: "`feat!:` / `BREAKING CHANGE:` → minor pre-1.0 rather than a major bump"). This brings kbmcp's release-please behaviour in line.

**Out of scope**: SEMVER.md's pre-1.0 paragraph already reads "Minor bumps (e.g. `0.5.0` → `0.6.0`) MAY include breaking changes" — accurate as-is, no edits needed there.

## Verification

- `python3 -c "import json; json.load(open('release-please-config.json'))"` — clean (parses)
- No code changes; ruff / format / ty / pytest unchanged

The first `feat!:` PR after this merges (M9 PR B for `recent_changes`) will be the live validation that release-please honours the flag — that's a feature, not a bug, since it'll catch any release-please config regression early.

## Test plan

- [x] `release-please-config.json` parses as valid JSON
- [x] `RELEASING.md` paragraph reads cleanly and reflects the new behaviour
- [ ] (Verified post-merge) The next `feat!:` PR cuts a minor bump, not a major

🤖 Generated with [Claude Code](https://claude.com/claude-code)