### PR TITLE
docs: extend drift gate to env vars + CLI flags

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,6 +100,32 @@ a way that contradicts any of these, update them in the same PR:
   affects what a fresh installer sees (new env var, renamed
   command, changed default).
 
+### When you add or rename an env var or CLI flag
+
+Env vars and CLI flags are the operator-facing contract and drift
+across a different set of surfaces than tools. When you add, rename,
+or change the semantics of either, update them in the same PR.
+
+For an env var (e.g. adding `KANBANTOOL_NEW_THING`):
+
+- **README env-var table** — the configuration reference under
+  "Wiring it into your client."
+- **`SEMVER.md` stable env var list** — the enumerated set under
+  "Environment variable names" in the stable surfaces section.
+- **`config.py`** — the reader and any validation.
+- **`_SERVER_INSTRUCTIONS`** — only if the env var changes how the
+  LLM should reason about the server (e.g. `KANBANTOOL_READ_ONLY`
+  hides write tools; `KANBANTOOL_LOG_LEVEL` doesn't).
+- **README per-client install snippets** — only if the env var is
+  required to start the server. Optional vars stay out of the
+  snippets to keep the happy path short.
+
+For a CLI flag (e.g. adding `--new-flag`):
+
+- **README install snippets / quickstart** — wherever the launcher
+  command appears.
+- **`__main__.py`** — the flag parser and handler.
+
 ### CI
 
 Every PR must pass:


### PR DESCRIPTION
## Summary

Adds a sibling subsection `### When you add or rename an env var or CLI flag` under the existing `### When you add or rename a tool` gate in `CONTRIBUTING.md`. PR #159 closed the first half of the morning audit's emergent PG observation (tool drift); this closes the second half by enumerating the lockstep set for env vars (README table, `SEMVER.md`, `config.py`, conditionally `_SERVER_INSTRUCTIONS`, conditionally per-client snippets) and CLI flags (README snippets, `__main__.py`).

## Design choice

Took **Option 1 (sibling subsection)** over Option 2 (master refactor):

- The existing tool subsection explicitly frames its surfaces as "the LLM-facing mental model." Env vars and CLI flags are operator-facing, so a single master section would have to either drop that framing or contort to cover both audiences.
- The lockstep sets are genuinely different sizes (4 / 5 / 2 surfaces). Bundling them under a master would land as three parallel bullet lists under a thin header, which is the same content with weaker headings.
- Sibling pattern keeps each gate scannable: a contributor adding an env var jumps straight to the env-var bullets without filtering past tool-specific guidance.

## Scope

- Pure docs, single-file diff (+26 lines, 0 deletions).
- Did **not** add a CLI-flag stable list to `SEMVER.md` — there's no incoherence in the new CONTRIBUTING.md text without one (the CLI gate references README + `__main__.py`, which are sufficient to catch drift today).
- No other refactoring of `CONTRIBUTING.md`.

Source: morning UX/QoL audit (overnight 2026-05-03), PG emergent principle on locking v1.0 contract surfaces deliberately.

Closes #160

## Test plan

- [ ] CI green (lint / format / type check / offline tests — none should be touched by a docs-only change, but verifying)
- [ ] Visual review: new subsection sits at the same `###` depth as the tool subsection and reads in the same terse declarative voice