### PR TITLE
docs: explain CodeQL py/clear-text-logging-sensitive-data dismissal at __main__.py:80

### DIFF
--- a/src/kanbantool_mcp/__main__.py
+++ b/src/kanbantool_mcp/__main__.py
@@ -77,6 +77,13 @@ def _fail(exc: BaseException, hint: str) -> None:
     un-scrubbed token. Cheap belt-and-suspenders that the audit brief
     explicitly required for the ``--check`` flow.
     """
+    # CodeQL flags this as ``py/clear-text-logging-sensitive-data``; the
+    # expression IS sanitized by ``_scrub_secrets`` (the project's
+    # centralized bearer-token regex scrubber, applied to every error
+    # surface — see ``client._scrub_secrets``) but CodeQL's taint tracker
+    # doesn't recognize the custom regex sanitizer. Dismissed as a false
+    # positive (alert #3 — see
+    # https://github.com/VeryLongOrgNameSuchWow/kanbantool-mcp/security/code-scanning/3).
     print(f"FAIL: {_scrub_secrets(str(exc))}", file=sys.stderr)
     print(hint, file=sys.stderr)
 


### PR DESCRIPTION
## Summary

- CodeQL flagged `src/kanbantool_mcp/__main__.py:80` (`print(f"FAIL: {_scrub_secrets(str(exc))}", file=sys.stderr)`) as [`py/clear-text-logging-sensitive-data`](https://github.com/VeryLongOrgNameSuchWow/kanbantool-mcp/security/code-scanning/3) (HIGH).
- The expression is in fact sanitized — `_scrub_secrets` is the project's centralized bearer-token regex scrubber defined in `client.py`, applied to every error surface (see `## Codebase conventions → Secret scrubbing` in `CLAUDE.md`). The `--check` `_fail` path wraps the exception text explicitly, layered on top of typed-exception `__str__` scrubbing as belt-and-suspenders (see the `_fail` docstring at lines 70-79).
- CodeQL's taint tracker doesn't recognize the custom regex sanitizer (it's not in CodeQL's stock sanitizer list). Alert #3 has been dismissed as a false positive in the GitHub UI.

This is a `docs:` PR adding a 7-line inline comment above the `print` so future contributors (and a re-triggered CodeQL run) see the reasoning without needing GitHub UI access. No behavior change, no refactor of the print itself, no `# noqa` / `# nosec` / legacy `lgtm` markers.

Dismissed alert: https://github.com/VeryLongOrgNameSuchWow/kanbantool-mcp/security/code-scanning/3

## Test plan

- [ ] `uv run ruff check .` clean
- [ ] `uv run ruff format --check .` clean
- [ ] CodeQL re-run on this branch still flags or no-longer-flags the line (informational; alert remains dismissed either way)
- [ ] Visual review: comment reads naturally above the `print`, matches the file's existing comment voice