### PR TITLE
fix(client): apply GET-only filter to TransportError retry to match 429/5xx policy

### DIFF
--- a/src/kanbantool_mcp/client.py
+++ b/src/kanbantool_mcp/client.py
@@ -311,7 +311,15 @@ class KanbanToolClient:
 
         try:
             response = await self._http.request(method, normalized, **kwargs)
-        except httpx.TransportError:
+        except httpx.TransportError as first_error:
+            # GET-only — same at-most-once write rationale as the 429/5xx retry
+            # below (see ``_RETRYABLE_STATUS_CODES`` module-scope comment). A
+            # POST that succeeded server-side but tripped a transport error
+            # before the response body finished streaming would, on retry,
+            # double-create the resource. Surface the typed transport error
+            # immediately and let the agent decide whether to re-issue.
+            if method.upper() != "GET":
+                raise _wrap_transport_error(first_error) from first_error
             await asyncio.sleep(_RETRY_BACKOFF_SECONDS)
             try:
                 response = await self._http.request(method, normalized, **kwargs)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -392,6 +392,26 @@ async def test_writes_do_not_retry_on_5xx(
         assert recorded_sleeps == []
 
 
+@pytest.mark.parametrize("method", ["POST", "PUT", "PATCH", "DELETE"])
+async def test_writes_do_not_retry_on_transport_error(
+    method: str, client: KanbanToolClient, recorded_sleeps: list[float]
+) -> None:
+    """Same at-most-once write semantics as ``test_writes_do_not_retry_on_5xx``,
+    extended to the transport-error retry path: a POST that succeeded
+    server-side but tripped a transport error mid-response must NOT retry,
+    or the server would double-create the resource. The first transport
+    error surfaces immediately as ``KanbanToolTransportError``."""
+    with respx.mock() as router:
+        route = router.request(method, f"{BASE_URL}tasks/1.json").mock(
+            side_effect=httpx.ConnectError("boom")
+        )
+        with pytest.raises(KanbanToolTransportError) as exc_info:
+            await client.request(method, "tasks/1")
+        assert isinstance(exc_info.value.__cause__, httpx.TransportError)
+        assert route.call_count == 1
+        assert recorded_sleeps == []
+
+
 async def test_get_retries_only_on_429_and_5xx_not_on_other_4xx(
     client: KanbanToolClient, recorded_sleeps: list[float]
 ) -> None:


### PR DESCRIPTION
## Bug

The pre-existing `httpx.TransportError` retry block in `client.py` was not method-filtered: it retried POST/PUT/PATCH/DELETE on transport failure. PR #145 carefully avoids this exact double-create risk for 429/5xx (GET-only, at-most-once write semantics), but the older transport-error retry contradicted the same principle.

A POST that succeeded server-side but tripped a transport error before the response body finished streaming would, on retry, double-create the resource. The Kanban Tool API has no idempotency-key support, so this is a real double-write hazard that has to be enforced client-side.

## Fix

Apply the same `if method.upper() != "GET":` gate PR #145 introduced for 429/5xx to the transport-error retry path. Writes (POST/PUT/PATCH/DELETE) now surface the typed `KanbanToolTransportError` immediately on the first transport error, leaving the agent (LLM) to decide whether to re-issue the write itself. GET retry behavior is unchanged.

The gate sits inside the `except httpx.TransportError` arm so the at-most-once decision and the retry are visually colocated, mirroring the structure of the existing 429/5xx GET-only gate immediately below it.

## Test plan

- [x] First transport error on a write surfaces immediately as `KanbanToolTransportError`, not retried (new parametrized test `test_writes_do_not_retry_on_transport_error` covers POST/PUT/PATCH/DELETE × `httpx.ConnectError`).
- [x] First transport error on a GET still retries once (existing `test_transport_error_then_success_retries`).
- [x] Two transport errors on a GET still surface as `KanbanToolTransportError` after the second attempt (existing `test_transport_error_twice_raises`).
- [x] `uv run ruff check` clean.
- [x] `uv run ruff format --check` clean.
- [x] `uv run ty check` clean.
- [x] `uv run pytest -q` — 357 passed (was 353, +4 from the new parametrized test).

Closes #150. Pattern source: PR #145.