### PR TITLE
feat(server,models)!: search_tasks returns SearchResults wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ You can also verify from inside the assistant: ask **"who am I?"** — it'll cal
 | --- | --- | --- |
 | `list_boards` | List boards visible to the authenticated user. | — |
 | `get_board` | Fetch a board with its columns, swimlanes, and custom-field definitions. | `board_id` |
-| `search_tasks` | Search tasks across boards using Kanban Tool's query DSL (e.g. `@alice priority:high tags:bug`). Forwarded to the API verbatim. | `query`, `board_id?`, `limit?`, `page?` |
+| `search_tasks` | Search tasks across boards using Kanban Tool's query DSL (e.g. `@alice priority:high tags:bug`). Forwarded to the API verbatim. Returns a `SearchResults` wrapper exposing `results`, `total_count`, `page`, and `has_more`. | `query`, `board_id?`, `limit?`, `page?` |
 | `get_task` | Fetch a task by id with headline metadata, subtask/comment counts, and tracked time. | `task_id` |
 | `recent_changes` | Fetch the changelog feed for a board — the change-tracking primitive that stands in for webhooks (Kanban Tool ships none). Poll sparingly. `since` is required (raises `ValueError` if `None`); for first-poll use a short lookback like `datetime.now(UTC) - timedelta(hours=1)`. | `board_id`, `since` |
 | `create_task` | Create a new task on a board. Optional kwargs are omitted when unset. | `name`, `board_id`, `description?`, `lane_id?`, `priority?`, `tags?`, ... |

--- a/examples/01-board-status.md
+++ b/examples/01-board-status.md
@@ -47,12 +47,17 @@ walks `list_boards` → `get_board` → `search_tasks` and summarises by column.
 ```
 
 ```json
-[
-  {"id": 50231, "name": "Wire up Stripe webhook",  "lane_id": 90002, "priority": "high",   "assigned_user_id": 12, "tags": "backend,billing"},
-  {"id": 50232, "name": "Refactor auth middleware","lane_id": 90002, "priority": "medium", "assigned_user_id": 18},
-  {"id": 50233, "name": "Onboarding tour copy",    "lane_id": 90003, "priority": "low",    "assigned_user_id": 44},
-  {"id": 50234, "name": "Migrate Postgres to 16",  "lane_id": 90001, "priority": "high",   "assigned_user_id": null}
-]
+{
+  "results": [
+    {"id": 50231, "name": "Wire up Stripe webhook",  "lane_id": 90002, "priority": "high",   "assigned_user_id": 12, "tags": "backend,billing"},
+    {"id": 50232, "name": "Refactor auth middleware","lane_id": 90002, "priority": "medium", "assigned_user_id": 18},
+    {"id": 50233, "name": "Onboarding tour copy",    "lane_id": 90003, "priority": "low",    "assigned_user_id": 44},
+    {"id": 50234, "name": "Migrate Postgres to 16",  "lane_id": 90001, "priority": "high",   "assigned_user_id": null}
+  ],
+  "total_count": 4,
+  "page": 1,
+  "has_more": false
+}
 ```
 
 **Assistant:** Engineering has 4 active tasks:

--- a/examples/04-user-discovery.md
+++ b/examples/04-user-discovery.md
@@ -101,9 +101,14 @@ assigning — `get_user` returns the full profile.
 ```
 
 ```json
-[
-  {"id": 50412, "name": "Auth migration kickoff", "board_id": 4711, "lane_id": 90002}
-]
+{
+  "results": [
+    {"id": 50412, "name": "Auth migration kickoff", "board_id": 4711, "lane_id": 90002}
+  ],
+  "total_count": 1,
+  "page": 1,
+  "has_more": false
+}
 ```
 
 ```text

--- a/src/kanbantool_mcp/models.py
+++ b/src/kanbantool_mcp/models.py
@@ -496,3 +496,36 @@ class TimeTracker(BaseModel):
     def is_running(self) -> bool:
         """True iff the timer is still active (no ``ended_at`` set)."""
         return self.ended_at is None
+
+
+class SearchResults(BaseModel):
+    """Paginated wrapper for ``search_tasks`` responses.
+
+    The Kanban Tool API wraps task-search results in
+    ``{"results": [...], "pagination": {...}}``. We surface the same shape
+    typed so callers get pagination context (total count, current page,
+    whether more pages exist) alongside the matched tasks rather than
+    inferring it from ``len(results) == limit`` (which is wrong on the
+    last page) or another HTTP round-trip.
+
+    Field names are part of the v1.0 contract — see SEMVER.md. ``total_count``
+    rather than ``total`` to disambiguate from ``len(results)``; ``has_more``
+    rather than ``next_page`` because the LLM cares about "is there another
+    page" (a boolean) more than about computing the next page number itself.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    # The page of matched tasks. Always populated, possibly empty.
+    results: list[Task] = Field(default_factory=list)
+    # Total number of matches across all pages. ``None`` when the API's
+    # pagination envelope is absent (the API drops it for unpaginated
+    # legacy responses); always present in the modern paginated path.
+    total_count: int | None = None
+    # 1-indexed page number of this response.
+    page: int = 1
+    # ``True`` when at least one further page exists. Derived from the
+    # API's ``page`` < ``pages_count``; conservatively ``False`` when the
+    # pagination envelope is absent or malformed (avoids a false "more
+    # exists" claim that would prompt the LLM to fetch nothing).
+    has_more: bool = False

--- a/src/kanbantool_mcp/server.py
+++ b/src/kanbantool_mcp/server.py
@@ -19,6 +19,7 @@ from .models import (
     Collaborator,
     Comment,
     CustomFieldDefinition,
+    SearchResults,
     Subtask,
     Task,
     TimeTracker,
@@ -443,7 +444,7 @@ async def search_tasks(
     board_id: Annotated[int, Field(ge=1)] | None = None,
     limit: Annotated[int, Field(ge=1)] = 25,
     page: Annotated[int, Field(ge=1)] = 1,
-) -> list[Task]:
+) -> SearchResults:
     """Search tasks across boards using Kanban Tool's query DSL.
 
     ``query`` is forwarded verbatim — do not URL-encode, do not wrap the whole
@@ -464,6 +465,17 @@ async def search_tasks(
     things the DSL doesn't cover (comment full-text, fuzzy match) — say so
     instead. ``board_id`` scopes to one board (omit to search all visible).
     ``limit`` is clamped to 50; paginate further with ``page`` (1-indexed).
+
+    Returns a ``SearchResults`` wrapper:
+
+    - ``results`` — the list of matched ``Task`` objects on this page.
+    - ``total_count`` — total matches across all pages (from the API's
+      pagination envelope; ``None`` if the API omits the envelope).
+    - ``page`` — 1-indexed page number of this response.
+    - ``has_more`` — ``True`` when at least one further page exists. Use
+      this to decide whether to bump ``page`` and call again, instead of
+      heuristics on ``len(results) == limit`` (which is wrong on the
+      last page).
     """
     capped_limit = min(limit, _SEARCH_TASKS_MAX_LIMIT)
     params: dict[str, str | int] = {
@@ -478,8 +490,34 @@ async def search_tasks(
     # When ``limit``/``page`` are supplied (always, here), the API wraps
     # results in ``{"results": [...], "pagination": {...}}``. Without those
     # params it returns a bare list — but we always paginate.
-    raw = data.get("results", []) if isinstance(data, dict) else []
-    return _decode_list(Task, raw, label="search")
+    raw_results: list[Any] = []
+    pagination: dict[str, Any] = {}
+    if isinstance(data, dict):
+        raw_results = data.get("results") or []
+        envelope = data.get("pagination")
+        if isinstance(envelope, dict):
+            pagination = envelope
+    tasks = _decode_list(Task, raw_results, label="search")
+
+    # Surface the API's pagination envelope as typed fields. Defaults
+    # below are intentionally conservative: ``total_count=None`` and
+    # ``has_more=False`` when the envelope is missing or malformed, so
+    # callers never get a phantom "more pages exist" signal that would
+    # prompt a wasted follow-up request.
+    total_count = pagination.get("results_count")
+    if not isinstance(total_count, int):
+        total_count = None
+    pages_count = pagination.get("pages_count")
+    has_more = isinstance(pages_count, int) and page < pages_count
+    response_page = pagination.get("page")
+    if not isinstance(response_page, int):
+        response_page = page
+    return SearchResults(
+        results=tasks,
+        total_count=total_count,
+        page=response_page,
+        has_more=has_more,
+    )
 
 
 @_write_tool(annotations=_WRITE, output_schema=_output_schema(Task))

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -66,8 +66,8 @@ async def populated_board_id(_inject_live_client: KanbanToolClient) -> int:
     """
     boards = await list_boards()
     for board in boards:
-        tasks = await search_tasks(query="archived:false", board_id=board.id)
-        if tasks:
+        response = await search_tasks(query="archived:false", board_id=board.id)
+        if response.results:
             return board.id
     pytest.skip(
         "no board with non-archived tasks on the test account; "

--- a/tests/integration/test_live_read_tools.py
+++ b/tests/integration/test_live_read_tools.py
@@ -74,14 +74,17 @@ async def test_search_tasks_filters_archived(
     # Earlier spike probes saw ``/tasks/search.json`` 500 on an empty account;
     # against a populated board the call should succeed. If it still 500s,
     # that's a real upstream finding worth flagging in CI output.
-    tasks = await search_tasks(query="archived:false", board_id=populated_board_id)
+    response = await search_tasks(query="archived:false", board_id=populated_board_id)
 
-    assert isinstance(tasks, list)
-    assert len(tasks) >= 1
-    assert all(isinstance(t, Task) for t in tasks)
-    assert all(t.board_id == populated_board_id for t in tasks)
+    assert len(response.results) >= 1
+    assert all(isinstance(t, Task) for t in response.results)
+    assert all(t.board_id == populated_board_id for t in response.results)
     # ``archived:false`` should mean the filter behaved.
-    assert all(t.archived_at is None for t in tasks)
+    assert all(t.archived_at is None for t in response.results)
+    # Pagination envelope is populated by the live API.
+    assert response.total_count is None or response.total_count >= len(response.results)
+    assert response.page == 1
+    assert isinstance(response.has_more, bool)
 
 
 async def test_get_task_populates_renamed_wire_fields(
@@ -92,8 +95,8 @@ async def test_get_task_populates_renamed_wire_fields(
     # LLM agent would actually use.
     board = await get_board(populated_board_id)
     search_hits = await search_tasks(query="archived:false", board_id=populated_board_id)
-    assert search_hits, "populated_board_id fixture promised non-archived tasks"
-    task_id = search_hits[0].id
+    assert search_hits.results, "populated_board_id fixture promised non-archived tasks"
+    task_id = search_hits.results[0].id
 
     task = await get_task(task_id)
 
@@ -125,8 +128,8 @@ async def test_get_task_surfaces_additive_v3_fields(
     typed attributes must exist on the resulting ``Task`` and respect their
     declared types where present."""
     search_hits = await search_tasks(query="archived:false", board_id=populated_board_id)
-    assert search_hits, "populated_board_id fixture promised non-archived tasks"
-    task_id = search_hits[0].id
+    assert search_hits.results, "populated_board_id fixture promised non-archived tasks"
+    task_id = search_hits.results[0].id
 
     task = await get_task(task_id)
 
@@ -199,8 +202,8 @@ async def test_list_subtasks_and_inline_task_subtasks_agree(
     than counts. This test would have caught the broken nested-endpoint path
     pre-fix (the old code 404'd live)."""
     search_hits = await search_tasks(query="archived:false", board_id=populated_board_id)
-    assert search_hits, "populated_board_id fixture promised non-archived tasks"
-    task_id = search_hits[0].id
+    assert search_hits.results, "populated_board_id fixture promised non-archived tasks"
+    task_id = search_hits.results[0].id
 
     subtasks = await list_subtasks(task_id)
     assert isinstance(subtasks, list)
@@ -290,8 +293,8 @@ async def test_get_task_collects_custom_field_values(
     ``custom_fields`` dict. Verify the lift happens against a real task —
     on the welcome board they're all ``None``, but the keys must be there."""
     search_hits = await search_tasks(query="archived:false", board_id=populated_board_id)
-    assert search_hits, "populated_board_id fixture promised non-archived tasks"
-    task_id = search_hits[0].id
+    assert search_hits.results, "populated_board_id fixture promised non-archived tasks"
+    task_id = search_hits.results[0].id
     task = await get_task(task_id)
 
     # On any board with all 15 slots emitted (every Kanban Tool board, per

--- a/tests/test_search_tasks.py
+++ b/tests/test_search_tasks.py
@@ -8,6 +8,7 @@ import respx
 
 from kanbantool_mcp.client import KanbanToolClient
 from kanbantool_mcp.exceptions import KanbanToolHTTPError, KanbanToolPermissionError
+from kanbantool_mcp.models import SearchResults
 from kanbantool_mcp.server import search_tasks
 
 from .conftest import BASE_URL
@@ -47,10 +48,14 @@ async def test_search_tasks_happy_path(_inject_client: KanbanToolClient) -> None
     }
     with respx.mock(assert_all_called=True) as router:
         router.get(SEARCH_URL).mock(return_value=httpx.Response(200, json=payload))
-        results = await search_tasks(query="@alice priority:high")
+        response = await search_tasks(query="@alice priority:high")
 
-    assert len(results) == 2
-    first, second = results
+    assert isinstance(response, SearchResults)
+    assert response.total_count == 2
+    assert response.page == 1
+    assert response.has_more is False
+    assert len(response.results) == 2
+    first, second = response.results
     assert first.id == 1
     assert first.name == "Ship release"
     assert first.board_id == 7
@@ -103,9 +108,11 @@ async def test_search_tasks_forwards_board_id_when_provided(
 async def test_search_tasks_empty_results(_inject_client: KanbanToolClient) -> None:
     with respx.mock(assert_all_called=True) as router:
         router.get(SEARCH_URL).mock(return_value=httpx.Response(200, json=_EMPTY_RESPONSE))
-        results = await search_tasks(query="name:nothing-matches")
+        response = await search_tasks(query="name:nothing-matches")
 
-    assert results == []
+    assert response.results == []
+    assert response.total_count == 0
+    assert response.has_more is False
 
 
 async def test_search_tasks_pagination_forwarded(_inject_client: KanbanToolClient) -> None:
@@ -185,9 +192,69 @@ async def test_search_tasks_drops_unknown_task_fields(
     }
     with respx.mock(assert_all_called=True) as router:
         router.get(SEARCH_URL).mock(return_value=httpx.Response(200, json=payload))
-        results = await search_tasks(query="name:round-trip")
+        response = await search_tasks(query="name:round-trip")
 
-    assert len(results) == 1
-    assert results[0].id == 99
-    assert results[0].name == "Round trip"
-    assert not hasattr(results[0], "speculative_future_field")
+    assert len(response.results) == 1
+    assert response.results[0].id == 99
+    assert response.results[0].name == "Round trip"
+    assert not hasattr(response.results[0], "speculative_future_field")
+
+
+async def test_search_tasks_has_more_true_when_more_pages_exist(
+    _inject_client: KanbanToolClient,
+) -> None:
+    """When the API reports ``page < pages_count``, ``has_more`` is True
+    so callers know to bump ``page`` and call again."""
+    payload = {
+        "results": [{"id": i, "name": f"task-{i}"} for i in range(25)],
+        "pagination": {"results_count": 73, "page": 1, "pages_count": 3},
+    }
+    with respx.mock(assert_all_called=True) as router:
+        router.get(SEARCH_URL).mock(return_value=httpx.Response(200, json=payload))
+        response = await search_tasks(query="name:task")
+
+    assert response.total_count == 73
+    assert response.page == 1
+    assert response.has_more is True
+    assert len(response.results) == 25
+
+
+async def test_search_tasks_has_more_false_on_last_page(
+    _inject_client: KanbanToolClient,
+) -> None:
+    """``has_more=False`` even when ``len(results) == limit`` if the API
+    says we're on the last page — guards against the off-by-one bug where
+    a full final page would otherwise look like 'more exist'."""
+    payload = {
+        # A full page worth of results...
+        "results": [{"id": i, "name": f"task-{i}"} for i in range(25)],
+        # ...but the pagination envelope confirms it's the last one.
+        "pagination": {"results_count": 75, "page": 3, "pages_count": 3},
+    }
+    with respx.mock(assert_all_called=True) as router:
+        router.get(SEARCH_URL).mock(return_value=httpx.Response(200, json=payload))
+        response = await search_tasks(query="name:task", page=3)
+
+    assert response.has_more is False
+    assert response.page == 3
+
+
+async def test_search_tasks_missing_pagination_envelope_is_safe(
+    _inject_client: KanbanToolClient,
+) -> None:
+    """If the API ever omits the ``pagination`` envelope (legacy responses
+    without ``limit``/``page``), the wrapper still parses cleanly with
+    conservative defaults: ``total_count=None``, ``has_more=False``."""
+    payload = {
+        "results": [{"id": 1, "name": "ok"}],
+        # No 'pagination' key.
+    }
+    with respx.mock(assert_all_called=True) as router:
+        router.get(SEARCH_URL).mock(return_value=httpx.Response(200, json=payload))
+        response = await search_tasks(query="name:ok")
+
+    assert len(response.results) == 1
+    assert response.total_count is None
+    assert response.has_more is False
+    # ``page`` falls back to the request's page (1).
+    assert response.page == 1


### PR DESCRIPTION
## Summary

Pre-1.0 breaking change for the M9 contract sweep. Replaces `search_tasks`'s bare `list[Task]` return with a typed `SearchResults` wrapper that surfaces the API's pagination envelope alongside the matched tasks.

The Kanban Tool API already wraps responses as `{"results": [...], "pagination": {...}}` when `limit`/`page` are set — the previous code threw the envelope away and surfaced only `results`. The wrapper preserves it as four fields the LLM can use directly.

## v1.0 contract — locked field names

| Field | Type | Source |
|---|---|---|
| `results` | `list[Task]` | API's `results[]` |
| `total_count` | `int \| None` | API's `pagination.results_count` (None when envelope absent) |
| `page` | `int` | API's `pagination.page` (falls back to request `page`) |
| `has_more` | `bool` | Derived from `page < pages_count` |

**Naming rationale** — locked because these become v1.0 contract:
- `total_count`, **not** `total` — disambiguates from `len(results)`. A single-word `total` invites the bug "is this the page count or the total count?"
- `has_more`, **not** `next_page` — the LLM cares about the boolean ("should I fetch another page?") more than the arithmetic. `next_page` would also tempt callers into building their own pagination logic instead of trusting the envelope.
- `has_more` is derived from the **API's `pagination` envelope** (`page < pages_count`), **not** from `len(results) == limit`. The latter is wrong on the last page when results happen to be a full multiple of limit (test case included).

Conservative defaults — `total_count=None`, `has_more=False` — when the envelope is absent so callers never get a phantom "more pages exist" signal that would prompt a wasted follow-up request.

## Migration

```python
# Before:
tasks = await search_tasks(query="...")
for t in tasks:
    ...

# After:
response = await search_tasks(query="...")
for t in response.results:
    ...
if response.has_more:
    next_page = await search_tasks(query="...", page=response.page + 1)
```

## Sweep

- `src/kanbantool_mcp/models.py`: new `SearchResults` BaseModel.
- `src/kanbantool_mcp/server.py`: `search_tasks` return type + body. Preserves the API's pagination envelope; builds `SearchResults` with conservative defaults when the envelope is missing or malformed.
- `README.md`: tool table mentions the wrapper.
- `examples/01-board-status.md`, `examples/04-user-discovery.md`: example responses show the wrapper shape with all four fields.
- `tests/integration/conftest.py` + `test_live_read_tools.py`: every `search_tasks` consumer reads from `.results`.
- `tests/test_search_tasks.py`: existing assertions updated. **Three new tests** cover:
  - `has_more=True` when more pages exist
  - `has_more=False` on a full last page (the off-by-one guard)
  - Missing pagination envelope yields conservative defaults

## Verification

- `uv run ruff check` — clean
- `uv run ruff format --check` — clean
- `uv run ty check src/ tests/` — clean
- `uv run pytest -q` — **322 passed** (no regressions; 3 new SearchResults coverage tests)

## Release

Per the M9 PR B alignment (`bump-minor-pre-major: true`), the `feat!:` prefix and `BREAKING CHANGE:` footer cut a **minor** bump. The `### BREAKING CHANGES` section in CHANGELOG will surface this loudly.

## Test plan

- [x] All existing tests still pass
- [x] New tests cover happy path, more-pages, last-page off-by-one, and missing envelope
- [x] Examples + README + integration tests scrubbed for `.results` access
- [x] Field names locked in PR description as v1.0 contract
- [ ] (Verified post-merge) The release-please PR opens with a minor bump and a `### BREAKING CHANGES` section

🤖 Generated with [Claude Code](https://claude.com/claude-code)