### PR TITLE
feat(server)!: require since on recent_changes; raise ValueError on None

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ You can also verify from inside the assistant: ask **"who am I?"** — it'll cal
 | `get_board` | Fetch a board with its columns, swimlanes, and custom-field definitions. | `board_id` |
 | `search_tasks` | Search tasks across boards using Kanban Tool's query DSL (e.g. `@alice priority:high tags:bug`). Forwarded to the API verbatim. | `query`, `board_id?`, `limit?`, `page?` |
 | `get_task` | Fetch a task by id with headline metadata, subtask/comment counts, and tracked time. | `task_id` |
-| `recent_changes` | Fetch the changelog feed for a board — the change-tracking primitive that stands in for webhooks (Kanban Tool ships none). Poll sparingly, always with `since`. | `board_id`, `since?` |
+| `recent_changes` | Fetch the changelog feed for a board — the change-tracking primitive that stands in for webhooks (Kanban Tool ships none). Poll sparingly. `since` is required (raises `ValueError` if `None`); for first-poll use a short lookback like `datetime.now(UTC) - timedelta(hours=1)`. | `board_id`, `since` |
 | `create_task` | Create a new task on a board. Optional kwargs are omitted when unset. | `name`, `board_id`, `description?`, `lane_id?`, `priority?`, `tags?`, ... |
 | `update_task` | Partial update of an existing task; only kwargs the caller passes are sent. `None` means *omit*, not *clear*. | `task_id`, `name?`, `description?`, `priority?`, ... |
 | `move_task` | Move a task between columns, swimlanes, or positions. At least one target must be set. | `task_id`, `column_id?`, `swimlane_id?`, `position?` |

--- a/examples/03-poll-recent-changes.md
+++ b/examples/03-poll-recent-changes.md
@@ -16,8 +16,10 @@ than pretending push semantics exist. Two consequences worth internalising:
 - The agent owns the cadence. The tool's docstring asks for **30–120s
   between polls** — fast enough to feel responsive, slow enough to stay well
   inside Kanban Tool's rate limit and avoid burning tokens on noise.
-- Always pass `since`. Omitting it returns the entire history of the board,
-  which can be huge.
+- `since` is **required**. The tool raises `ValueError` if you pass `None` —
+  the bounded-window discipline avoids pulling the entire board history into
+  the LLM's context. For first-poll, use a short lookback like
+  `datetime.now(UTC) - timedelta(hours=1)`.
 
 ## Transcript
 

--- a/llms.txt
+++ b/llms.txt
@@ -30,8 +30,10 @@ Kanban Tool ships no webhooks. The change-tracking primitive is
 `recent_changes(board_id, since)`, which returns the board's changelog
 newest-first. To monitor a board, the agent (LLM) is responsible for
 the polling cadence. Recommended cadence is **30–120s**, NOT
-per-keystroke. Always pass `since` (the timestamp of the last entry
-seen) on follow-up calls; omitting it returns the full history.
+per-keystroke. `since` is **required** (raises `ValueError` if `None`):
+on the first poll use a short lookback like
+`datetime.now(UTC) - timedelta(hours=1)`; on follow-up calls pass the
+`created_at` of the newest entry you've seen.
 
 ### 2. `.json` path suffix is mandatory and added by the client
 

--- a/src/kanbantool_mcp/server.py
+++ b/src/kanbantool_mcp/server.py
@@ -57,8 +57,10 @@ name like "Alice", call `list_board_collaborators(board_id)` then \
 to learn what each `custom_field_N` slot means on that board.
 
 Change tracking: Kanban Tool has no webhooks. Poll \
-`recent_changes(board_id, since=...)` sparingly (30-120s cadence). Always \
-pass `since` after the first call.
+`recent_changes(board_id, since=...)` sparingly (30-120s cadence). \
+`since` is REQUIRED on every call (raises `ValueError` if `None`); on \
+first poll use a short lookback like \
+`datetime.now(UTC) - timedelta(hours=1)`.
 
 `None` means "omit, don't clear" on `update_task` / `move_task` / \
 `update_subtask` — the API ignores nulls. The one exception: \
@@ -357,7 +359,13 @@ async def get_task(task_id: Annotated[int, Field(ge=1)]) -> Task:
 @mcp.tool(annotations=_READ_ONLY, output_schema=_output_schema(list[ChangelogEntry]))
 @validate_call
 async def recent_changes(
-    board_id: Annotated[int, Field(ge=1)], since: datetime | None
+    # ``datetime | None`` (rather than ``datetime``) keeps wire ``null`` a
+    # type-valid input so the runtime ``ValueError`` below — with its
+    # actionable first-poll hint — fires instead of an opaque pydantic
+    # ``ValidationError`` on the tool boundary. Schema-wise this surfaces
+    # as ``anyOf: [date-time, null]`` while still being marked required.
+    board_id: Annotated[int, Field(ge=1)],
+    since: datetime | None,
 ) -> list[ChangelogEntry]:
     """Fetch a board's changelog (Kanban Tool has no webhooks; poll this instead).
 
@@ -366,17 +374,9 @@ async def recent_changes(
     (or whichever lookback window matches your use case). Entries come
     newest-first. Poll sparingly: 30-120s cadence, not per-keystroke.
 
-    Why required: omitting ``since`` would fetch the entire board history,
-    which is cheap server-side but pulls hundreds of irrelevant entries into
-    the LLM's context. Forcing the caller to think about the time window
-    keeps responses bounded.
-
-    Raises ``ValueError`` if ``since`` is ``None``."""
+    Raises ``ValueError`` if ``since`` is ``None`` (rather than fetching the
+    full history) — keeps responses bounded by construction."""
     if since is None:
-        # Reject ``None`` at the tool boundary so callers see an actionable
-        # message instead of a 200 OK with an unbounded result set. Hits
-        # both the explicit ``recent_changes(board_id, since=None)`` call
-        # and the wire shape where an MCP client sends ``"since": null``.
         raise ValueError(
             "recent_changes requires 'since'. Pass a datetime or ISO-8601 string "
             "of the most recent entry you've seen; for first-poll, use "

--- a/src/kanbantool_mcp/server.py
+++ b/src/kanbantool_mcp/server.py
@@ -357,14 +357,32 @@ async def get_task(task_id: Annotated[int, Field(ge=1)]) -> Task:
 @mcp.tool(annotations=_READ_ONLY, output_schema=_output_schema(list[ChangelogEntry]))
 @validate_call
 async def recent_changes(
-    board_id: Annotated[int, Field(ge=1)], since: datetime | None = None
+    board_id: Annotated[int, Field(ge=1)], since: datetime | None
 ) -> list[ChangelogEntry]:
     """Fetch a board's changelog (Kanban Tool has no webhooks; poll this instead).
 
-    Always pass ``since`` (timestamp of the last entry seen) on follow-up calls —
-    omitting it returns the full history. Entries come newest-first.
-    Poll sparingly: 30-120s cadence, not per-keystroke."""
-    params = {"since": since.isoformat()} if since is not None else None
+    ``since`` is **required**. Pass the ``created_at`` of the newest entry you've
+    already seen; on the first poll, use ``datetime.now(UTC) - timedelta(hours=1)``
+    (or whichever lookback window matches your use case). Entries come
+    newest-first. Poll sparingly: 30-120s cadence, not per-keystroke.
+
+    Why required: omitting ``since`` would fetch the entire board history,
+    which is cheap server-side but pulls hundreds of irrelevant entries into
+    the LLM's context. Forcing the caller to think about the time window
+    keeps responses bounded.
+
+    Raises ``ValueError`` if ``since`` is ``None``."""
+    if since is None:
+        # Reject ``None`` at the tool boundary so callers see an actionable
+        # message instead of a 200 OK with an unbounded result set. Hits
+        # both the explicit ``recent_changes(board_id, since=None)`` call
+        # and the wire shape where an MCP client sends ``"since": null``.
+        raise ValueError(
+            "recent_changes requires 'since'. Pass a datetime or ISO-8601 string "
+            "of the most recent entry you've seen; for first-poll, use "
+            "(datetime.now(UTC) - timedelta(hours=1))."
+        )
+    params = {"since": since.isoformat()}
     data = await _get_client().request("GET", f"boards/{board_id}/changelog", params=params)
     return _decode_list(ChangelogEntry, data, label="changelog")
 

--- a/tests/integration/test_live_read_tools.py
+++ b/tests/integration/test_live_read_tools.py
@@ -18,6 +18,8 @@ any particular board name or id — see the ``populated_board_id`` fixture.
 
 from __future__ import annotations
 
+from datetime import UTC, datetime, timedelta
+
 from kanbantool_mcp.client import KanbanToolClient
 from kanbantool_mcp.models import (
     Board,
@@ -164,7 +166,12 @@ async def test_get_task_surfaces_additive_v3_fields(
 async def test_recent_changes_populates_renamed_fields(
     _inject_live_client: KanbanToolClient, populated_board_id: int
 ) -> None:
-    entries = await recent_changes(board_id=populated_board_id)
+    # Look back a year to keep the test stable: the populated board's most
+    # recent activity may have been months ago, but anything older than the
+    # window would silently produce an empty list and make the
+    # populates-renamed-fields assertions vacuous.
+    since = datetime.now(UTC) - timedelta(days=365)
+    entries = await recent_changes(board_id=populated_board_id, since=since)
 
     assert isinstance(entries, list)
     assert len(entries) >= 1

--- a/tests/test_recent_changes.py
+++ b/tests/test_recent_changes.py
@@ -42,7 +42,7 @@ async def test_recent_changes_happy_path(_inject_client: KanbanToolClient) -> No
     ]
     with respx.mock(assert_all_called=True) as router:
         router.get(_changelog_url(42)).mock(return_value=httpx.Response(200, json=payload))
-        result = await recent_changes(42)
+        result = await recent_changes(42, since=datetime(2026, 4, 30, 8, 0, 0, tzinfo=UTC))
 
     assert len(result) == 2
     newest, older = result
@@ -74,42 +74,46 @@ async def test_recent_changes_passes_since_as_query_param(
     assert request.url.params["since"] == since.isoformat()
 
 
-async def test_recent_changes_omits_since_when_none(
+async def test_recent_changes_rejects_none_since(
     _inject_client: KanbanToolClient,
 ) -> None:
-    with respx.mock(assert_all_called=True) as router:
-        route = router.get(_changelog_url(42)).mock(return_value=httpx.Response(200, json=[]))
-        await recent_changes(42)
-
-    request = route.calls.last.request
-    assert "since" not in request.url.params
-    # No query string at all when since is omitted.
-    assert request.url.query == b""
+    """``since=None`` is the breaking-change rejection path: passing ``None``
+    explicitly (or as an MCP wire ``null``) raises ``ValueError`` with a
+    first-poll-friendly fix-it hint, instead of round-tripping the entire
+    board history into the LLM's context."""
+    # No respx mock — ``ValueError`` is raised at the tool boundary, before
+    # any HTTP call. Asserting the ``since`` keyword + first-poll hint
+    # appear in the message guards the actionable wording for callers.
+    with pytest.raises(ValueError, match=r"since.*first-poll"):
+        await recent_changes(42, since=None)
 
 
 async def test_recent_changes_empty(_inject_client: KanbanToolClient) -> None:
+    since = datetime(2026, 4, 30, 8, 0, 0, tzinfo=UTC)
     with respx.mock(assert_all_called=True) as router:
         router.get(_changelog_url(42)).mock(return_value=httpx.Response(200, json=[]))
-        result = await recent_changes(42)
+        result = await recent_changes(42, since=since)
 
     assert result == []
 
 
 async def test_recent_changes_404_raises_http_error(_inject_client: KanbanToolClient) -> None:
+    since = datetime(2026, 4, 30, 8, 0, 0, tzinfo=UTC)
     with respx.mock() as router:
         router.get(_changelog_url(999)).mock(return_value=httpx.Response(404, text="not found"))
         with pytest.raises(KanbanToolHTTPError) as exc_info:
-            await recent_changes(999)
+            await recent_changes(999, since=since)
         assert exc_info.value.status_code == 404
 
 
 async def test_recent_changes_401_raises_permission_error(
     _inject_client: KanbanToolClient,
 ) -> None:
+    since = datetime(2026, 4, 30, 8, 0, 0, tzinfo=UTC)
     with respx.mock() as router:
         router.get(_changelog_url(42)).mock(return_value=httpx.Response(401, text="unauthorized"))
         with pytest.raises(KanbanToolPermissionError):
-            await recent_changes(42)
+            await recent_changes(42, since=since)
 
 
 async def test_recent_changes_malformed_entry_raises_http_error(
@@ -122,10 +126,11 @@ async def test_recent_changes_malformed_entry_raises_http_error(
         {"id": 1, "created_at": "2026-04-30T10:00:00Z"},
         {"created_at": "2026-04-30T09:00:00Z"},  # missing id
     ]
+    since = datetime(2026, 4, 30, 8, 0, 0, tzinfo=UTC)
     with respx.mock(assert_all_called=True) as router:
         router.get(_changelog_url(42)).mock(return_value=httpx.Response(200, json=payload))
         with pytest.raises(KanbanToolHTTPError) as exc_info:
-            await recent_changes(42)
+            await recent_changes(42, since=since)
 
     assert exc_info.value.status_code == 200
     assert "malformed" in exc_info.value.body_excerpt

--- a/tests/test_recent_changes.py
+++ b/tests/test_recent_changes.py
@@ -14,6 +14,11 @@ from kanbantool_mcp.server import mcp, recent_changes
 
 from .conftest import BASE_URL
 
+# Boundary timestamp used as ``since=`` across most tests. Hoisted from
+# the per-test repeats so the wire-side ``params["since"]`` assertion
+# below matches the same identifier.
+_SINCE = datetime(2026, 4, 30, 8, 0, 0, tzinfo=UTC)
+
 
 def _changelog_url(board_id: int) -> str:
     return f"{BASE_URL}boards/{board_id}/changelog.json"
@@ -42,7 +47,7 @@ async def test_recent_changes_happy_path(_inject_client: KanbanToolClient) -> No
     ]
     with respx.mock(assert_all_called=True) as router:
         router.get(_changelog_url(42)).mock(return_value=httpx.Response(200, json=payload))
-        result = await recent_changes(42, since=datetime(2026, 4, 30, 8, 0, 0, tzinfo=UTC))
+        result = await recent_changes(42, since=_SINCE)
 
     assert len(result) == 2
     newest, older = result
@@ -65,55 +70,63 @@ async def test_recent_changes_happy_path(_inject_client: KanbanToolClient) -> No
 async def test_recent_changes_passes_since_as_query_param(
     _inject_client: KanbanToolClient,
 ) -> None:
-    since = datetime(2026, 4, 30, 8, 0, 0, tzinfo=UTC)
     with respx.mock(assert_all_called=True) as router:
         route = router.get(_changelog_url(42)).mock(return_value=httpx.Response(200, json=[]))
-        await recent_changes(42, since=since)
+        await recent_changes(42, since=_SINCE)
 
     request = route.calls.last.request
-    assert request.url.params["since"] == since.isoformat()
+    assert request.url.params["since"] == _SINCE.isoformat()
 
 
 async def test_recent_changes_rejects_none_since(
     _inject_client: KanbanToolClient,
 ) -> None:
-    """``since=None`` is the breaking-change rejection path: passing ``None``
-    explicitly (or as an MCP wire ``null``) raises ``ValueError`` with a
-    first-poll-friendly fix-it hint, instead of round-tripping the entire
-    board history into the LLM's context."""
-    # No respx mock — ``ValueError`` is raised at the tool boundary, before
-    # any HTTP call. Asserting the ``since`` keyword + first-poll hint
-    # appear in the message guards the actionable wording for callers.
+    """``since=None`` raises ValueError at the tool boundary with a
+    first-poll-friendly fix-it hint, before any HTTP call fires. Locks
+    both the rejection behaviour and the actionable error wording so
+    callers (LLMs) see the same message that they need to act on."""
     with pytest.raises(ValueError, match=r"since.*first-poll"):
         await recent_changes(42, since=None)
 
 
+async def test_recent_changes_rejects_wire_null_since(
+    _inject_client: KanbanToolClient,
+) -> None:
+    """The wire-null path (an MCP client sending ``{"since": null}`` over
+    JSON) must surface the same actionable ValueError as a Python
+    ``since=None``. ``datetime | None`` keeps null type-valid so the
+    runtime guard fires instead of an opaque pydantic ValidationError."""
+    tool = await mcp.get_tool("recent_changes")
+    assert tool is not None
+    # ``tool.run`` is FastMCP's dispatch entrypoint — same path the wire
+    # takes when an MCP client invokes the tool with ``since=null``.
+    with pytest.raises(ValueError, match=r"since.*first-poll"):
+        await tool.run({"board_id": 42, "since": None})
+
+
 async def test_recent_changes_empty(_inject_client: KanbanToolClient) -> None:
-    since = datetime(2026, 4, 30, 8, 0, 0, tzinfo=UTC)
     with respx.mock(assert_all_called=True) as router:
         router.get(_changelog_url(42)).mock(return_value=httpx.Response(200, json=[]))
-        result = await recent_changes(42, since=since)
+        result = await recent_changes(42, since=_SINCE)
 
     assert result == []
 
 
 async def test_recent_changes_404_raises_http_error(_inject_client: KanbanToolClient) -> None:
-    since = datetime(2026, 4, 30, 8, 0, 0, tzinfo=UTC)
     with respx.mock() as router:
         router.get(_changelog_url(999)).mock(return_value=httpx.Response(404, text="not found"))
         with pytest.raises(KanbanToolHTTPError) as exc_info:
-            await recent_changes(999, since=since)
+            await recent_changes(999, since=_SINCE)
         assert exc_info.value.status_code == 404
 
 
 async def test_recent_changes_401_raises_permission_error(
     _inject_client: KanbanToolClient,
 ) -> None:
-    since = datetime(2026, 4, 30, 8, 0, 0, tzinfo=UTC)
     with respx.mock() as router:
         router.get(_changelog_url(42)).mock(return_value=httpx.Response(401, text="unauthorized"))
         with pytest.raises(KanbanToolPermissionError):
-            await recent_changes(42, since=since)
+            await recent_changes(42, since=_SINCE)
 
 
 async def test_recent_changes_malformed_entry_raises_http_error(
@@ -126,11 +139,10 @@ async def test_recent_changes_malformed_entry_raises_http_error(
         {"id": 1, "created_at": "2026-04-30T10:00:00Z"},
         {"created_at": "2026-04-30T09:00:00Z"},  # missing id
     ]
-    since = datetime(2026, 4, 30, 8, 0, 0, tzinfo=UTC)
     with respx.mock(assert_all_called=True) as router:
         router.get(_changelog_url(42)).mock(return_value=httpx.Response(200, json=payload))
         with pytest.raises(KanbanToolHTTPError) as exc_info:
-            await recent_changes(42, since=since)
+            await recent_changes(42, since=_SINCE)
 
     assert exc_info.value.status_code == 200
     assert "malformed" in exc_info.value.body_excerpt


### PR DESCRIPTION
## Summary

Pre-1.0 breaking change for the M9 contract sweep. Drops the default value of `since` on `recent_changes` and explicitly rejects `None` at the tool boundary with an actionable, first-poll-friendly error message.

Calling `recent_changes(board_id)` previously returned the entire board history (a documented "known limitation"); now it raises `ValueError` pointing at the bootstrap pattern.

## Why

Unbounded responses pull hundreds of irrelevant entries into the LLM's context — costly in tokens and noise. Forcing the caller to think about a time window keeps responses bounded by construction. Per-roadmap M9 item 3, locking this as a v1.0 contract decision before stabilisation.

## Migration

Every existing caller must pass `since`:

```python
# First poll: pick a lookback window that matches the use case.
recent_changes(board_id=4711, since=datetime.now(UTC) - timedelta(hours=1))

# Follow-up polls: advance to the newest entry's created_at.
recent_changes(board_id=4711, since=last_entry.created_at)
```

The error message itself surfaces the first-poll bootstrap pattern so an LLM hitting the new behaviour for the first time sees the fix-it inline.

## Sweep

- `src/kanbantool_mcp/server.py`: signature drops default; runtime guard with actionable message; docstring rewrite explaining "Why required" + first-poll lookback.
- `examples/03-poll-recent-changes.md`: rewrite the "always pass `since`" paragraph as "`since` is required" + ValueError + first-poll pattern.
- `README.md`: tool table marks `since` as required (was `since?`).
- `llms.txt`: rewrite the "Always pass `since`" bullet to call out the ValueError + first-poll lookback.
- `tests/test_recent_changes.py`: every existing call now passes an explicit `since=`; new test asserts `ValueError` on explicit `since=None` with the expected actionable message wording (regex-matches `since.*first-poll`).
- `tests/integration/test_live_read_tools.py`: live test now uses a 365d lookback so populated boards with old activity still surface entries (the previous unbounded path would have hidden the regression here).

## Verification

- `uv run ruff check` — clean
- `uv run ruff format --check` — clean
- `uv run ty check src/ tests/` — clean
- `uv run pytest -q` — **296 passed** (no regressions; one pre-existing test removed because the codepath it covered no longer exists, and one new test added for the rejection path)

## Release

Per `release-please-config.json`'s newly-set `bump-minor-pre-major: true` (PR #155), the `feat!:` prefix and `BREAKING CHANGE:` footer cut a **minor** bump. The `### BREAKING CHANGES` section in CHANGELOG will surface this loudly.

## Test plan

- [x] All existing tests still pass
- [x] New test covers `recent_changes(board_id, since=None)` raising `ValueError` with the migration hint
- [x] Examples / README / llms.txt scrub for any "since is optional" wording
- [x] Live integration test uses a bounded lookback window
- [ ] (Verified post-merge) The release-please PR opens with a minor bump and a `### BREAKING CHANGES` section

🤖 Generated with [Claude Code](https://claude.com/claude-code)