### PR TITLE
docs: promote two implicit principles + add tool-surface drift note

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,16 @@ M5 — Custom-field writes & comment polish:
 - **M6** — v1.0 readiness: SemVer commitment policy, README pass, error-message audit, RELEASING.md updates. *Complete.*
 - **M7** — Pre-1.0 naming sweep: align Python parameter names with wire shapes / sibling tools before v1.0 locks them in. `add_comment(text=...)` → `add_comment(content=...)` (matches the wire field that the M5 bugfix had to send anyway). `add_subtask(title=...)` → `add_subtask(name=...)` (matches `Subtask.name` and `update_subtask(name=...)`). Wire bodies unchanged; this is purely a Python parameter rename. *Complete.*
 
+## Principles
+
+**Be honest about the upstream, even when awkward.** Surface what the Kanban Tool API actually does, not a tidied-up version of it. LLM-facing defaults belong in docstrings, explicit; do not invent windows, synthesize dry-run results, or paper over missing endpoints with plausible-looking shims.
+
+In practice: every docstring spells out the Rails `{"task": {...}}` envelope vs. flat body, soft-delete vs. hard, omit-vs-clear semantics, and the absence of comment-edit and bulk list-users endpoints — rather than letting the LLM guess.
+
+**Stateless write semantics; every write returns the updated resource.** Write tools decode and return the post-write resource so the caller can confirm state without a follow-up `get_*`. The return shape of a write tool is part of the contract, especially as the project locks v1.0.
+
+In practice: every write path runs `Model.model_validate(...)` on the response and returns the typed model — `update_task`, `move_task`, `add_comment`, `delete_comment`, `set_custom_field`, the subtask family, and the timer family all follow the pattern. New write tools must too.
+
 ## Codebase conventions
 
 - **Client singleton** — `server._get_client()` is a lazy module-level singleton (`_client: KanbanToolClient | None`). The stdio MCP runs on a single asyncio loop on a single thread, so no lock around init. Tools call `_get_client()` per request; tests overwrite `server._client` via the `_inject_client` fixture.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,13 +78,27 @@ workflow).
   Keep them terse, action-oriented, and accurate. Don't explain
   *what* the code does — explain *when* an agent should reach for
   this tool and what a good argument looks like.
-- The `_SERVER_INSTRUCTIONS` string in `src/kanbantool_mcp/server.py`
-  is the always-loaded mental model surfaced to MCP clients. It's
-  hard-capped at ~150 words. The longer `llms.txt` at the repo root
-  (when present) extends it with quirks and edge cases. **When you
-  add or remove a tool, or change its semantics in a way that
-  contradicts either surface, update both `_SERVER_INSTRUCTIONS`
-  AND `llms.txt`.** They must not drift.
+
+### When you add or rename a tool
+
+The LLM-facing mental model of `kanbantool-mcp` is encoded across
+several surfaces that will silently drift if you only update one.
+When you add a tool, rename a tool, or change a tool's semantics in
+a way that contradicts any of these, update them in the same PR:
+
+- **Tool registration** — the `@mcp.tool` function and its
+  docstring in `src/kanbantool_mcp/server.py`. The docstring is the
+  per-tool prompt the LLM sees.
+- **`_SERVER_INSTRUCTIONS`** in `src/kanbantool_mcp/server.py` —
+  the always-loaded preamble passed as `instructions=` on the
+  FastMCP server. Hard-capped at ~150 words; it's the mental model,
+  not the reference.
+- **`llms.txt`** at the repo root — the longer companion that
+  extends the preamble with quirks, edge cases, and the full tool
+  inventory.
+- **README per-client install snippets** — only when the change
+  affects what a fresh installer sees (new env var, renamed
+  command, changed default).
 
 ### CI
 


### PR DESCRIPTION
## Summary

Two follow-ups from the **2026-05-03 morning UX/QoL audit** (PRs #142–#157, batched into v0.8.0) that the principles-guardian (PG) recommended but didn't ship with the release. Meta-docs only — no code, no version bumps.

### CLAUDE.md — promote two implicit principles

PG flagged two principles that are load-bearing in code but stated nowhere. Added a new **`## Principles`** section between **Phases** and **Codebase conventions**, in the file's existing terse declarative voice (rule + one-line "in practice" example, two short paragraphs each):

- **"Be honest about the upstream, even when awkward."** — surface what the Kanban Tool API actually does (Rails `{"task": {...}}` envelope vs flat body, soft- vs hard-delete, omit-vs-clear, missing comment-edit and bulk list-users endpoints) instead of papering over it. PG cited this across audit proposals **#7** (dry-run synthesis), **#8** (24h-default fallback inventing a window), **#14** (exception-string enrichment despite SemVer disclaiming it). PG verbatim: *"kbmcp surfaces what the upstream API actually does; LLM-facing defaults are explicit in docstrings, not magic."*

- **"Stateless write semantics; every write returns the updated resource."** — every write tool runs `Model.model_validate(...)` on the response so the caller can confirm state without a follow-up `get_*`. PG cited this from the dry-run-shape rejection. PG verbatim: *"Return-shape stability for write tools is part of the contract callers will rely on, especially as the project locks v1.0."*

### CONTRIBUTING.md — drift-coordination note

PG flagged that #147 (`instructions=` on the FastMCP server, `_SERVER_INSTRUCTIONS`) and #152 (`llms.txt` at repo root) both encode the LLM-facing mental model and will silently drift if updated independently. PG offered two options: source-of-truth-and-extract, or a CONTRIBUTING.md note. Picked the latter — single source-of-truth + extraction is more infra than the project warrants today.

Added a new **`### When you add or rename a tool`** subsection under **Pull requests** listing the four surfaces that must move in lockstep:

- Tool registration (`@mcp.tool` + docstring) in `server.py`
- `_SERVER_INSTRUCTIONS` (the `instructions=` preamble, #147) in `server.py`
- `llms.txt` at the repo root (#152)
- README per-client install snippets (#148) — only when the change is installer-visible

This replaces the narrower buried bullet in *"What a good PR looks like"* that previously only mentioned `_SERVER_INSTRUCTIONS` and `llms.txt`, so we don't have two overlapping drift notes.

## Out of scope

- The third PG cleanup (GET-only retry guard test) — that's a separate test PR.
- Any code, `instructions=` text, or `llms.txt` content changes.
- Version bumps / CHANGELOG (release-please owns those; `docs:` is a patch bump per the `RELEASING.md` table — exactly what we want).

## Test plan

- [ ] CI green (`test (3.11 / 3.12 / 3.13)` — only doc files touched, should be a no-op for tests)
- [ ] `ruff check` / `ruff format --check` clean (no `.py` files touched)
- [ ] CLAUDE.md renders with the new `## Principles` section between Phases and Codebase conventions
- [ ] CONTRIBUTING.md renders with the new `### When you add or rename a tool` subsection under Pull requests, replacing the older buried bullet